### PR TITLE
Threshold ground detection based on velocity trend

### DIFF
--- a/ow_lander/scripts/ground_detection.py
+++ b/ow_lander/scripts/ground_detection.py
@@ -54,7 +54,8 @@ class GroundDetector:
 
     if self._check_ground_method == self._gazebo_link_states_method:
       rospy.Subscriber("/gazebo/link_states", LinkStates, self._handle_link_states)
-      self._query_ground_position_method = lambda: self._tf_lookup_position(rospy.Duration(10))
+      self._query_ground_position_method = lambda: self._tf_lookup_position(
+          rospy.Duration(10))
     else:
       self._query_ground_position_method = lambda: self._last_position
 
@@ -66,10 +67,12 @@ class GroundDetector:
 
   def _check_condition(self, new_position):
     if self._last_position is None:
-      self._last_position = np.array([new_position.x, new_position.y, new_position.z])
+      self._last_position = np.array(
+          [new_position.x, new_position.y, new_position.z])
       self._last_time = time.time()
       return False
-    current_position = np.array([new_position.x, new_position.y, new_position.z])
+    current_position = np.array(
+        [new_position.x, new_position.y, new_position.z])
     current_time = time.time()
     delta_d = current_position - self._last_position
     delta_t = current_time - self._last_time
@@ -85,7 +88,8 @@ class GroundDetector:
     try:
       idx = data.name.index("lander::l_scoop_tip")
     except ValueError:
-      rospy.logerr_throttle(1, "GroundDetector: lander::l_scoop_tip not found in link_states")
+      rospy.logerr_throttle(
+          1, "GroundDetector: lander::l_scoop_tip not found in link_states")
       return
 
     self._ground_detected = self._check_condition(data.pose[idx].position)

--- a/ow_lander/scripts/ground_detection.py
+++ b/ow_lander/scripts/ground_detection.py
@@ -5,46 +5,45 @@
 # this repository.
 
 import time
+import numpy as np
 import rospy
 import tf2_ros
+from collections import deque
 from gazebo_msgs.msg import LinkStates
 
-# TODO: rather than basing the decision on a single value we can take the trend
-# over a short term of position z value it would probably make the implementation
-# more robust against an arm physics configuration where the end effector doesn't
-#  bounce off the ground at all.
 
-GROUND_DETECTION_THRESHOLD = 0.0009 # TODO: tune this value further to improve
-                                    # detection.
-                                    # Need to  choose a value that works for the
-                                    # majority of configurations
+GROUND_DETECTION_THRESHOLD = -0.005
 
-# class SlidingWindow:
-#   """
-#   A class that maintains a sliding window over a stream of samples in FIFO order
-#   """
+class SlidingWindow:
+  """
+  A class that maintains a sliding window over a stream of samples in FIFO order
+  """
 
-#   def __init__(self, size, method):
-#     self.que = deque()
-#     self.size = size
-#     self.method = method
+  def __init__(self, size, method):
+    self._que = deque()
+    self._size = size
+    self._method = method
 
-#   def append(self, val):
-#     if len(self.que) >= self.size:
-#       self.que.pop()
-#     self.que.appendleft(val)
+  def append(self, val):
+    if len(self._que) >= self._size:
+      self._que.pop()
+    self._que.appendleft(val)
 
-#   @property
-#   def value(self):
-#     # TODO: consider caching the value to speed up query
-#     return self.method(self.que)
+  @property
+  def valid(self):
+    return len(self._que) == self._size
+
+  @property
+  def value(self):
+    # TODO: consider caching the value to speed up query
+    return self._method(self._que)
 
 class GroundDetector:
   """
   GroundDetector uses readings of the link states obtained either directly from
   the simulator via the gazebo/link_states topic or computed through TF2 package
   and implements ground detection by observing a change in movement of the lander
-  arm as it descends to touch the ground.    
+  arm as it descends to touch the ground.
   """
 
   def __init__(self):
@@ -63,16 +62,20 @@ class GroundDetector:
     """ Reset the state of the ground detector for another round """
     self._last_position, self._last_time = None, None
     self._ground_detected = False
+    self._trending_velocity = SlidingWindow(3, np.mean)
 
   def _check_condition(self, new_position):
     if self._last_position is None:
-      self._last_position, self._last_time = new_position, time.time()
+      self._last_position = np.array([new_position.x, new_position.y, new_position.z])
+      self._last_time = time.time()
       return False
-    current_position, current_time = new_position, time.time()
-    delta_d = current_position.z - self._last_position.z
+    current_position = np.array([new_position.x, new_position.y, new_position.z])
+    current_time = time.time()
+    delta_d = current_position - self._last_position
     delta_t = current_time - self._last_time
     self._last_position, self._last_time = current_position, current_time
-    return delta_d / delta_t > GROUND_DETECTION_THRESHOLD
+    self._trending_velocity.append(delta_d[2] / delta_t)
+    return self._trending_velocity.value > GROUND_DETECTION_THRESHOLD if self._trending_velocity.valid else False
 
   def _handle_link_states(self, data):
     # if ground is found ignore further readings until the detector has been reset


### PR DESCRIPTION
## Summary of changes
Significantly improved ground detection by tracking the **trending value** of the arm movement speed and use it to decide if the arm reached ground or not. 

## Verify
Launch the simulation against the europa_terminator_workspace and atacama_y1a
```bash
roslaunch ow europa_terminator_workspace.launch
```
or
```bash
roslaunch ow atacama_y1a.launch
```

Use __ros service caller__ or your favorite method to perform the invoked guarded detection command.

Observe whether the ground detection takes place at the instant the scoop touches the ground. This should perform better than before as I was able to lower the threshold value with the latest changes.

**Note:** Even though I compute the arm movement in 3d but the current criterion to detect ground use only on the z values for decision making. The reason I didn't try this is I would require some time to create these scenarios and test them. Nonetheless, the current implementation may actually be able to detect the guarded move in 3d as the largest trending value will be the z value. If you are able to test that easily please do so and let me know if this works or not.

## Objectives
* Make sure the code runs successfully 
* run the guarded move command multiple times in one session against the current configuration on melodic-devel, also you may try the following configurations:
  - europa_terminator_workspace
  - atacma_y1a
  - world solver instead of quick
  - increase or decrease the trajectory publish rate as the arm descends

If you can think of any other scenario please try it and report any failure and I can work on addressing that.

**Linked Issues:**
* https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-481 (current issue)
* https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-485 (follow up issue)