### PR TITLE
return Point object for trajectory_publisher

### DIFF
--- a/ow_lander/scripts/ground_detection.py
+++ b/ow_lander/scripts/ground_detection.py
@@ -10,6 +10,7 @@ import rospy
 import tf2_ros
 from collections import deque
 from gazebo_msgs.msg import LinkStates
+from geometry_msgs.msg import Point
 
 
 GROUND_DETECTION_THRESHOLD = -0.005
@@ -115,7 +116,8 @@ class GroundDetector:
     Use this method right after ground has been detected to get ground position
     with reference to the base_link
     """
-    return self._query_ground_position_method()
+    position = self._query_ground_position_method()
+    return Point(position[0], position[1], position[2])
 
   def detect(self):
     """


### PR DESCRIPTION
A quick fix that provides the ground position as a a geometry Point message object as the trajectory publisher expects 