### PR TITLE
OCEANWATER-346: Use a different topic name for dynamic terrain model and visual plugins

### DIFF
--- a/ow_dynamic_terrain/CMakeLists.txt
+++ b/ow_dynamic_terrain/CMakeLists.txt
@@ -162,6 +162,7 @@ add_library(${PROJECT_NAME}_shared SHARED
   src/TerrainBrush.cpp
   src/MergeMethods.cpp
   src/TerrainModifier.cpp
+  src/DynamicTerrainBase.cpp
 )
 
 add_dependencies(${PROJECT_NAME}_shared

--- a/ow_dynamic_terrain/README.md
+++ b/ow_dynamic_terrain/README.md
@@ -4,11 +4,12 @@ this repository.
 
 # Dynamic Terrain
 
-- [Introduction](#introduction)
-- [Requirements](#requirements)
+* [Introduction](#introduction)
+* [Requirements](#requirements)
   - [Compatibility](#compatibility)
-- [Usage](#usage)
-- [Demo](#demo)
+* [Usage](#usage)
+  - [Control Visual and Physical Aspects of the Terrain Individually](#control-visual-and-physical-aspects-of-the-terrain-individually)
+* [Demo](#demo)
   - [Modify Terrain with Circle](#modify-terrain-with-circle)
   - [Modify Terrain with Ellipse](#modify-terrain-with-ellipse)
   - [Modify Terrain with Patch](#modify-terrain-with-patch)
@@ -19,12 +20,14 @@ A package that adds the capability to update Gazebo terrains dynamically at run-
 
 ## Requirements
 
-ROS distro: melodic  
-Gazebo version 9.13 or later
+* This package was developed and tested against `ROS melodic` distrbution.
+* One of the plugins included in this package _DynamicTerrainModel_ requires `Gazebo` version 9.13 or later.
 
 ### Compatibility
-* The _IRGLinkTracksPlugin_ and _DynamicTerrainVisual_ plugin may conflict with each other as both affect the visual appearance of the terrain.
-* The _DynamicTerrainVisual_  is incompatible with the _HeightmapLODPlugin_.
+* The _IRGLinkTracksPlugin_ and _DynamicTerrainVisual_ plugin may conflict with each other as both affect the visual
+appearance of the terrain.
+* The _DynamicTerrainVisual_  is incompatible with the _HeightmapLODPlugin_; Either disable the plugin or configure it
+to always use the highest LOD level.
 
 ## Usage
 
@@ -69,6 +72,30 @@ The following excerpt shows how to apply the two plugins towards a DEM object:
   </model>
 </sdf>
 ```
+
+Once these plugins have been configured for a heightmap object, the user can then modify the terrain by composing and
+submitting an appropriate ros message to the following three topics/methods:
+- */ow_dynamic_terrain/modify_terrain_circle*
+- */ow_dynamic_terrain/modify_terrain_ellipse*
+- */ow_dynamic_terrain/modify_terrain_patch*
+
+See [Demo](#demo) for additional details on each method.
+
+## Control Visual and Physical Aspects of the Terrain Individually
+
+In certain situations it may be desirable to only modify one of the two terrain aspects: the visual part and the
+physical. This certainly can be achieved by enabling one of the two plugins for the model. However, in other cases the
+user may want to alter each aspect slightly different than the other. To handle such use case, the two plugins
+_DynamicTerrainVisual_ and _DynamicTerrainModel_ both add an extension to the three topics listed above that correspond
+to their aspect. i.e. The _DynamicTerrainVisual_ plugin has the following three additional topics that it subscribes to:
+- */ow_dynamic_terrain/modify_terrain_circle/visual*
+- */ow_dynamic_terrain/modify_terrain_ellipse/visual*
+- */ow_dynamic_terrain/modify_terrain_patch/visual*
+
+Meanwhile, the _DynamicTerrainModel_ plugin adds the following three topics:
+- */ow_dynamic_terrain/modify_terrain_circle/collision*
+- */ow_dynamic_terrain/modify_terrain_ellipse/collision*
+- */ow_dynamic_terrain/modify_terrain_patch/collision*
 
 ## Demo
 
@@ -183,5 +210,4 @@ The choices are the same ones listed in the [Modify Terrain with Circle](#modify
 
 > **_NOTE:_** Currently only single channel 32 float image formats are supported.
 
-You may refer to the [documentation](https://babelfish.arc.nasa.gov/confluence/pages/viewpage.action?pageId=122756318)
- for more details.
+You may refer to the project [wiki](https://github.com/nasa/ow_simulator/wiki) for more details.

--- a/ow_dynamic_terrain/include/MergeMethods.h
+++ b/ow_dynamic_terrain/include/MergeMethods.h
@@ -27,7 +27,6 @@ public:
   static const MergeMethod max;
   static const MergeMethod avg;
 
-public:
   static boost::optional<const MergeMethod&> mergeMethodFromString(const std::string& method_name);
 
 private:

--- a/ow_dynamic_terrain/include/TerrainModifier.h
+++ b/ow_dynamic_terrain/include/TerrainModifier.h
@@ -22,13 +22,11 @@ public:
                            const std::function<float(int, int)>& get_height_value,
                            const std::function<void(int, int, float)>& set_height_value);
 
-public:
   static void modifyEllipse(gazebo::rendering::Heightmap* heightmap,
                             const ow_dynamic_terrain::modify_terrain_ellipse::ConstPtr& msg,
                             const std::function<float(int, int)>& get_height_value,
                             const std::function<void(int, int, float)>& set_height_value);
 
-public:
   static void modifyPatch(gazebo::rendering::Heightmap* heightmap,
                           const ow_dynamic_terrain::modify_terrain_patch::ConstPtr& msg,
                           const std::function<float(int, int)>& get_height_value,
@@ -41,11 +39,9 @@ private:
   static cv::Point2i getHeightmapPosition(gazebo::rendering::Heightmap* heightmap,
                                           const geometry_msgs::Point32& position);
 
-private:
   // Imports an OpenCV Matrix object from a sensor_msgs::Image object through cv_bridge
   static cv_bridge::CvImageConstPtr importImageToOpenCV(const ow_dynamic_terrain::modify_terrain_patch::ConstPtr& msg);
 
-private:
   // Applies the an OpenCV image to a heightmap at a given position
   // param heightmap: heightmap to merge the image with
   // param center: absolute position within the heightmap where the image will be applied

--- a/ow_dynamic_terrain/include/memory_ext.h
+++ b/ow_dynamic_terrain/include/memory_ext.h
@@ -1,0 +1,21 @@
+#ifndef MEMORY_EXT_H
+#define MEMORY_EXT_H
+
+// TODO: consider moving the file to a common place
+
+#include <memory>
+
+#if __cplusplus < 201402L  // if less than C++14 is detected add the extension
+
+namespace std
+{
+template <typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args)
+{
+  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+}  // namespace std
+
+#endif
+
+#endif  // MEMORY_EXT_H

--- a/ow_dynamic_terrain/include/memory_ext.h
+++ b/ow_dynamic_terrain/include/memory_ext.h
@@ -1,5 +1,14 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
 #ifndef MEMORY_EXT_H
 #define MEMORY_EXT_H
+
+/**
+ * This module adds the missing 'make_unique' when compiling against C++11 standard. For more info on this refer to:
+ * Scott Meyers' Effective Modern C++ Item 21: Prefer std::make_unique and std::make_shared to direct use of new.
+ */
 
 // TODO: consider moving the file to a common place
 

--- a/ow_dynamic_terrain/scripts/modify_terrain_grinder_pub.py
+++ b/ow_dynamic_terrain/scripts/modify_terrain_grinder_pub.py
@@ -29,6 +29,15 @@ class ModifyTerrainGrinder:
         "/gazebo/link_states", LinkStates, self.handle_link_states)
 
   def compose_modify_terrain_circle_message(self, position, scale=1.0):
+    """ Composes a modify_terrain_circle that matches the grinder end effector
+    it is positioned downwards ready for digging. When the grinder is position
+    downward for digging the shape it projects on the terrain as a circle.
+
+    Parameters:
+      position: Corresponds to the center of the modify_terrain_circle operation
+      scale: A value that uniformaly scales the generated modify_terrain_circle
+        message
+    """
     return modify_terrain_circle(position=Point(position.x, position.y, position.z),
                                  outer_radius=0.008*scale, inner_radius=0.001*scale,
                                  weight=-0.2*scale, merge_method="min")

--- a/ow_dynamic_terrain/scripts/modify_terrain_grinder_pub.py
+++ b/ow_dynamic_terrain/scripts/modify_terrain_grinder_pub.py
@@ -21,15 +21,17 @@ class ModifyTerrainGrinder:
   def __init__(self, *args):
     rospy.init_node("modify_terrain_grinder_pub", anonymous=True)
     self.last_translation = np.zeros(3)
-    self.pub = rospy.Publisher(
-        'ow_dynamic_terrain/modify_terrain_circle', modify_terrain_circle, queue_size=1)
+    self.pub_visual = rospy.Publisher(
+        'ow_dynamic_terrain/modify_terrain_circle/visual', modify_terrain_circle, queue_size=1)
+    self.pub_collision = rospy.Publisher(
+        'ow_dynamic_terrain/modify_terrain_circle/collision', modify_terrain_circle, queue_size=1)
     self.states_sub = rospy.Subscriber(
         "/gazebo/link_states", LinkStates, self.handle_link_states)
 
-  def compose_modify_terrain_circle_message(self, position):
+  def compose_modify_terrain_circle_message(self, position, scale=1.0):
     return modify_terrain_circle(position=Point(position.x, position.y, position.z),
-                                 outer_radius=0.008, inner_radius=0.001,
-                                 weight=-0.2, merge_method="min")
+                                 outer_radius=0.008*scale, inner_radius=0.001*scale,
+                                 weight=-0.2*scale, merge_method="min")
 
   def check_and_submit(self, new_position, new_rotation):
     """ Checks if position has changed significantly before submmitting a message """
@@ -46,12 +48,12 @@ class ModifyTerrainGrinder:
     if all(np.isclose(current_translation, self.last_translation, atol=1.e-4)):
       return  # no significant change, abort
 
-
-
     self.last_translation = current_translation
 
     msg = self.compose_modify_terrain_circle_message(new_position)
-    self.pub.publish(msg)
+    self.pub_visual.publish(msg)
+    msg = self.compose_modify_terrain_circle_message(new_position, scale=2.0)
+    self.pub_collision.publish(msg)
     
     rospy.logdebug_throttle(1, "modify_terrain_grinder message:\n" + str(msg))
 

--- a/ow_dynamic_terrain/scripts/modify_terrain_scoop_pub.py
+++ b/ow_dynamic_terrain/scripts/modify_terrain_scoop_pub.py
@@ -15,23 +15,24 @@ from gazebo_msgs.msg import LinkStates
 from tf.transformations import euler_from_quaternion
 from ow_dynamic_terrain.msg import modify_terrain_ellipse
 
-
 class ModifyTerrainScoop:
 
   def __init__(self, *args):
     rospy.init_node("modify_terrain_scoop_pub", anonymous=True)
     self.last_translation = np.zeros(3)
-    self.pub = rospy.Publisher(
-        'ow_dynamic_terrain/modify_terrain_ellipse', modify_terrain_ellipse, queue_size=1)
+    self.visual_pub = rospy.Publisher(
+        'ow_dynamic_terrain/modify_terrain_ellipse/visual', modify_terrain_ellipse, queue_size=1)
+    self.collision_pub = rospy.Publisher(
+        'ow_dynamic_terrain/modify_terrain_ellipse/collision', modify_terrain_ellipse, queue_size=1)
     self.states_sub = rospy.Subscriber(
         "/gazebo/link_states", LinkStates, self.handle_link_states)
 
-  def compose_modify_terrain_ellipse_message(self, position, orientation):
+  def compose_modify_terrain_ellipse_message(self, position, orientation, scale=1.0):
     return modify_terrain_ellipse(position=Point(position.x, position.y, position.z),
                                   orientation=orientation,
-                                  outer_radius_a=0.002, outer_radius_b=0.005,
-                                  inner_radius_a=0.001, inner_radius_b=0.001,
-                                  weight=-0.025, merge_method="min")
+                                  outer_radius_a=0.002*scale, outer_radius_b=0.005*scale,
+                                  inner_radius_a=0.001*scale, inner_radius_b=0.001*scale,
+                                  weight=-0.025*scale, merge_method="min")
 
   def check_and_submit(self, new_position, new_rotation):
     """ Checks if position has changed significantly before submmitting a message """
@@ -46,7 +47,9 @@ class ModifyTerrainScoop:
         quaternion=(new_rotation.x, new_rotation.y, new_rotation.z, new_rotation.w))
 
     msg = self.compose_modify_terrain_ellipse_message(new_position, degrees(yaw))
-    self.pub.publish(msg)
+    self.visual_pub.publish(msg)
+    msg = self.compose_modify_terrain_ellipse_message(new_position, degrees(yaw), scale=1.5)
+    self.collision_pub.publish(msg)
     
     rospy.logdebug_throttle(1, "modify_terrain_scoop message:\n" + str(msg))
 

--- a/ow_dynamic_terrain/scripts/modify_terrain_scoop_pub.py
+++ b/ow_dynamic_terrain/scripts/modify_terrain_scoop_pub.py
@@ -28,6 +28,15 @@ class ModifyTerrainScoop:
         "/gazebo/link_states", LinkStates, self.handle_link_states)
 
   def compose_modify_terrain_ellipse_message(self, position, orientation, scale=1.0):
+    """ Composes a modify_terrain_ellipse that matches the tip of scoop end effector
+    when it is positioned for scopping. The scoop has a wide tip hence an ellipse
+    is used to approximate its changes to the terrain.
+
+    Parameters:
+      position: Corresponds to the center of the modify_terrain_ellipse operation
+      orientation: The angle of scoop in world frame
+      scale: A value that uniformaly scales the generated modify_terrain_ellipse message
+    """
     return modify_terrain_ellipse(position=Point(position.x, position.y, position.z),
                                   orientation=orientation,
                                   outer_radius_a=0.002*scale, outer_radius_b=0.005*scale,

--- a/ow_dynamic_terrain/src/DynamicTerrainBase.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainBase.cpp
@@ -6,63 +6,63 @@ using namespace ow_dynamic_terrain;
 
 void DynamicTerrainBase::Initialize(const std::string& topic_extension)
 {
-    if (!ros::isInitialized())
-    {
-        gzerr << m_plugin_name + ": ROS not initilized! The plugin won't load" << endl;
-        return;
-    }
+  if (!ros::isInitialized())
+  {
+    gzerr << m_plugin_name + ": ROS not initilized! The plugin won't load" << endl;
+    return;
+  }
 
-    m_node_handle = make_unique<ros::NodeHandle>(m_plugin_name);
-    m_node_handle->setCallbackQueue(&m_callback_queue);
+  m_node_handle = make_unique<ros::NodeHandle>(m_plugin_name);
+  m_node_handle->setCallbackQueue(&m_callback_queue);
 
-    auto on_modify_terrain_circle = [this](const modify_terrain_circle::ConstPtr& msg) {
-        this->onModifyTerrainCircleMsg(msg);
-    };
-    subscribe<modify_terrain_circle>("modify_terrain_circle", on_modify_terrain_circle);
-    subscribe<modify_terrain_circle>("modify_terrain_circle/" + topic_extension, on_modify_terrain_circle);
+  auto on_modify_terrain_circle = [this](const modify_terrain_circle::ConstPtr& msg) {
+    this->onModifyTerrainCircleMsg(msg);
+  };
+  subscribe<modify_terrain_circle>("modify_terrain_circle", on_modify_terrain_circle);
+  subscribe<modify_terrain_circle>("modify_terrain_circle/" + topic_extension, on_modify_terrain_circle);
 
-    auto on_modify_terrain_ellipse = [this](const modify_terrain_ellipse::ConstPtr& msg) {
-        this->onModifyTerrainEllipseMsg(msg);
-    };
-    subscribe<modify_terrain_ellipse>("modify_terrain_ellipse", on_modify_terrain_ellipse);
-    subscribe<modify_terrain_ellipse>("modify_terrain_ellipse/" + topic_extension, on_modify_terrain_ellipse);
+  auto on_modify_terrain_ellipse = [this](const modify_terrain_ellipse::ConstPtr& msg) {
+    this->onModifyTerrainEllipseMsg(msg);
+  };
+  subscribe<modify_terrain_ellipse>("modify_terrain_ellipse", on_modify_terrain_ellipse);
+  subscribe<modify_terrain_ellipse>("modify_terrain_ellipse/" + topic_extension, on_modify_terrain_ellipse);
 
-    auto on_modify_terrain_patch = [this](const modify_terrain_patch::ConstPtr& msg) {
-        this->onModifyTerrainPatchMsg(msg);
-    };
-    subscribe<modify_terrain_patch>("modify_terrain_patch", on_modify_terrain_patch);
-    subscribe<modify_terrain_patch>("modify_terrain_patch/" + topic_extension, on_modify_terrain_patch);
+  auto on_modify_terrain_patch = [this](const modify_terrain_patch::ConstPtr& msg) {
+    this->onModifyTerrainPatchMsg(msg);
+  };
+  subscribe<modify_terrain_patch>("modify_terrain_patch", on_modify_terrain_patch);
+  subscribe<modify_terrain_patch>("modify_terrain_patch/" + topic_extension, on_modify_terrain_patch);
 
-    m_on_update_connection = gazebo::event::Events::ConnectPostRender([this]() {
-        if (m_node_handle->ok())
-            m_callback_queue.callAvailable();
-    });
+  m_on_update_connection = gazebo::event::Events::ConnectPostRender([this]() {
+    if (m_node_handle->ok())
+      m_callback_queue.callAvailable();
+  });
 
-    gzlog << m_plugin_name << ": successfully loaded!" << endl;
+  gzlog << m_plugin_name << ": successfully loaded!" << endl;
 }
 
 template <typename T>
 void DynamicTerrainBase::subscribe(const std::string& topic,
-    const boost::function<void (const boost::shared_ptr<T const>&)>& callback)
+                                   const boost::function<void(const boost::shared_ptr<T const>&)>& callback)
 {
-    auto topic_fqn = "/" + m_package_name + "/" + topic;
-    m_subscribers.push_back(m_node_handle->subscribe<T>(topic_fqn, 10, callback));
+  auto topic_fqn = "/" + m_package_name + "/" + topic;
+  m_subscribers.push_back(m_node_handle->subscribe<T>(topic_fqn, 10, callback));
 }
 
 gazebo::rendering::Heightmap* DynamicTerrainBase::getHeightmap(gazebo::rendering::ScenePtr scene)
 {
-    if (!scene)
-    {
-        gzerr << m_plugin_name << ": Couldn't acquire scene!" << endl;
-        return nullptr;
-    }
+  if (!scene)
+  {
+    gzerr << m_plugin_name << ": Couldn't acquire scene!" << endl;
+    return nullptr;
+  }
 
-    auto heightmap = scene->GetHeightmap();
-    if (heightmap == nullptr)
-    {
-        gzerr << m_plugin_name << ": scene has no heightmap!" << endl;
-        return nullptr;
-    }
+  auto heightmap = scene->GetHeightmap();
+  if (heightmap == nullptr)
+  {
+    gzerr << m_plugin_name << ": scene has no heightmap!" << endl;
+    return nullptr;
+  }
 
-    return heightmap;
+  return heightmap;
 }

--- a/ow_dynamic_terrain/src/DynamicTerrainBase.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainBase.cpp
@@ -49,7 +49,7 @@ template <typename T>
 void DynamicTerrainBase::subscribe(const std::string& topic,
                                    const boost::function<void(const boost::shared_ptr<T const>&)>& callback)
 {
-  auto topic_fqn = "/" + m_package_name + "/" + topic;
+  string topic_fqn = "/" + m_package_name + "/" + topic;
   m_subscribers.push_back(m_node_handle->subscribe<T>(topic_fqn, 10, callback));
 }
 
@@ -61,7 +61,7 @@ gazebo::rendering::Heightmap* DynamicTerrainBase::getHeightmap(gazebo::rendering
     return nullptr;
   }
 
-  auto heightmap = scene->GetHeightmap();
+  gazebo::rendering::Heightmap* heightmap = scene->GetHeightmap();
   if (heightmap == nullptr)
   {
     gzerr << m_plugin_name << ": scene has no heightmap!" << endl;

--- a/ow_dynamic_terrain/src/DynamicTerrainBase.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainBase.cpp
@@ -8,11 +8,10 @@ void DynamicTerrainBase::Initialize(const std::string& topic_extension)
 {
     if (!ros::isInitialized())
     {
-        gzerr << m_plugin_name + ": ROS not initilized!" << endl;
+        gzerr << m_plugin_name + ": ROS not initilized! The plugin won't load" << endl;
         return;
     }
 
-    // m_node_handle.reset(new ros::NodeHandle(m_plugin_name));
     m_node_handle = make_unique<ros::NodeHandle>(m_plugin_name);
     m_node_handle->setCallbackQueue(&m_callback_queue);
 
@@ -42,7 +41,7 @@ void DynamicTerrainBase::Initialize(const std::string& topic_extension)
     gzlog << m_plugin_name << ": successfully loaded!" << endl;
 }
 
-template <class T>
+template <typename T>
 void DynamicTerrainBase::subscribe(const std::string& topic,
     const boost::function<void (const boost::shared_ptr<T const>&)>& callback)
 {

--- a/ow_dynamic_terrain/src/DynamicTerrainBase.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainBase.cpp
@@ -1,0 +1,69 @@
+#include "DynamicTerrainBase.h"
+#include "memory_ext.h"
+
+using namespace std;
+using namespace ow_dynamic_terrain;
+
+void DynamicTerrainBase::Initialize(const std::string& topic_extension)
+{
+    if (!ros::isInitialized())
+    {
+        gzerr << m_plugin_name + ": ROS not initilized!" << endl;
+        return;
+    }
+
+    // m_node_handle.reset(new ros::NodeHandle(m_plugin_name));
+    m_node_handle = make_unique<ros::NodeHandle>(m_plugin_name);
+    m_node_handle->setCallbackQueue(&m_callback_queue);
+
+    auto on_modify_terrain_circle = [this](const modify_terrain_circle::ConstPtr& msg) {
+        this->onModifyTerrainCircleMsg(msg);
+    };
+    subscribe<modify_terrain_circle>("modify_terrain_circle", on_modify_terrain_circle);
+    subscribe<modify_terrain_circle>("modify_terrain_circle/" + topic_extension, on_modify_terrain_circle);
+
+    auto on_modify_terrain_ellipse = [this](const modify_terrain_ellipse::ConstPtr& msg) {
+        this->onModifyTerrainEllipseMsg(msg);
+    };
+    subscribe<modify_terrain_ellipse>("modify_terrain_ellipse", on_modify_terrain_ellipse);
+    subscribe<modify_terrain_ellipse>("modify_terrain_ellipse/" + topic_extension, on_modify_terrain_ellipse);
+
+    auto on_modify_terrain_patch = [this](const modify_terrain_patch::ConstPtr& msg) {
+        this->onModifyTerrainPatchMsg(msg);
+    };
+    subscribe<modify_terrain_patch>("modify_terrain_patch", on_modify_terrain_patch);
+    subscribe<modify_terrain_patch>("modify_terrain_patch/" + topic_extension, on_modify_terrain_patch);
+
+    m_on_update_connection = gazebo::event::Events::ConnectPostRender([this]() {
+        if (m_node_handle->ok())
+            m_callback_queue.callAvailable();
+    });
+
+    gzlog << m_plugin_name << ": successfully loaded!" << endl;
+}
+
+template <class T>
+void DynamicTerrainBase::subscribe(const std::string& topic,
+    const boost::function<void (const boost::shared_ptr<T const>&)>& callback)
+{
+    auto topic_fqn = "/" + m_package_name + "/" + topic;
+    m_subscribers.push_back(m_node_handle->subscribe<T>(topic_fqn, 10, callback));
+}
+
+gazebo::rendering::Heightmap* DynamicTerrainBase::getHeightmap(gazebo::rendering::ScenePtr scene)
+{
+    if (!scene)
+    {
+        gzerr << m_plugin_name << ": Couldn't acquire scene!" << endl;
+        return nullptr;
+    }
+
+    auto heightmap = scene->GetHeightmap();
+    if (heightmap == nullptr)
+    {
+        gzerr << m_plugin_name << ": scene has no heightmap!" << endl;
+        return nullptr;
+    }
+
+    return heightmap;
+}

--- a/ow_dynamic_terrain/src/DynamicTerrainBase.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainBase.cpp
@@ -1,3 +1,7 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
 #include "DynamicTerrainBase.h"
 #include "memory_ext.h"
 

--- a/ow_dynamic_terrain/src/DynamicTerrainBase.h
+++ b/ow_dynamic_terrain/src/DynamicTerrainBase.h
@@ -17,19 +17,18 @@ namespace ow_dynamic_terrain
 class DynamicTerrainBase
 {
 protected:
-    DynamicTerrainBase(const std::string& package_name, const std::string& plugin_name) :
-        m_package_name{package_name},
-        m_plugin_name{plugin_name}
-    {
-    }
+  DynamicTerrainBase(const std::string& package_name, const std::string& plugin_name) :
+    m_package_name{ package_name },
+    m_plugin_name{ plugin_name }
+  {
+  }
 
 protected:
   void Initialize(const std::string& topic_extension);
 
 private:
   template <typename T>
-  void subscribe(const std::string& topic,
-    const boost::function<void (const boost::shared_ptr<T const>&)>& callback);
+  void subscribe(const std::string& topic, const boost::function<void(const boost::shared_ptr<T const>&)>& callback);
 
 protected:
   gazebo::rendering::Heightmap* getHeightmap(gazebo::rendering::ScenePtr scene);
@@ -44,10 +43,10 @@ protected:
   virtual void onModifyTerrainPatchMsg(const modify_terrain_patch::ConstPtr& msg) = 0;
 
 protected:
-    std::string m_package_name;
+  std::string m_package_name;
 
 protected:
-    std::string m_plugin_name;
+  std::string m_plugin_name;
 
 protected:
   gazebo::event::ConnectionPtr m_on_update_connection;

--- a/ow_dynamic_terrain/src/DynamicTerrainBase.h
+++ b/ow_dynamic_terrain/src/DynamicTerrainBase.h
@@ -27,7 +27,7 @@ protected:
   void Initialize(const std::string& topic_extension);
 
 private:
-  template <class T>
+  template <typename T>
   void subscribe(const std::string& topic,
     const boost::function<void (const boost::shared_ptr<T const>&)>& callback);
 

--- a/ow_dynamic_terrain/src/DynamicTerrainBase.h
+++ b/ow_dynamic_terrain/src/DynamicTerrainBase.h
@@ -1,0 +1,65 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+#include <ros/callback_queue.h>
+#include <ros/ros.h>
+#include <ros/subscribe_options.h>
+#include <gazebo/common/common.hh>
+#include <gazebo/rendering/RenderingIface.hh>
+#include <gazebo/rendering/Scene.hh>
+#include "ow_dynamic_terrain/modify_terrain_circle.h"
+#include "ow_dynamic_terrain/modify_terrain_ellipse.h"
+#include "ow_dynamic_terrain/modify_terrain_patch.h"
+
+namespace ow_dynamic_terrain
+{
+class DynamicTerrainBase
+{
+protected:
+    DynamicTerrainBase(const std::string& package_name, const std::string& plugin_name) :
+        m_package_name{package_name},
+        m_plugin_name{plugin_name}
+    {
+    }
+
+protected:
+  void Initialize(const std::string& topic_extension);
+
+private:
+  template <class T>
+  void subscribe(const std::string& topic,
+    const boost::function<void (const boost::shared_ptr<T const>&)>& callback);
+
+protected:
+  gazebo::rendering::Heightmap* getHeightmap(gazebo::rendering::ScenePtr scene);
+
+protected:
+  virtual void onModifyTerrainCircleMsg(const modify_terrain_circle::ConstPtr& msg) = 0;
+
+protected:
+  virtual void onModifyTerrainEllipseMsg(const modify_terrain_ellipse::ConstPtr& msg) = 0;
+
+protected:
+  virtual void onModifyTerrainPatchMsg(const modify_terrain_patch::ConstPtr& msg) = 0;
+
+protected:
+    std::string m_package_name;
+
+protected:
+    std::string m_plugin_name;
+
+protected:
+  gazebo::event::ConnectionPtr m_on_update_connection;
+
+protected:
+  std::unique_ptr<ros::NodeHandle> m_node_handle;
+
+protected:
+  ros::CallbackQueue m_callback_queue;
+
+protected:
+  std::vector<ros::Subscriber> m_subscribers;
+};
+
+}  // namespace ow_dynamic_terrain

--- a/ow_dynamic_terrain/src/DynamicTerrainBase.h
+++ b/ow_dynamic_terrain/src/DynamicTerrainBase.h
@@ -23,41 +23,26 @@ protected:
   {
   }
 
-protected:
   void Initialize(const std::string& topic_extension);
 
-private:
+  virtual void onModifyTerrainCircleMsg(const modify_terrain_circle::ConstPtr& msg) = 0;
+
+  virtual void onModifyTerrainEllipseMsg(const modify_terrain_ellipse::ConstPtr& msg) = 0;
+
+  virtual void onModifyTerrainPatchMsg(const modify_terrain_patch::ConstPtr& msg) = 0;
+
+protected:
+  gazebo::rendering::Heightmap* getHeightmap(gazebo::rendering::ScenePtr scene);
+  
   template <typename T>
   void subscribe(const std::string& topic, const boost::function<void(const boost::shared_ptr<T const>&)>& callback);
 
 protected:
-  gazebo::rendering::Heightmap* getHeightmap(gazebo::rendering::ScenePtr scene);
-
-protected:
-  virtual void onModifyTerrainCircleMsg(const modify_terrain_circle::ConstPtr& msg) = 0;
-
-protected:
-  virtual void onModifyTerrainEllipseMsg(const modify_terrain_ellipse::ConstPtr& msg) = 0;
-
-protected:
-  virtual void onModifyTerrainPatchMsg(const modify_terrain_patch::ConstPtr& msg) = 0;
-
-protected:
   std::string m_package_name;
-
-protected:
   std::string m_plugin_name;
-
-protected:
   gazebo::event::ConnectionPtr m_on_update_connection;
-
-protected:
   std::unique_ptr<ros::NodeHandle> m_node_handle;
-
-protected:
   ros::CallbackQueue m_callback_queue;
-
-protected:
   std::vector<ros::Subscriber> m_subscribers;
 };
 

--- a/ow_dynamic_terrain/src/DynamicTerrainModel.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainModel.cpp
@@ -46,17 +46,35 @@ public:
     m_ros_node.reset(new ros::NodeHandle("dynamic_terrain_model"));
     m_ros_node->setCallbackQueue(&m_ros_queue);
 
-    m_ros_subscriber_circle = m_ros_node->subscribe<modify_terrain_circle>(
-        "/ow_dynamic_terrain/modify_terrain_circle", 10,
-        [this](const modify_terrain_circle::ConstPtr& msg) { this->onModifyTerrainCircleMsg(msg); });
+    auto on_modify_terrain_circle = [this](const modify_terrain_circle::ConstPtr& msg) {
+      this->onModifyTerrainCircleMsg(msg);
+    };
 
-    m_ros_subscriber_ellipse = m_ros_node->subscribe<modify_terrain_ellipse>(
-        "/ow_dynamic_terrain/modify_terrain_ellipse", 10,
-        [this](const modify_terrain_ellipse::ConstPtr& msg) { this->onModifyTerrainEllipseMsg(msg); });
+    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_circle>(
+        "/ow_dynamic_terrain/modify_terrain_circle", 10, on_modify_terrain_circle));
 
-    m_ros_subscriber_patch = m_ros_node->subscribe<modify_terrain_patch>(
-        "/ow_dynamic_terrain/modify_terrain_patch", 10,
-        [this](const modify_terrain_patch::ConstPtr& msg) { this->onModifyTerrainPatchMsg(msg); });
+    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_circle>(
+        "/ow_dynamic_terrain/modify_terrain_circle/collision", 10, on_modify_terrain_circle));
+
+    auto on_modify_terrain_ellipse = [this](const modify_terrain_ellipse::ConstPtr& msg) {
+      this->onModifyTerrainEllipseMsg(msg);
+    };
+
+    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_ellipse>(
+        "/ow_dynamic_terrain/modify_terrain_ellipse", 10, on_modify_terrain_ellipse));
+
+    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_ellipse>(
+        "/ow_dynamic_terrain/modify_terrain_ellipse/collision", 10, on_modify_terrain_ellipse));
+
+    auto on_modify_terrain_patch = [this](const modify_terrain_patch::ConstPtr& msg) {
+      this->onModifyTerrainPatchMsg(msg);
+    };
+
+    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_patch>(
+        "/ow_dynamic_terrain/modify_terrain_patch", 10, on_modify_terrain_patch));
+
+    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_patch>(
+        "/ow_dynamic_terrain/modify_terrain_patch/collision", 10, on_modify_terrain_patch));
 
     m_on_update_connection = event::Events::ConnectPostRender([this]() { this->onUpdate(); });
 
@@ -231,13 +249,7 @@ private:
   ros::CallbackQueue m_ros_queue;
 
 private:
-  ros::Subscriber m_ros_subscriber_circle;
-
-private:
-  ros::Subscriber m_ros_subscriber_ellipse;
-
-private:
-  ros::Subscriber m_ros_subscriber_patch;
+  vector<ros::Subscriber> m_ros_subscribers;
 };
 
 // Register this plugin with the simulator

--- a/ow_dynamic_terrain/src/DynamicTerrainModel.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainModel.cpp
@@ -4,7 +4,6 @@
 
 #include <gazebo/physics/physics.hh>
 #include "TerrainModifier.h"
-
 #include "DynamicTerrainBase.h"
 
 #if GAZEBO_MAJOR_VERSION < 9 || (GAZEBO_MAJOR_VERSION == 9 && GAZEBO_MINOR_VERSION < 13)
@@ -25,8 +24,7 @@ namespace ow_dynamic_terrain
 class DynamicTerrainModel : public ModelPlugin, public DynamicTerrainBase
 {
 public:
-  DynamicTerrainModel() :
-    DynamicTerrainBase{ "ow_dynamic_terrain", "DynamicTerrainModel" }
+  DynamicTerrainModel() : DynamicTerrainBase{ "ow_dynamic_terrain", "DynamicTerrainModel" }
   {
   }
 
@@ -112,8 +110,8 @@ private:
     }
 
     modify_method(
-      heightmap, msg, [&heightmap_shape](int x, int y) { return getHeightInWorldCoords(heightmap_shape, x, y); },
-      [&heightmap_shape](int x, int y, float value) { setHeightFromWorldCoords(heightmap_shape, x, y, value); });
+        heightmap, msg, [&heightmap_shape](int x, int y) { return getHeightInWorldCoords(heightmap_shape, x, y); },
+        [&heightmap_shape](int x, int y, float value) { setHeightFromWorldCoords(heightmap_shape, x, y, value); });
 
     // Re-enable physics updates for models that may have entered a standstill state
     m_model->GetWorld()->EnableAllModels();

--- a/ow_dynamic_terrain/src/DynamicTerrainModel.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainModel.cpp
@@ -28,7 +28,6 @@ public:
   {
   }
 
-public:
   void Load(ModelPtr model, sdf::ElementPtr /*sdf*/) override
   {
     GZ_ASSERT(model != nullptr, "DynamicTerrainModel: model can't be null!");
@@ -76,7 +75,6 @@ private:
     return shape;
   }
 
-private:
   static inline float getHeightInWorldCoords(const HeightmapShapePtr& heightmap_shape, int x, int y)
   {
     auto value = heightmap_shape->GetHeight(x, heightmap_shape->VertexCount().Y() - y - 1);
@@ -84,14 +82,12 @@ private:
     return value;
   }
 
-private:
   static inline void setHeightFromWorldCoords(const HeightmapShapePtr& heightmap_shape, int x, int y, float value)
   {
     value -= heightmap_shape->Pos().Z();
     heightmap_shape->SetHeight(x, heightmap_shape->VertexCount().Y() - y - 1, value);
   }
 
-private:
   template <typename T, typename M>
   void onModifyTerrainMsg(T msg, M modify_method)
   {
@@ -117,19 +113,16 @@ private:
     m_model->GetWorld()->EnableAllModels();
   }
 
-private:
   void onModifyTerrainCircleMsg(const modify_terrain_circle::ConstPtr& msg) override
   {
     onModifyTerrainMsg(msg, TerrainModifier::modifyCircle);
   }
 
-private:
   void onModifyTerrainEllipseMsg(const modify_terrain_ellipse::ConstPtr& msg) override
   {
     onModifyTerrainMsg(msg, TerrainModifier::modifyEllipse);
   }
 
-private:
   void onModifyTerrainPatchMsg(const modify_terrain_patch::ConstPtr& msg) override
   {
     onModifyTerrainMsg(msg, TerrainModifier::modifyPatch);

--- a/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
@@ -2,8 +2,8 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-#include "TerrainModifier.h"
 #include "DynamicTerrainBase.h"
+#include "TerrainModifier.h"
 
 using namespace std;
 using namespace gazebo;
@@ -14,8 +14,7 @@ namespace ow_dynamic_terrain
 class DynamicTerrainVisual : public VisualPlugin, public DynamicTerrainBase
 {
 public:
-  DynamicTerrainVisual() :
-    DynamicTerrainBase{ "ow_dynamic_terrain", "DynamicTerrainVisual" }
+  DynamicTerrainVisual() : DynamicTerrainBase{ "ow_dynamic_terrain", "DynamicTerrainVisual" }
   {
   }
 
@@ -52,9 +51,8 @@ private:
     }
 
     auto terrain = heightmap->OgreTerrain()->getTerrain(0, 0);
-    modify_method(
-        heightmap, msg, [&terrain](int x, int y) { return getHeightInWorldCoords(terrain, x, y); },
-        [&terrain](int x, int y, float value) { setHeightFromWorldCoords(terrain, x, y, value); });
+    modify_method(heightmap, msg, [&terrain](int x, int y) { return getHeightInWorldCoords(terrain, x, y); },
+                  [&terrain](int x, int y, float value) { setHeightFromWorldCoords(terrain, x, y, value); });
 
     terrain->updateGeometry();
     terrain->updateDerivedData(false, Ogre::Terrain::DERIVED_DATA_NORMALS | Ogre::Terrain::DERIVED_DATA_LIGHTMAP);

--- a/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
@@ -18,7 +18,6 @@ public:
   {
   }
 
-public:
   void Load(VisualPtr /*visual*/, sdf::ElementPtr /*sdf*/) override
   {
     Initialize("visual");
@@ -32,14 +31,12 @@ private:
     return value;
   }
 
-private:
   static inline void setHeightFromWorldCoords(Ogre::Terrain* terrain, int x, int y, float value)
   {
     value -= terrain->getPosition().z;
     terrain->setHeightAtPoint(x, y, value);
   }
 
-private:
   template <typename T, typename M>
   void onModifyTerrainMsg(T msg, M modify_method)
   {
@@ -58,19 +55,16 @@ private:
     terrain->updateDerivedData(false, Ogre::Terrain::DERIVED_DATA_NORMALS | Ogre::Terrain::DERIVED_DATA_LIGHTMAP);
   }
 
-private:
   void onModifyTerrainCircleMsg(const modify_terrain_circle::ConstPtr& msg) override
   {
     onModifyTerrainMsg(msg, TerrainModifier::modifyCircle);
   }
 
-private:
   void onModifyTerrainEllipseMsg(const modify_terrain_ellipse::ConstPtr& msg) override
   {
     onModifyTerrainMsg(msg, TerrainModifier::modifyEllipse);
   }
 
-private:
   void onModifyTerrainPatchMsg(const modify_terrain_patch::ConstPtr& msg) override
   {
     onModifyTerrainMsg(msg, TerrainModifier::modifyPatch);

--- a/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
@@ -41,7 +41,8 @@ private:
   }
 
 private:
-  void onModifyTerrainCircleMsg(const modify_terrain_circle::ConstPtr& msg) override
+  template <typename T, typename M>
+  void onModifyTerrainMsg(T msg, M modify_method)
   {
     auto heightmap = getHeightmap(get_scene());
     if (heightmap == nullptr)
@@ -51,50 +52,30 @@ private:
     }
 
     auto terrain = heightmap->OgreTerrain()->getTerrain(0, 0);
-    TerrainModifier::modifyCircle(
+    modify_method(
         heightmap, msg, [&terrain](int x, int y) { return getHeightInWorldCoords(terrain, x, y); },
         [&terrain](int x, int y, float value) { setHeightFromWorldCoords(terrain, x, y, value); });
 
     terrain->updateGeometry();
     terrain->updateDerivedData(false, Ogre::Terrain::DERIVED_DATA_NORMALS | Ogre::Terrain::DERIVED_DATA_LIGHTMAP);
+  }
+
+private:
+  void onModifyTerrainCircleMsg(const modify_terrain_circle::ConstPtr& msg) override
+  {
+    onModifyTerrainMsg(msg, TerrainModifier::modifyCircle);
   }
 
 private:
   void onModifyTerrainEllipseMsg(const modify_terrain_ellipse::ConstPtr& msg) override
   {
-    auto heightmap = getHeightmap(get_scene());
-    if (heightmap == nullptr)
-    {
-      gzerr << m_plugin_name << ": Couldn't acquire heightmap!" << endl;
-      return;
-    }
-
-    auto terrain = heightmap->OgreTerrain()->getTerrain(0, 0);
-    TerrainModifier::modifyEllipse(
-        heightmap, msg, [&terrain](int x, int y) { return getHeightInWorldCoords(terrain, x, y); },
-        [&terrain](int x, int y, float value) { setHeightFromWorldCoords(terrain, x, y, value); });
-
-    terrain->updateGeometry();
-    terrain->updateDerivedData(false, Ogre::Terrain::DERIVED_DATA_NORMALS | Ogre::Terrain::DERIVED_DATA_LIGHTMAP);
+    onModifyTerrainMsg(msg, TerrainModifier::modifyEllipse);
   }
 
 private:
   void onModifyTerrainPatchMsg(const modify_terrain_patch::ConstPtr& msg) override
   {
-    auto heightmap = getHeightmap(get_scene());
-    if (heightmap == nullptr)
-    {
-      gzerr << m_plugin_name << ": Couldn't acquire heightmap!" << endl;
-      return;
-    }
-
-    auto terrain = heightmap->OgreTerrain()->getTerrain(0, 0);
-    TerrainModifier::modifyPatch(
-        heightmap, msg, [&terrain](int x, int y) { return getHeightInWorldCoords(terrain, x, y); },
-        [&terrain](int x, int y, float value) { setHeightFromWorldCoords(terrain, x, y, value); });
-
-    terrain->updateGeometry();
-    terrain->updateDerivedData(false, Ogre::Terrain::DERIVED_DATA_NORMALS | Ogre::Terrain::DERIVED_DATA_LIGHTMAP);
+    onModifyTerrainMsg(msg, TerrainModifier::modifyPatch);
   }
 };
 

--- a/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
@@ -33,17 +33,35 @@ public:
     m_ros_node.reset(new ros::NodeHandle("dynamic_terrain_visual"));
     m_ros_node->setCallbackQueue(&m_ros_queue);
 
-    m_ros_subscriber_circle = m_ros_node->subscribe<modify_terrain_circle>(
-        "/ow_dynamic_terrain/modify_terrain_circle", 10,
-        [this](const modify_terrain_circle::ConstPtr& msg) { this->onModifyTerrainCircleMsg(msg); });
+    auto on_modify_terrain_circle = [this](const modify_terrain_circle::ConstPtr& msg) {
+      this->onModifyTerrainCircleMsg(msg);
+    };
 
-    m_ros_subscriber_ellipse = m_ros_node->subscribe<modify_terrain_ellipse>(
-        "/ow_dynamic_terrain/modify_terrain_ellipse", 10,
-        [this](const modify_terrain_ellipse::ConstPtr& msg) { this->onModifyTerrainEllipseMsg(msg); });
+    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_circle>(
+        "/ow_dynamic_terrain/modify_terrain_circle", 10, on_modify_terrain_circle));
 
-    m_ros_subscriber_patch = m_ros_node->subscribe<modify_terrain_patch>(
-        "/ow_dynamic_terrain/modify_terrain_patch", 10,
-        [this](const modify_terrain_patch::ConstPtr& msg) { this->onModifyTerrainPatchMsg(msg); });
+    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_circle>(
+        "/ow_dynamic_terrain/modify_terrain_circle/visual", 10, on_modify_terrain_circle));
+
+    auto on_modify_terrain_ellipse = [this](const modify_terrain_ellipse::ConstPtr& msg) {
+      this->onModifyTerrainEllipseMsg(msg);
+    };
+
+    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_ellipse>(
+        "/ow_dynamic_terrain/modify_terrain_ellipse", 10, on_modify_terrain_ellipse));
+
+    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_ellipse>(
+        "/ow_dynamic_terrain/modify_terrain_ellipse/visual", 10, on_modify_terrain_ellipse));
+
+    auto on_modify_terrain_patch = [this](const modify_terrain_patch::ConstPtr& msg) {
+      this->onModifyTerrainPatchMsg(msg);
+    };
+
+    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_patch>(
+        "/ow_dynamic_terrain/modify_terrain_patch", 10, on_modify_terrain_patch));
+
+    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_patch>(
+        "/ow_dynamic_terrain/modify_terrain_patch/visual", 10, on_modify_terrain_patch));
 
     m_on_update_connection = event::Events::ConnectPostRender([this]() { this->onUpdate(); });
 
@@ -159,13 +177,7 @@ private:
   ros::CallbackQueue m_ros_queue;
 
 private:
-  ros::Subscriber m_ros_subscriber_circle;
-
-private:
-  ros::Subscriber m_ros_subscriber_ellipse;
-
-private:
-  ros::Subscriber m_ros_subscriber_patch;
+  vector<ros::Subscriber> m_ros_subscribers;
 };
 
 GZ_REGISTER_VISUAL_PLUGIN(DynamicTerrainVisual)

--- a/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
@@ -2,16 +2,8 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-#include <ros/callback_queue.h>
-#include <ros/ros.h>
-#include <ros/subscribe_options.h>
-#include <gazebo/common/common.hh>
-#include <gazebo/rendering/RenderingIface.hh>
-#include <gazebo/rendering/Scene.hh>
 #include "TerrainModifier.h"
-#include "ow_dynamic_terrain/modify_terrain_circle.h"
-#include "ow_dynamic_terrain/modify_terrain_ellipse.h"
-#include "ow_dynamic_terrain/modify_terrain_patch.h"
+#include "DynamicTerrainBase.h"
 
 using namespace std;
 using namespace gazebo;
@@ -19,80 +11,18 @@ using namespace rendering;
 
 namespace ow_dynamic_terrain
 {
-class DynamicTerrainVisual : public VisualPlugin
+class DynamicTerrainVisual : public VisualPlugin, public DynamicTerrainBase
 {
+public:
+  DynamicTerrainVisual() :
+    DynamicTerrainBase{ "ow_dynamic_terrain", "DynamicTerrainVisual" }
+  {
+  }
+
 public:
   void Load(VisualPtr /*visual*/, sdf::ElementPtr /*sdf*/) override
   {
-    if (!ros::isInitialized())
-    {
-      gzerr << "DynamicTerrainVisual: ROS not initilized!" << endl;
-      return;
-    }
-
-    m_ros_node.reset(new ros::NodeHandle("dynamic_terrain_visual"));
-    m_ros_node->setCallbackQueue(&m_ros_queue);
-
-    auto on_modify_terrain_circle = [this](const modify_terrain_circle::ConstPtr& msg) {
-      this->onModifyTerrainCircleMsg(msg);
-    };
-
-    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_circle>(
-        "/ow_dynamic_terrain/modify_terrain_circle", 10, on_modify_terrain_circle));
-
-    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_circle>(
-        "/ow_dynamic_terrain/modify_terrain_circle/visual", 10, on_modify_terrain_circle));
-
-    auto on_modify_terrain_ellipse = [this](const modify_terrain_ellipse::ConstPtr& msg) {
-      this->onModifyTerrainEllipseMsg(msg);
-    };
-
-    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_ellipse>(
-        "/ow_dynamic_terrain/modify_terrain_ellipse", 10, on_modify_terrain_ellipse));
-
-    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_ellipse>(
-        "/ow_dynamic_terrain/modify_terrain_ellipse/visual", 10, on_modify_terrain_ellipse));
-
-    auto on_modify_terrain_patch = [this](const modify_terrain_patch::ConstPtr& msg) {
-      this->onModifyTerrainPatchMsg(msg);
-    };
-
-    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_patch>(
-        "/ow_dynamic_terrain/modify_terrain_patch", 10, on_modify_terrain_patch));
-
-    m_ros_subscribers.push_back(m_ros_node->subscribe<modify_terrain_patch>(
-        "/ow_dynamic_terrain/modify_terrain_patch/visual", 10, on_modify_terrain_patch));
-
-    m_on_update_connection = event::Events::ConnectPostRender([this]() { this->onUpdate(); });
-
-    gzlog << "DynamicTerrainVisual: successfully loaded!" << endl;
-  }
-
-private:
-  Heightmap* getHeightmap()
-  {
-    const auto& scene = get_scene();
-    if (!scene)
-    {
-      gzerr << "DynamicTerrainVisual: Couldn't acquire scene!" << endl;
-      return nullptr;
-    }
-
-    auto heightmap = scene->GetHeightmap();
-    if (heightmap == nullptr)
-    {
-      gzerr << "DynamicTerrainVisual: scene has no heightmap!" << endl;
-      return nullptr;
-    }
-
-    return heightmap;
-  }
-
-private:
-  void onUpdate()
-  {
-    if (m_ros_node->ok())
-      m_ros_queue.callAvailable();
+    Initialize("visual");
   }
 
 private:
@@ -111,12 +41,12 @@ private:
   }
 
 private:
-  void onModifyTerrainCircleMsg(const modify_terrain_circle::ConstPtr& msg)
+  void onModifyTerrainCircleMsg(const modify_terrain_circle::ConstPtr& msg) override
   {
-    auto heightmap = getHeightmap();
+    auto heightmap = getHeightmap(get_scene());
     if (heightmap == nullptr)
     {
-      gzerr << "DynamicTerrainVisual: Couldn't acquire heightmap!" << endl;
+      gzerr << m_plugin_name << ": Couldn't acquire heightmap!" << endl;
       return;
     }
 
@@ -130,12 +60,12 @@ private:
   }
 
 private:
-  void onModifyTerrainEllipseMsg(const modify_terrain_ellipse::ConstPtr& msg)
+  void onModifyTerrainEllipseMsg(const modify_terrain_ellipse::ConstPtr& msg) override
   {
-    auto heightmap = getHeightmap();
+    auto heightmap = getHeightmap(get_scene());
     if (heightmap == nullptr)
     {
-      gzerr << "DynamicTerrainVisual: Couldn't acquire heightmap!" << endl;
+      gzerr << m_plugin_name << ": Couldn't acquire heightmap!" << endl;
       return;
     }
 
@@ -149,12 +79,12 @@ private:
   }
 
 private:
-  void onModifyTerrainPatchMsg(const modify_terrain_patch::ConstPtr& msg)
+  void onModifyTerrainPatchMsg(const modify_terrain_patch::ConstPtr& msg) override
   {
-    auto heightmap = getHeightmap();
+    auto heightmap = getHeightmap(get_scene());
     if (heightmap == nullptr)
     {
-      gzerr << "DynamicTerrainVisual: Couldn't acquire heightmap!" << endl;
+      gzerr << m_plugin_name << ": Couldn't acquire heightmap!" << endl;
       return;
     }
 
@@ -166,18 +96,6 @@ private:
     terrain->updateGeometry();
     terrain->updateDerivedData(false, Ogre::Terrain::DERIVED_DATA_NORMALS | Ogre::Terrain::DERIVED_DATA_LIGHTMAP);
   }
-
-private:
-  event::ConnectionPtr m_on_update_connection;
-
-private:
-  unique_ptr<ros::NodeHandle> m_ros_node;
-
-private:
-  ros::CallbackQueue m_ros_queue;
-
-private:
-  vector<ros::Subscriber> m_ros_subscribers;
 };
 
 GZ_REGISTER_VISUAL_PLUGIN(DynamicTerrainVisual)

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -639,6 +639,13 @@
       </plugin>
     </visual>
     <selfCollide>1</selfCollide>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>0x0002</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
   <joint name="j_grinder" type="fixed">
     <origin xyz="-0.075 -0.129903811 0" rpy="0 0 ${-pi*2/3}" />

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -543,15 +543,6 @@
       </plugin>
     </visual>
     <selfCollide>1</selfCollide>
-    <!-- Turn off collisions with the terrain so scoop can go underground. For
-         this to work, the terrain must use a different collide_bitmask. -->
-    <collision>
-      <surface>
-        <contact>
-          <collide_bitmask>0x0002</collide_bitmask>
-        </contact>
-      </surface>
-    </collision>
   </gazebo>
 
   <!-- link that we can reference in Gazebo to get altitude of tip
@@ -648,15 +639,6 @@
       </plugin>
     </visual>
     <selfCollide>1</selfCollide>
-    <!-- Turn off collisions with the terrain so scoop can go underground. For
-         this to work, the terrain must use a different collide_bitmask. -->
-    <collision>
-      <surface>
-        <contact>
-          <collide_bitmask>0x0002</collide_bitmask>
-        </contact>
-      </surface>
-    </collision>
   </gazebo>
   <joint name="j_grinder" type="fixed">
     <origin xyz="-0.075 -0.129903811 0" rpy="0 0 ${-pi*2/3}" />

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -455,8 +455,8 @@
       </plugin>
     </visual>
     <selfCollide>1</selfCollide>
-    <!-- Turn off collisions with the terrain so scoop can go underground. For
-         this to work, the terrain must use a different collide_bitmask.-->
+    <!-- Keep the collision between the terrain and the hand turned off as it
+         results in a slower simulation and worse physics. -->
 
     <collision>
       <surface>


### PR DESCRIPTION
## Summary of changes:
* Collision between the terrain and the end effectors is now enabled
* Topics corresponding to /ow_dynamic_terrain/modify_terrain_* are left intact. Plugin-specific topics {visual and collision} are added to the *DynamicTerrainVisual* and *DynamicTerrainModel* plugins
* Python scripts `modify_terrain_scoop_pub.py` and `modify_terrain_grinder_pub.py` corresponding to the scoop and grinder has been updated to use the Plugin-specific topics with a slightly different parameters for visual vs collision.
 - The `modify_terrain_*/collision` message is merely a scaled up version of the `modify_terrain_*/visual` message  
* README file updated with the new changes

## Verify
Launch the simulation against the `europa_terminator_workspace`:
```bash
roslaunch ow europa_terminator_workspace.launch
```

Use the rqt service caller to perform any arm planning operation that may interact with the terrain. e.g.
- /planning/arm/dig_circular
- /planning/arm/dig_linear
- /planning/arm/grind
Followed by a service call to `/planning/arm/publish_trajectory` with use_latest=True

**Observe the arm modifies the terrain and the arm is not colliding with the terrain.**

## Experiments 
To see the actual size of the terrain set the `modify_terrain_*/visual` message scale value in the  `modify_terrain_scoop_pub.py` and `modify_terrain_grinder_pub.py` to the same scale value of the `modify_terrain_*/collision` message.