### PR TITLE
Use git URLs identical to the ones on github.

### DIFF
--- a/oceanwaters/workspaces/oceanwaters.rosinstall
+++ b/oceanwaters/workspaces/oceanwaters.rosinstall
@@ -1,12 +1,12 @@
 ## Top-level repo and ROS/Gazebo packages
-- git: { local-name: ow_simulator,    uri: 'https://github.com/nasa/ow_simulator' }
+- git: { local-name: ow_simulator,    uri: 'https://github.com/nasa/ow_simulator.git' }
 
 ## Gazebo world files and the big data that accompanies them
-- git: { local-name: ow_europa,       uri: 'https://github.com/nasa/ow_europa'    }
+- git: { local-name: ow_europa,       uri: 'https://github.com/nasa/ow_europa.git'    }
 
 ## Autonomy
-- git: { local-name: ow_autonomy,     uri: 'https://github.com/nasa/ow_autonomy'  }
+- git: { local-name: ow_autonomy,     uri: 'https://github.com/nasa/ow_autonomy.git'  }
 
 ## misc
-- git: { local-name: irg_open,        uri: 'https://github.com/nasa/irg_open'     }
+- git: { local-name: irg_open,        uri: 'https://github.com/nasa/irg_open.git'     }
 


### PR DESCRIPTION
The git URLs we are using are different from the ones that github gives you to clone code. Both work. But if you clone a repo using github's URL and then do a wstool up, you get this:
```
Url https://github.com/nasa/irg_open does not match https://github.com/nasa/irg_open.git requested.
  (d)elete and replace, (a)bort, (b)ackup and replace, (s)kip:
```
This ticket just changes to use github's URLs in our .rosinstall file. It will cause a little confusing in the near term but may save developers that confusion later on. Consistency is good.