### PR TITLE
Feature/oceanwater 485 dynamically infer ground detection threshold

### DIFF
--- a/ow_lander/scripts/ground_detection.py
+++ b/ow_lander/scripts/ground_detection.py
@@ -78,7 +78,7 @@ class GroundDetector:
 
   def _check_condition(self, new_position):
     """
-    :type new_position: class 'geometry_msgs.msg._Vector3.Vector3
+    :type new_position: geometry_msgs.msg._Vector3.Vector3
     """
     if self._last_position is None:
       self._last_position = np.array(

--- a/ow_lander/scripts/ground_detection.py
+++ b/ow_lander/scripts/ground_detection.py
@@ -76,7 +76,7 @@ class GroundDetector:
     self._ground_detected = False
     self._trending_velocity = SlidingWindow(5, np.mean)
     self._dynamic_threshold = None
-    self._threshold_tolerance = 0.015 # TODO: infer tolerance dynamically
+    self._threshold_tolerance = None
 
   def _check_condition(self, new_position):
     """
@@ -99,6 +99,7 @@ class GroundDetector:
     if self._dynamic_threshold is None:
       if self._trending_velocity.valid:
         self._dynamic_threshold = self._trending_velocity.value
+        self._threshold_tolerance = np.std(self._trending_velocity._que)
         return False
     else:
       return self._trending_velocity.value > self._dynamic_threshold + self._threshold_tolerance

--- a/ow_lander/scripts/ground_detection.py
+++ b/ow_lander/scripts/ground_detection.py
@@ -78,8 +78,10 @@ class GroundDetector:
     self._dynamic_threshold = None
     self._threshold_tolerance = 0.015 # TODO: infer tolerance dynamically
 
-  def _check_condition(self, 
-                       new_position):  # type: class 'geometry_msgs.msg._Vector3.Vector3'
+  def _check_condition(self, new_position):
+    """
+    :type new_position: class 'geometry_msgs.msg._Vector3.Vector3
+    """
 
     if self._last_position is None:
       self._last_position = np.array(
@@ -101,8 +103,10 @@ class GroundDetector:
     else:
       return self._trending_velocity.value > self._dynamic_threshold + self._threshold_tolerance
 
-  def _handle_link_states(self, 
-                          data):  # type: class 'gazebo_msgs.msg._LinkStates.LinkStates'
+  def _handle_link_states(self, data):
+    """
+    :type data: gazebo_msgs.msg._LinkStates.LinkStates
+    """
 
     # if ground is found ignore further readings until the detector has been reset
     if self._ground_detected:
@@ -121,8 +125,10 @@ class GroundDetector:
 
     return self._ground_detected
 
-  def _tf_lookup_position(self, 
-                          timeout=rospy.Duration(0.0)):      # type: class 'rospy.rostime.Duration'
+  def _tf_lookup_position(self, timeout=rospy.Duration(0.0)):
+    """
+    :type timeout: rospy.rostime.Duration
+    """
 
     try:
       t = self._buffer.lookup_transform(

--- a/ow_lander/scripts/ground_detection.py
+++ b/ow_lander/scripts/ground_detection.py
@@ -56,7 +56,6 @@ class GroundDetector:
   """
 
   def __init__(self):
-
     self._buffer = tf2_ros.Buffer()
     self._listener = tf2_ros.TransformListener(self._buffer)
     self.reset()
@@ -70,7 +69,6 @@ class GroundDetector:
       self._query_ground_position_method = lambda: self._last_position
 
   def reset(self):
-
     """ Reset the state of the ground detector for another round """
     self._last_position, self._last_time = None, None
     self._ground_detected = False
@@ -82,7 +80,6 @@ class GroundDetector:
     """
     :type new_position: class 'geometry_msgs.msg._Vector3.Vector3
     """
-
     if self._last_position is None:
       self._last_position = np.array(
           [new_position.x, new_position.y, new_position.z])
@@ -145,7 +142,6 @@ class GroundDetector:
 
   @property
   def ground_position(self):
-
     """
     Use this method right after ground has been detected to get ground position
     with reference to the base_link
@@ -154,7 +150,6 @@ class GroundDetector:
     return Point(position[0], position[1], position[2])
 
   def detect(self):
-
     """
     Checks if the robot arm has hit the ground
     :returns: True if ground was detected, False otherwise


### PR DESCRIPTION
## Summary of Changes
* This change gets rid of having to set a fixed threshold. This change addresses an issue with the current implementation fails to detect ground if arm speed is reduced significantly.
* Code Formatting & Docstring

## Verfity
```bash
roslaunch ow atacama_y1a.launch (or europa_terminator_workspace.launch)
```

**Tests**:
- Then invoke guarded move planning followed by publish_trajectory under default settings (run multiple times in same session)
- Repeat the process after reducing joint speed constraints to *0.01* for all of arm joints in the `lander.xacro` file
 
>__Note:__ This is designed  to work against a mainly downwards movement
 
__Linked Issue(s):__ https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-485