### PR TITLE
Oceanwater 487 energy efficient planner

### DIFF
--- a/ow_lander/config/ompl_planning.yaml
+++ b/ow_lander/config/ompl_planning.yaml
@@ -35,6 +35,7 @@ planner_configs:
     type: geometric::RRTstar
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
     goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
+    optimization_objective: MechanicalWorkOptimizationObjective # Optimizer minimizes the mechanical effort
     delay_collision_checking: 1  # Stop collision checking as soon as C-free parent found. default 1
   TRRT:
     type: geometric::TRRT

--- a/ow_lander/scripts/activity_grind.py
+++ b/ow_lander/scripts/activity_grind.py
@@ -65,19 +65,6 @@ def grind(move_arm, move_limbs, move_grinder, args):
   h = math.sqrt( pow(y_start-constants.Y_SHOU,2) + pow(x_start-constants.X_SHOU,2) )
   l = constants.Y_SHOU - constants.HAND_Y_OFFSET
   beta = math.asin (l/h)
-
-  joint_goal = move_arm.get_current_joint_values()
-  joint_goal[constants.J_DIST_PITCH] = 0
-  joint_goal[constants.J_HAND_YAW] = 4*math.pi/3
-  joint_goal[constants.J_PROX_PITCH] = -math.pi/2
-  joint_goal[constants.J_SHOU_PITCH] = math.pi/2
-  joint_goal[constants.J_SHOU_YAW] = alpha + beta
-  # If out of joint range, abort
-  if (is_shou_yaw_goal_in_range(joint_goal)==False):
-    return False
-  move_arm.go(joint_goal, wait=True)
-  move_arm.stop()
-
   alpha = alpha+beta
   
   if parallel:
@@ -93,12 +80,16 @@ def grind(move_arm, move_limbs, move_grinder, args):
     x_start = 0.97*(x_start - dx) # Move starting point back to avoid scoop-terrain collision
     y_start = 0.97*(y_start + dy)   
 
-  # Place the grinder placed above the desired starting point, at
+  # Place the grinder vertical, above the desired starting point, at
   # an altitude of 0.25 meters in the base_link frame. 
   goal_pose = move_grinder.get_current_pose().pose
   goal_pose.position.x = x_start # Position
   goal_pose.position.y = y_start
   goal_pose.position.z = 0.25 
+  goal_pose.orientation.x = 0.70616885803 # Orientation
+  goal_pose.orientation.y = 0.0303977418722
+  goal_pose.orientation.z = -0.706723318474
+  goal_pose.orientation.w = 0.0307192507001
   move_grinder.set_pose_target(goal_pose)
   plan = move_grinder.plan()
   if len(plan.joint_trajectory.points) == 0: # If no plan found, abort


### PR DESCRIPTION
**ABOUT THIS BRANCH**
While reviewing the renovated grinder service, @Samahu noticed that the arm would make an unnecessary motion before the grinder penetrates the terrain. Here is the video: https://www.youtube.com/watch?v=IytOorLmMf8 . This raised a question on whether the planner is actually optimizing the motion for something in particular. I did some research and discovered the following.

- In OceanWATERS we use two planners: RRTconnect and RRTstar. RRT connect is not an optimal planner. The basic idea behind RRTconnect is to grow two trees, one from the start and one from the goal, and attempt to connect them.
- RRTstar is an optimal planner. For RRTstar, the following optimization objectives are available: PathLengthOptimizationObjective (Default), MechanicalWorkOptimizationObjective, MaximizeMinClearanceObjective, StateCostIntegralObjective, MinimaxObjective. 
- We are interested in minimizing the mechanical work, so I introduced in the ompl_planning.yaml a line to specify that. 

Now that the optimization objective is specified, I removed from activity_grinder.py that intermediate motion that I had to introduce to avoid the arm twisting. I tested multiple times and the twisting doesn't happen. 

**TEST**
- Please plan "Unstow". 
- Then plan the grinding service with use_defaults=True. You don't need to publish any trajectory because this was a problem at the planning level.
- Plan "Unstow" again.
- Plan "Grind" with x=1.65, y=0, depth=0.1, length=0.6, parallel=False, ground_position=-0.155
Please report if you see any twisting, thanks!