### PR TITLE
reduced hand rotation in DigCircular

### DIFF
--- a/ow_lander/scripts/activity_full_digging_traj.py
+++ b/ow_lander/scripts/activity_full_digging_traj.py
@@ -175,7 +175,7 @@ def dig_circular(move_arm, move_limbs, args):
     go_to_Z_coordinate(move_limbs, x_start, y_start, z_start)
 
     # Rotate hand perpendicular to radial direction
-    change_joint_value(move_arm, constants.J_HAND_YAW, -math.pi/2.2)
+    change_joint_value(move_arm, constants.J_HAND_YAW, -0.29*math.pi)
 
   else:
     # Rotate hand so scoop is in middle point


### PR DESCRIPTION
Ticket: https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-445
This is to avoid collision between grinder and terrain during scooping, in particular DigCircular when radial==False. I implemented both Ussama's suggestion of reducing the hand rotation and Terry's suggestion of relocating the grinder to a 180 deg angle from the scoop. Both work, but Ussama's approach is simpler and avoids the "floating grinder" visualization. So I pushed only this one. I have Terry's approach in another local branch, which I didn't push.

Try calling DigCircular and check that there is collision. Try calling other services that might be compromised by this modification. Let me know your thoughts, thanks!