### PR TITLE
trajectory_publisher node publishes message with guarded_move result when guarded_move is published, for autonomy

### DIFF
--- a/ow_lander/CMakeLists.txt
+++ b/ow_lander/CMakeLists.txt
@@ -23,6 +23,11 @@ add_service_files(
   Unstow.srv
 )
 
+add_message_files(
+  FILES
+  GuardedMoveResult.msg
+)
+
 generate_messages(
   DEPENDENCIES
   std_msgs
@@ -30,6 +35,7 @@ generate_messages(
 
 catkin_package(
   INCLUDE_DIRS include
+  CATKIN_DEPENDS message_runtime
 )
 
 catkin_add_env_hooks(

--- a/ow_lander/CMakeLists.txt
+++ b/ow_lander/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
   std_msgs
   message_generation
+  geometry_msgs
 )
 
 find_package(roslaunch)
@@ -31,6 +32,7 @@ add_message_files(
 generate_messages(
   DEPENDENCIES
   std_msgs
+  geometry_msgs
 )
 
 catkin_package(

--- a/ow_lander/msg/GuardedMoveResult.msg
+++ b/ow_lander/msg/GuardedMoveResult.msg
@@ -1,5 +1,3 @@
-bool success   # true if the ground has been successfully found
-float32 X      # ground location coordinates
-float32 Y
-float32 Z
-string frame   # reference frame that ground coordinates refer to
+bool success                 # true if the ground has been successfully found
+geometry_msgs/Point32 point  # X,Y,Z location coordinates
+string frame                 # reference frame that ground coordinates refer to

--- a/ow_lander/msg/GuardedMoveResult.msg
+++ b/ow_lander/msg/GuardedMoveResult.msg
@@ -1,3 +1,3 @@
-bool success                 # true if the ground has been successfully found
-geometry_msgs/Point32 point  # X,Y,Z location coordinates
-string frame                 # reference frame that ground coordinates refer to
+bool success                    # true if the ground has been successfully found
+geometry_msgs/Point32 position  # X,Y,Z location coordinates
+string frame                    # reference frame that ground coordinates refer to

--- a/ow_lander/msg/GuardedMoveResult.msg
+++ b/ow_lander/msg/GuardedMoveResult.msg
@@ -1,0 +1,5 @@
+bool success   # true if the ground has been successfully found
+float32 X      # ground location coordinates
+float32 Y
+float32 Z
+string frame   # reference frame that ground coordinates refer to

--- a/ow_lander/scripts/trajectory_publisher.py
+++ b/ow_lander/scripts/trajectory_publisher.py
@@ -5,7 +5,7 @@
 # this repository.
 
 import rospy
-import tf
+import tf2
 from std_msgs.msg import Float64
 from sensor_msgs.msg import JointState
 from ow_lander.srv import *
@@ -23,27 +23,27 @@ velocity_array = np.array([0.0] *1)
 
 
 def thresholding_algo(y, lag, threshold, influence):
-    ground_found = 0
-    if (len(y) < lag):
-        return
-    filteredY = np.array(y)
-    avgFilter = [0]*len(y)
-    stdFilter = [0]*len(y)
-    avgFilter[lag - 1] = np.mean(y[0:lag])
-    stdFilter[lag - 1] = np.std(y[0:lag])
-    for i in range(lag, len(y)):
-        if abs(y[i] - avgFilter[i-1]) > threshold * stdFilter [i-1]:
-            if y[i] > avgFilter[i-1]:
-                ground_found = 1
-            filteredY[i] = influence * y[i] + (1 - influence) * filteredY[i-1]
-            avgFilter[i] = np.mean(filteredY[(i-lag+1):i+1])
-            stdFilter[i] = np.std(filteredY[(i-lag+1):i+1])
-        else:
-            filteredY[i] = y[i]
-            avgFilter[i] = np.mean(filteredY[(i-lag+1):i+1])
-            stdFilter[i] = np.std(filteredY[(i-lag+1):i+1])
+  ground_found = 0
+  if (len(y) < lag):
+    return
+  filteredY = np.array(y)
+  avgFilter = [0]*len(y)
+  stdFilter = [0]*len(y)
+  avgFilter[lag - 1] = np.mean(y[0:lag])
+  stdFilter[lag - 1] = np.std(y[0:lag])
+  for i in range(lag, len(y)):
+    if abs(y[i] - avgFilter[i-1]) > threshold * stdFilter [i-1]:
+      if y[i] > avgFilter[i-1]:
+        ground_found = 1
+      filteredY[i] = influence * y[i] + (1 - influence) * filteredY[i-1]
+      avgFilter[i] = np.mean(filteredY[(i-lag+1):i+1])
+      stdFilter[i] = np.std(filteredY[(i-lag+1):i+1])
+    else:
+      filteredY[i] = y[i]
+      avgFilter[i] = np.mean(filteredY[(i-lag+1):i+1])
+      stdFilter[i] = np.std(filteredY[(i-lag+1):i+1])
 
-    return ground_found
+  return ground_found
 
 def check_for_contact(y):
   # lag, threshold and innfluence can be tuned to detect contact with the ground. These numbers were tested with
@@ -148,24 +148,24 @@ def talker(req):
       if row[0][0] == '1' : # If the row is a command
         ground = check_for_contact(velocity_array)
         if (ground == 1):
-            print "Found ground, stopped motion..."
+          print "Found ground, stopped motion..."
 
-            listener = tf.TransformListener()
-            listener.waitForTransform("/base_link", "/l_scoop_tip", rospy.Time(0), rospy.Duration(10.0))
-            (trans,rot) = listener.lookupTransform("base_link", "l_scoop_tip", rospy.Time(0))
-            pubs[6].publish(ground, trans[0], trans[1], trans[2], 'base_link')
+          listener = tf.TransformListener()
+          listener.waitForTransform("/base_link", "/l_scoop_tip", rospy.Time(0), rospy.Duration(10.0))
+          (trans,rot) = listener.lookupTransform("base_link", "l_scoop_tip", rospy.Time(0))
+          pubs[6].publish(ground, trans[0], trans[1], trans[2], 'base_link')
 
-            # msg = GuardedMoveResult()
-            # msg.success = ground
-            # msg.X = trans[0]
-            # msg.Y = trans[1]
-            # msg.Z = trans[2]
-            # msg.frame = 'base_link'
-            # print(trans)
-            # print(msg)
-            # print(GuardedMoveResult)
+          # msg = GuardedMoveResult()
+          # msg.success = ground
+          # msg.X = trans[0]
+          # msg.Y = trans[1]
+          # msg.Z = trans[2]
+          # msg.frame = 'base_link'
+          # print(trans)
+          # print(msg)
+          # print(GuardedMoveResult)
 
-            return True, "Done publishing guarded_move"
+          return True, "Done publishing guarded_move"
 
         for x in range(nb_links):
           pubs[x].publish(float("%14s\n"%row[12+x]))
@@ -173,10 +173,10 @@ def talker(req):
         rate.sleep()
 
     if (ground != 1):
-        listener = tf.TransformListener()
-        listener.waitForTransform("/base_link", "/l_scoop_tip", rospy.Time(0), rospy.Duration(10.0))
-        (trans,rot) = listener.lookupTransform("base_link", "l_scoop_tip", rospy.Time(0))
-        pubs[6].publish(ground, 0.0, 0.0, 0.0, 'base_link')
+      listener = tf.TransformListener()
+      listener.waitForTransform("/base_link", "/l_scoop_tip", rospy.Time(0), rospy.Duration(10.0))
+      (trans,rot) = listener.lookupTransform("base_link", "l_scoop_tip", rospy.Time(0))
+      pubs[6].publish(ground, 0.0, 0.0, 0.0, 'base_link')
 
   return True, "Done publishing trajectory"
 

--- a/ow_lander/scripts/trajectory_publisher.py
+++ b/ow_lander/scripts/trajectory_publisher.py
@@ -5,6 +5,7 @@
 # this repository.
 
 import rospy
+import tf
 from std_msgs.msg import Float64
 from sensor_msgs.msg import JointState
 from ow_lander.srv import *
@@ -15,6 +16,7 @@ import os
 import constants
 import numpy as np
 import pylab
+from ow_lander.msg import GuardedMoveResult
 
 
 velocity_array = np.array([0.0] *1)
@@ -23,7 +25,7 @@ velocity_array = np.array([0.0] *1)
 def thresholding_algo(y, lag, threshold, influence):
     ground_found = 0
     if (len(y) < lag):
-        return 
+        return
     filteredY = np.array(y)
     avgFilter = [0]*len(y)
     stdFilter = [0]*len(y)
@@ -45,12 +47,12 @@ def thresholding_algo(y, lag, threshold, influence):
 
 def check_for_contact(y):
   # lag, threshold and innfluence can be tuned to detect contact with the ground. These numbers were tested with
-  #different planning algorithms to check for ground. If these number doesnot work for your particular configuration, 
-  #you can re-tune the numbers. Save velocity array (uncomment line 60 np.savetxt ....), and run   peak_detect.py. see 
-  #peak_detect.py for more information. 
+  #different planning algorithms to check for ground. If these number doesnot work for your particular configuration,
+  #you can re-tune the numbers. Save velocity array (uncomment line 60 np.savetxt ....), and run   peak_detect.py. see
+  #peak_detect.py for more information.
   lag = 100
   threshold = 20
-  influence = 1.0 
+  influence = 1.0
   # Run algo with settings from above
   result = thresholding_algo(y, lag=lag, threshold=threshold, influence=influence)
   return result
@@ -60,13 +62,13 @@ def joint_states_cb(data):
   global velocity_array
   velocity_array  = np.append(velocity_array , data.velocity[6])
   #c = np.savetxt('velocity_array.txt', velocity_array)  # save the velocity_array to tune the ground detection
-  
 
-# The talker runs once the publish service is called. It starts a publisher 
-# per joint controller, then reads the trajectory csvs. 
+
+# The talker runs once the publish service is called. It starts a publisher
+# per joint controller, then reads the trajectory csvs.
 # If the traj csv is a guarded move, it reads both parts.
 # When publishing the safe (second) part of a guarded_move, it
-# monitors the velocity, and cuts off the publishing after is ground is detected. 
+# monitors the velocity, and cuts off the publishing after is ground is detected.
 #The ground is detected after the peak_detection algorithm detects a spike in the velocity data
 
 
@@ -81,7 +83,7 @@ def talker(req):
   pub_rate = constants.TRAJ_PUB_RATE # Hz
   rate = rospy.Rate(pub_rate) # Hz
   nb_links = constants.NB_ARM_LINKS
-  rows = [] 
+  rows = []
   guard_rows = []
   guarded_move_bool = False
 
@@ -98,30 +100,30 @@ def talker(req):
 
   # Use two files instead of one if this is a guarded move
   if filename.startswith('guarded_move_traj_'):
-    # reading csv file 
+    # reading csv file
     guard_filename = filename
     prefix = "pre_"
     filename = prefix + filename
     guarded_move_bool = True
 
-  # Reading csv file 
-  with open(filename, 'r') as csvfile: 
-    # creating a csv reader object 
-    csvreader = csv.reader(csvfile) 
+  # Reading csv file
+  with open(filename, 'r') as csvfile:
+    # creating a csv reader object
+    csvreader = csv.reader(csvfile)
 
-    # extracting each data row one by one 
-    for row in csvreader: 
-      rows.append(row) 
+    # extracting each data row one by one
+    for row in csvreader:
+      rows.append(row)
 
   # If guarded_move, read the guarded motion traj csv
   if guarded_move_bool :
-    with open(guard_filename, 'r') as csvfile: 
-      # creating a csv reader object 
-      csvreader = csv.reader(csvfile) 
+    with open(guard_filename, 'r') as csvfile:
+      # creating a csv reader object
+      csvreader = csv.reader(csvfile)
 
-      # extracting each data row one by one 
-      for row in csvreader: 
-        guard_rows.append(row) 
+      # extracting each data row one by one
+      for row in csvreader:
+        guard_rows.append(row)
 
   # === PUBLISH TRAJ FILE(S) ===============================
   for row in rows[1:]: # Cycles on all the rows except header
@@ -131,24 +133,50 @@ def talker(req):
       print "Sent %s on joint[0] publisher"%(float("%14s\n"%row[12+0]))
       rate.sleep()
 
-        
+
   if guarded_move_bool : # If the activity is a guarded_move
+
+    # Start publisher for guarded_move result message
+    pubs.append(rospy.Publisher('/GUARDED_MOVE_RESULT_W0OOOOHHHHHHHH', GuardedMoveResult, queue_size=10))
+
     # Start subscriber for the joint_states
     rate = rospy.Rate(int(pub_rate/2)) # Hz
     rospy.Subscriber("/joint_states", JointState, joint_states_cb)
     time.sleep(2)
-    start_guard_delay_acc = 0 
+    start_guard_delay_acc = 0
     for row in guard_rows[1:]: # Cycles on all the rows except header
       if row[0][0] == '1' : # If the row is a command
-        ground = check_for_contact(velocity_array)  
-        if (ground == 1):     
+        ground = check_for_contact(velocity_array)
+        if (ground == 1):
             print "Found ground, stopped motion..."
+
+            listener = tf.TransformListener()
+            listener.waitForTransform("/base_link", "/l_scoop_tip", rospy.Time(0), rospy.Duration(10.0))
+            (trans,rot) = listener.lookupTransform("base_link", "l_scoop_tip", rospy.Time(0))
+            pubs[6].publish(ground, trans[0], trans[1], trans[2], 'base_link')
+
+            # msg = GuardedMoveResult()
+            # msg.success = ground
+            # msg.X = trans[0]
+            # msg.Y = trans[1]
+            # msg.Z = trans[2]
+            # msg.frame = 'base_link'
+            # print(trans)
+            # print(msg)
+            # print(GuardedMoveResult)
+
             return True, "Done publishing guarded_move"
 
         for x in range(nb_links):
           pubs[x].publish(float("%14s\n"%row[12+x]))
         print "Guarded. Sent %s on joint[0] publisher"%(float("%14s\n"%row[12+0]))
-        rate.sleep()        
+        rate.sleep()
+
+    if (ground != 1):
+        listener = tf.TransformListener()
+        listener.waitForTransform("/base_link", "/l_scoop_tip", rospy.Time(0), rospy.Duration(10.0))
+        (trans,rot) = listener.lookupTransform("base_link", "l_scoop_tip", rospy.Time(0))
+        pubs[6].publish(ground, 0.0, 0.0, 0.0, 'base_link')
 
   return True, "Done publishing trajectory"
 

--- a/ow_lander/scripts/trajectory_publisher.py
+++ b/ow_lander/scripts/trajectory_publisher.py
@@ -137,7 +137,7 @@ def talker(req):
   if guarded_move_bool : # If the activity is a guarded_move
 
     # Start publisher for guarded_move result message
-    pubs.append(rospy.Publisher('/GUARDED_MOVE_RESULT_W0OOOOHHHHHHHH', GuardedMoveResult, queue_size=10))
+    pubs.append(rospy.Publisher('/guarded_move_result', GuardedMoveResult, queue_size=10))
 
     # Start subscriber for the joint_states
     rate = rospy.Rate(int(pub_rate/2)) # Hz

--- a/ow_lander/scripts/trajectory_publisher.py
+++ b/ow_lander/scripts/trajectory_publisher.py
@@ -143,6 +143,8 @@ def talker(req):
     # Start subscriber for the joint_states
     rate = rospy.Rate(int(pub_rate/2)) # Hz
     rospy.Subscriber("/joint_states", JointState, joint_states_cb)
+    tfBuffer = tf2_ros.Buffer()
+    listener = tf2_ros.TransformListener(tfBuffer)
     time.sleep(2)
     for row in guard_rows[1:]: # Cycles on all the rows except header
       if row[0][0] == '1' : # If the row is a command
@@ -150,13 +152,8 @@ def talker(req):
         if (ground == 1):
           print "Found ground, stopped motion..."
 
-          tfBuffer = tf2_ros.Buffer()
-          listener = tf2_ros.TransformListener(tfBuffer)
           trans = tfBuffer.lookup_transform("base_link", "l_scoop_tip", rospy.Time(0), rospy.Duration(10.0))
-          Point_X = trans.transform.translation.x
-          Point_Y = trans.transform.translation.y
-          Point_Z = trans.transform.translation.z
-          guarded_move_pub.publish(ground, Point(Point_X, Point_Y, Point_Z), 'base_link')
+          guarded_move_pub.publish(ground, trans.transform.translation, 'base_link')
 
           return True, "Done publishing guarded_move"
 


### PR DESCRIPTION
Hello!
Ticket: https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-434

Background:
We agreed some time ago that, after publishing guarded_move, there should be a message containing the following information: has ground been found successfully? What are the coordinates of the ground? In which reference frame? Autonomy will use this info to store the ground height at that specific location and feed it to the digging services. 

What I did here:
- I use the existing node "trajectory_publisher" to publish a message on a new topic, at the end of publish_trajectory for guarded_move. 
- the message is defined in ow_lander>msg, called "GuardedMoveResult.msg"
- the topic is called: "/guarded_move_result".

How to test:
- Terminal 1: roslaunch ow europa_terminator_workspace.launch

- Terminal 2: 
a) rosservice call /planning/arm/guarded_move True True 0 0 0 0 0 0 0
b) rosservice call /planning/arm/publish_trajectory True a
 
- Terminal 3, while trajectory is being published: 
a) rostopic list . Check if the topic "/guarded_move_result" is in the list
b) rostopic echo /guarded_move_result . wait until ground is found. The message should show up when it is found.

Questions for you:
- I am having the trajectory_publisher node publishing on a separate topic the guarded_move result. Is that OK or should I create another node?
- Once ground is found, the message with ground info is published only once. Is that OK? If not, how long should I publish it for? Shall I wait for a feedback from autonomy that confirms reception of the message and then publishing?
- @kmdalal, does that message look OK on the autonomy side?
- @Samahu can you give me feedback on how the code is written? Given the existing code, did I choose the proper way of publishing on a new topic?