### PR TITLE
OCEANWATER-409 utilize frost Y1A for ocean waters

### DIFF
--- a/ow/launch/atacama_y1a.launch
+++ b/ow/launch/atacama_y1a.launch
@@ -6,7 +6,7 @@
   <arg name="gzclient" default="true"/>
 
   <include file="$(find ow)/launch/common.launch" >
-    <arg name="world_name" value="$(find ow_europa)/worlds/atacama_z1.world"/>
+    <arg name="world_name" value="$(find ow_europa)/worlds/atacama_y1a.world"/>
     <arg name="init_x" value="0"/>
     <arg name="init_y" value="0"/>
     <arg name="init_z" value="1"/>

--- a/ow/launch/atacama_z1.launch
+++ b/ow/launch/atacama_z1.launch
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<launch>
+
+  <arg name="arm_sim_enable" default="false"/>
+  <arg name="gazebo" default="true"/>
+  <arg name="gzclient" default="true"/>
+
+  <include file="$(find ow)/launch/common.launch" >
+    <arg name="world_name" value="$(find ow_europa)/worlds/atacama_z1.world"/>
+    <arg name="init_x" value="0"/>
+    <arg name="init_y" value="0"/>
+    <arg name="init_z" value="1"/>
+    <arg name="init_R" value="-0.105"/>
+    <arg name="init_P" value="0.008"/>
+    <arg name="init_Y" value="0"/>
+    <arg name="freeze_base_link" value="true"/>
+    <arg name="arm_sim_enable" value="$(arg arm_sim_enable)"/>
+    <arg name="gazebo" value="$(arg gazebo)"/>
+    <arg name="gzclient" value="$(arg gzclient)"/>
+  </include>
+
+</launch>


### PR DESCRIPTION
This is the same branch that I have been working on babelfish (all unused maps are cleaned up).
Please note the new [UPDATE 2](#update-2) section at the bottom.

__What has been done:__
* imported Y1A DEM into ow_europa along with the texture
* Applied a proper geo-coordinate
* Generated a proper normals map
* Created a model file, a world file and a launch file to load the new map

__To test all you need to do is update both ow_simulator/ow_europa to OCEANWATER-409_Utilize_FROST_Y1A_for_OceanWATERS, then once you have sourced the oceanwaters environment, execute:

```bash
roslaunch ow atacama_z1.launch
```

## Objectives:

* Make sure all need files has been pushed to git
* Validate the map coordinate and pixel size
* Validate the visual appearance of the map and provide feedback
* I have added a sample of the expected output to the associated Jira ticket: OCEANWATER-409 - Utilize FROST Y1A for OceanWATERS

__What is missing:__

Enable the shader materials, those will come into play next, the reason they are not enabled is they render the map very dark and I can hardly see the surface. I don't have enough insights into the shader scripts, so I will start reviewing them
Apply an albedo map. I split the original Jira issue and moved the part of applying an albedo texture to a separate Jira issue: Generate and apply an appropriate albedo texture for Y1A terrain

## UPDATE 1:

* The old maps has been removed from the branch
* A new map at half the size has been added with a heightmap size of 1025x1025
* Both the diffuse texture & the normal map has been adapted accordingly.

## UPDATE 2:
* The DEM is still at a resolution of 1025x1025
* Used the original diffuse texture of the dataset which has a resolution of 2048x2048
* Re-generated the normal map at a resolution 2048x2048 