### PR TITLE
Refine digging collision and deformation

### DIFF
--- a/ow_dynamic_terrain/scripts/modify_terrain_grinder_pub.py
+++ b/ow_dynamic_terrain/scripts/modify_terrain_grinder_pub.py
@@ -28,7 +28,7 @@ class ModifyTerrainGrinder:
     self.states_sub = rospy.Subscriber(
         "/gazebo/link_states", LinkStates, self.handle_link_states)
 
-  def compose_modify_terrain_circle_message(self, position, scale=1.0):
+  def compose_modify_terrain_circle_message(self, position, depth, scale=1.0):
     """ Composes a modify_terrain_circle that matches the grinder end effector
     it is positioned downwards ready for digging. When the grinder is position
     downward for digging the shape it projects on the terrain as a circle.
@@ -39,8 +39,8 @@ class ModifyTerrainGrinder:
         message
     """
     return modify_terrain_circle(position=Point(position.x, position.y, position.z),
-                                 outer_radius=0.008*scale, inner_radius=0.001*scale,
-                                 weight=-0.2*scale, merge_method="min")
+                                 outer_radius=0.08*scale, inner_radius=0.04*scale,
+                                 weight=depth*scale, merge_method="min")
 
   def check_and_submit(self, new_position, new_rotation):
     """ Checks if position has changed significantly before submmitting a message """
@@ -59,10 +59,10 @@ class ModifyTerrainGrinder:
 
     self.last_translation = current_translation
 
-    msg = self.compose_modify_terrain_circle_message(new_position)
-    self.pub_visual.publish(msg)
-    msg = self.compose_modify_terrain_circle_message(new_position, scale=2.0)
+    msg = self.compose_modify_terrain_circle_message(new_position, depth=-0.16, scale=2.0)
     self.pub_collision.publish(msg)
+    msg = self.compose_modify_terrain_circle_message(new_position, depth=-0.06, scale=1.0)
+    self.pub_visual.publish(msg)
     
     rospy.logdebug_throttle(1, "modify_terrain_grinder message:\n" + str(msg))
 

--- a/ow_dynamic_terrain/scripts/modify_terrain_scoop_pub.py
+++ b/ow_dynamic_terrain/scripts/modify_terrain_scoop_pub.py
@@ -39,8 +39,8 @@ class ModifyTerrainScoop:
     """
     return modify_terrain_ellipse(position=Point(position.x, position.y, position.z),
                                   orientation=orientation,
-                                  outer_radius_a=0.002*scale, outer_radius_b=0.005*scale,
-                                  inner_radius_a=0.001*scale, inner_radius_b=0.001*scale,
+                                  outer_radius_a=0.02*scale, outer_radius_b=0.05*scale,
+                                  inner_radius_a=0.01*scale, inner_radius_b=0.01*scale,
                                   weight=-0.025*scale, merge_method="min")
 
   def check_and_submit(self, new_position, new_rotation):
@@ -57,8 +57,6 @@ class ModifyTerrainScoop:
 
     msg = self.compose_modify_terrain_ellipse_message(new_position, degrees(yaw))
     self.visual_pub.publish(msg)
-    msg = self.compose_modify_terrain_ellipse_message(new_position, degrees(yaw), scale=1.5)
-    self.collision_pub.publish(msg)
     
     rospy.logdebug_throttle(1, "modify_terrain_scoop message:\n" + str(msg))
 

--- a/ow_dynamic_terrain/src/TerrainModifier.cpp
+++ b/ow_dynamic_terrain/src/TerrainModifier.cpp
@@ -55,10 +55,8 @@ void TerrainModifier::modifyCircle(Heightmap* heightmap, const modify_terrain_ci
   }
 
   auto center = TerrainModifier::getHeightmapPosition(heightmap, msg->position);
-
-  auto heightmap_size = terrain->getSize();
-  auto image =
-      TerrainBrush::circle(heightmap_size * msg->outer_radius, heightmap_size * msg->inner_radius, msg->weight);
+  auto h_scale = terrain->getSize() / terrain->getWorldSize();  // horizontal scale factor
+  auto image = TerrainBrush::circle(h_scale * msg->outer_radius, h_scale * msg->inner_radius, msg->weight);
 
   applyImageToHeightmap(heightmap, center, msg->position.z, image, true, get_height_value, set_height_value,
                         *merge_method);
@@ -102,10 +100,10 @@ void TerrainModifier::modifyEllipse(Heightmap* heightmap, const modify_terrain_e
 
   auto center = TerrainModifier::getHeightmapPosition(heightmap, msg->position);
 
-  auto heightmap_size = terrain->getSize();
+  auto h_scale = terrain->getSize() / terrain->getWorldSize();  // horizontal scale factor
   auto image =
-      TerrainBrush::ellipse(heightmap_size * msg->outer_radius_a, heightmap_size * msg->inner_radius_a,
-                            heightmap_size * msg->outer_radius_b, heightmap_size * msg->inner_radius_b, msg->weight);
+      TerrainBrush::ellipse(h_scale * msg->outer_radius_a, h_scale * msg->inner_radius_a,
+                            h_scale * msg->outer_radius_b, h_scale * msg->inner_radius_b, msg->weight);
 
   if (!ignition::math::equal<float>(msg->orientation, 0.0f))  // Avoid performing the rotation if orientation is zero
   {

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -543,6 +543,13 @@
       </plugin>
     </visual>
     <selfCollide>1</selfCollide>
+    <collision>
+      <surface>
+        <contact>
+          <collide_bitmask>0x0001</collide_bitmask>
+        </contact>
+      </surface>
+    </collision>
   </gazebo>
 
   <!-- link that we can reference in Gazebo to get altitude of tip
@@ -642,7 +649,7 @@
     <collision>
       <surface>
         <contact>
-          <collide_bitmask>0x0002</collide_bitmask>
+          <collide_bitmask>0x0001</collide_bitmask>
         </contact>
       </surface>
     </collision>

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -546,7 +546,7 @@
     <collision>
       <surface>
         <contact>
-          <collide_bitmask>0x0001</collide_bitmask>
+          <collide_bitmask>0x0001</collide_bitmask> <!-- Enable collision with the terrain by matching the bitmask -->
         </contact>
       </surface>
     </collision>
@@ -649,7 +649,8 @@
     <collision>
       <surface>
         <contact>
-          <collide_bitmask>0x0001</collide_bitmask>
+          <collide_bitmask>0x0001</collide_bitmask> <!-- Enable collision with the terrain by matching the bitmask -->
+
         </contact>
       </surface>
     </collision>


### PR DESCRIPTION
## Summary of Changes:
+ Ensure the same digging values works for all terrains
+ Grinder only affects 1/3 of the value
+ Enable collision for scoop and grinder

## Verify
```bash
roslaunch ow europa_terminator_workspace.launch
```
or
```bash
roslaunch ow atacama_y1a.launch
```
and then perform the grind operation followed by a scoop. Note that scooping now collides with the terrain.

## Objectives
* Check that the grind operation affects all the terrain in same manner (in particular atacama and terminator_workspace).
* Check that the Scoop operation no longer updates the collision.
* Check that the Scoop operation only updates the terrain visuals.
* Any suggestions or improvements that can be made to make this work better.

Linked Issue: https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-471