### PR TITLE
Modified dig_linear, changed default terrain height

### DIFF
--- a/ow_lander/scripts/activity_full_digging_traj.py
+++ b/ow_lander/scripts/activity_full_digging_traj.py
@@ -132,12 +132,14 @@ def dig_linear(move_arm,move_limbs,args):
   #rotate dist pith to pre-trenching position.
   change_joint_value(move_arm, constants.J_DIST_PITCH, -math.pi/2)
 
-  ## Once aligned to trench goal, place hand above trench middle point
-  z_start = ground_position + constants.SCOOP_OFFSET - depth
-  go_to_Z_coordinate(move_limbs, x_start, y_start, z_start)
+  ## Once aligned to trench goal, place hand above the desired start point
+  alpha = math.atan2(constants.WRIST_SCOOP_PARAL,constants.WRIST_SCOOP_PERP)
+  distance_from_ground = constants.ROT_RADIUS*(math.cos(alpha)-math.sin(alpha))
+  z_start = ground_position + constants.SCOOP_HEIGHT - depth + distance_from_ground
+  go_to_Z_coordinate(move_arm, x_start, y_start, z_start)
 
   #  rotate to dig in the ground
-  change_joint_value(move_arm, constants.J_DIST_PITCH, 55.0/180.0*math.pi)
+  change_joint_value(move_arm, constants.J_DIST_PITCH, 2.0/9.0*math.pi)
 
   # determine linear trenching direction (alpha)
   current_pose = move_arm.get_current_pose().pose

--- a/ow_lander/scripts/constants.py
+++ b/ow_lander/scripts/constants.py
@@ -18,10 +18,12 @@ HAND_Y_OFFSET = 0.0249979319838
 
 SCOOP_OFFSET = 0.215
 GRINDER_OFFSET = 0.8
+
+# Distance between scoop center of mass and lower blade
 SCOOP_HEIGHT = 0.076
 GRINDER_HEIGHT = 3*SCOOP_HEIGHT
 
-DEFAULT_GROUND_HEIGHT = -0.175
+DEFAULT_GROUND_HEIGHT = -0.135
 
 X_DELIV = 0.2
 Y_DELIV = 0.2
@@ -33,3 +35,12 @@ GUARD_FILTER_AV_WIDTH = 10
 GUARD_MAX_SLOPE_BEFORE_CONTACT_COEFF = 5
 TRAJ_PUB_RATE = 10
 NB_ARM_LINKS = 6
+
+# Distance between center or mass of the scoop and center of rotation in l_wrist
+ROT_RADIUS = 0.36
+
+# Distance between wrist center of mass and scoop center of mass
+# Component parallel to ground
+WRIST_SCOOP_PARAL = 0.2
+# Component perperdicular to ground
+WRIST_SCOOP_PERP = 0.3


### PR DESCRIPTION
1) Did some modifications to dig_linear because it wouldn't go to the target depth. 
2) Reduced default depth because doing experiments with guarded_move for Ussama's review I realized the given default terrain depth was too high.

I am selecting only Terry as reviewer because these are small changes.

To test, plan and publish dig_linear. The scoop should go underground. I suggest to disable collision for the scoop to avoid problems in visualizing this caused by dynamic terrain. Thanks! 