### PR TITLE
Oceanwater 457 refactor thresholding algo to scan samples once

### DIFF
--- a/ow_lander/scripts/peak_detection_real_time.py
+++ b/ow_lander/scripts/peak_detection_real_time.py
@@ -56,10 +56,10 @@ class PeakDetectionRT:
 
 
   def _warmup(self):
-  """
-  accumulate enough samples (determined by lag) before performing detection 
-  :return: always returns zero. i.e. no peak or anomaly.
-  """
+    """
+    accumulate enough samples (determined by lag) before performing detection 
+    :return: always returns zero. i.e. no peak or anomaly.
+    """
     self.y_filtered = self.y_raw
     self.avg_filter.append(self.y_filtered)
     self.std_filter.append(self.y_filtered)

--- a/ow_lander/scripts/peak_detection_real_time.py
+++ b/ow_lander/scripts/peak_detection_real_time.py
@@ -56,6 +56,10 @@ class PeakDetectionRT:
 
 
   def _warmup(self):
+  """
+  accumulate enough samples (determined by lag) before performing detection 
+  :return: always returns zero. i.e. no peak or anomaly.
+  """
     self.y_filtered = self.y_raw
     self.avg_filter.append(self.y_filtered)
     self.std_filter.append(self.y_filtered)

--- a/ow_lander/scripts/peak_detection_real_time.py
+++ b/ow_lander/scripts/peak_detection_real_time.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import numpy as np
+import csv
+from collections import deque
+
+class SlidingWindow:
+  """
+  A class that maintains a sliding window over a stream of samples in FIFO order
+  """
+
+  def __init__(self, size, method):
+    self.que = deque()
+    self.size = size
+    self.method = method
+
+  def append(self, val):
+    if len(self.que) >= self.size:
+      self.que.pop()
+    self.que.appendleft(val)
+
+  @property
+  def value(self):
+    # TODO: consider caching the value to speed up query
+    return self.method(self.que)
+
+
+class PeakDetectionRT:
+  """
+  This class implements a modified version of the peak detection algorithm described in:
+  https://stackoverflow.com/questions/22583391/peak-signal-detection-in-realtime-timeseries-data
+  This implementation acts on a data stream rather than assuming all data preloaded
+  into an array.
+  """
+
+  def __init__(self, lag, threshold, influence):
+    self.lag = lag
+    self.threshold = threshold
+    self.influence = influence
+
+    self.reset()
+
+  def reset(self):
+    """ Resets all internal counters.
+    Use for every new session without having to recreate the object. """
+    self.counter = 0
+    self.y_raw = 0
+    self.y_filtered = 0
+    self.signal = 0
+    self.avg_filter = SlidingWindow(self.lag, np.mean)
+    self.std_filter = SlidingWindow(self.lag, np.std)
+
+
+  def _warmup(self):
+    self.y_filtered = self.y_raw
+    self.avg_filter.append(self.y_filtered)
+    self.std_filter.append(self.y_filtered)
+    return self.signal  # signal is 0
+
+  def _detect(self):
+    if abs(self.y_raw - self.avg_filter.value) > self.threshold * self.std_filter.value:
+      self.signal = np.sign(self.y_raw - self.avg_filter.value)
+      self.y_filtered = self.influence * self.y_raw + \
+          (1 - self.influence) * self.y_filtered
+    else:
+      self.signal = 0
+      self.y_filtered = self.y_raw
+    self.avg_filter.append(self.y_filtered)
+    self.std_filter.append(self.y_filtered)
+    return self.signal
+
+  def detect(self, value):
+    """
+    Performs peak detection
+
+    :param float value: a single value of a stream of data
+    :return: If a peak is detected the method returns +1 or -1 which indicate
+    a strong postive deivation from the mean or negative one respectively. When
+    no peak is detected the method returns 0.
+    :rtype: int
+    """
+    self.counter += 1
+    self.y_raw = value
+    result = self._warmup() if self.counter < self.lag else self._detect()
+    return result

--- a/ow_lander/scripts/trajectory_publisher.py
+++ b/ow_lander/scripts/trajectory_publisher.py
@@ -14,10 +14,9 @@ import glob
 import os
 import constants
 import numpy as np
-import pylab
 
 
-velocity_array = np.array([0.0] *1)
+from peak_detection_real_time import PeakDetectionRT
 
 
 def thresholding_algo(y, lag, threshold, influence):
@@ -41,25 +40,25 @@ def thresholding_algo(y, lag, threshold, influence):
             avgFilter[i] = np.mean(filteredY[(i-lag+1):i+1])
             stdFilter[i] = np.std(filteredY[(i-lag+1):i+1])
 
-    return ground_found
+lag = 80
+threshold = 6.3
+influence = 0.5
+peak_detection = PeakDetectionRT(lag=lag, threshold=threshold, influence=influence)
+ground_detected = 0
 
 def check_for_contact(y):
-  # lag, threshold and innfluence can be tuned to detect contact with the ground. These numbers were tested with
-  #different planning algorithms to check for ground. If these number doesnot work for your particular configuration, 
-  #you can re-tune the numbers. Save velocity array (uncomment line 60 np.savetxt ....), and run   peak_detect.py. see 
-  #peak_detect.py for more information. 
-  lag = 100
-  threshold = 20
-  influence = 1.0 
-  # Run algo with settings from above
-  result = thresholding_algo(y, lag=lag, threshold=threshold, influence=influence)
-  return result
+
+  global ground_detected, peak_detection
+
+  if ground_detected == 0:
+    result = peak_detection.detect(y)
+
+    if result != 0:
+      ground_detected = result
 
 def joint_states_cb(data):
 
-  global velocity_array
-  velocity_array  = np.append(velocity_array , data.velocity[6])
-  #c = np.savetxt('velocity_array.txt', velocity_array)  # save the velocity_array to tune the ground detection
+  check_for_contact(data.velocity[6])
   
 
 # The talker runs once the publish service is called. It starts a publisher 
@@ -134,21 +133,21 @@ def talker(req):
         
   if guarded_move_bool : # If the activity is a guarded_move
     # Start subscriber for the joint_states
+    time.sleep(2) # subscribe right after coming from sleep .. this way we maintain values when moving downwards
+    global ground_detected, peak_detection
+    ground_detected = 0
+    peak_detection.reset()
     rate = rospy.Rate(int(pub_rate/2)) # Hz
     rospy.Subscriber("/joint_states", JointState, joint_states_cb)
-    time.sleep(2)
-    start_guard_delay_acc = 0 
     for row in guard_rows[1:]: # Cycles on all the rows except header
       if row[0][0] == '1' : # If the row is a command
-        ground = check_for_contact(velocity_array)  
-        if (ground == 1):     
+        if ground_detected != 0:
             print "Found ground, stopped motion..."
             return True, "Done publishing guarded_move"
 
         for x in range(nb_links):
           pubs[x].publish(float("%14s\n"%row[12+x]))
-        print "Guarded. Sent %s on joint[0] publisher"%(float("%14s\n"%row[12+0]))
-        rate.sleep()        
+        rate.sleep()
 
   return True, "Done publishing trajectory"
 

--- a/ow_lander/scripts/trajectory_publisher.py
+++ b/ow_lander/scripts/trajectory_publisher.py
@@ -117,6 +117,7 @@ def talker(req):
 
     # Start subscriber for the joint_states
     time.sleep(2) # subscribe right after coming from sleep .. this way we maintain values when moving downwards
+    # begin tracking velocity values as soon as the scoop moves downward 
     global ground_detected, peak_detection
     ground_detected = 0
     peak_detection.reset()

--- a/ow_lander/scripts/trajectory_publisher.py
+++ b/ow_lander/scripts/trajectory_publisher.py
@@ -116,7 +116,7 @@ def talker(req):
     guarded_move_pub = rospy.Publisher('/guarded_move_result', GuardedMoveResult, queue_size=10)
 
     # Start subscriber for the joint_states
-    time.sleep(2) # subscribe right after coming from sleep .. this way we maintain values when moving downwards
+    time.sleep(2) # wait for 2 seconds till the arm settles
     # begin tracking velocity values as soon as the scoop moves downward 
     global ground_detected, peak_detection
     ground_detected = 0


### PR DESCRIPTION
## Summary of Changes:
This PR improves and addresses several issues in current implementation/integration of the ground detection:
The improvements include:
- Scan velocity samples only once
- Catch peaks that could have been missed
- Make sure that the peak detector state is reset on every invocation (to enable invoking multiple times in one session).
- Limit resource usage

## Verify:
Launch the simulation using
```bash
roslaunch ow europa_terminator_workspace.launch
```
Then plan a guarded move and execute it.
Try Invoking the plan multiple times in one session.
Report how to often do you successfully get the ground detected signal. This doesn't address making the ground detection robust yet. See the note down below. 

## Objectives
- Verify functionality described
- Verify that this change didn't break any existing functionality (for example the **guarded_move_result**)
- Review code and spot an potential issues or improvements

**Linked Issue:** https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-457

__Note:__ This PR doesn't include the necessary changes to make robust against minor tweaks to the simulation. This will be addressed as part of issue: https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-461