### PR TITLE
Increase the timeout for MoveGroupCommanders to 15 seconds

### DIFF
--- a/ow_lander/scripts/path_planning_commander.py
+++ b/ow_lander/scripts/path_planning_commander.py
@@ -33,9 +33,9 @@ class MoveGroupPythonInteface(object):
     robot = moveit_commander.RobotCommander()
     scene = moveit_commander.PlanningSceneInterface()
 
-    move_arm = moveit_commander.MoveGroupCommander("arm")
-    move_limbs = moveit_commander.MoveGroupCommander("limbs")
-    move_grinder = moveit_commander.MoveGroupCommander("grinder")
+    move_arm = moveit_commander.MoveGroupCommander("arm", wait_for_servers=15.0)
+    move_limbs = moveit_commander.MoveGroupCommander("limbs", wait_for_servers=15.0)
+    move_grinder = moveit_commander.MoveGroupCommander("grinder", wait_for_servers=15.0)
     display_trajectory_publisher = rospy.Publisher('/move_group/display_planned_path',
                                                    moveit_msgs.msg.DisplayTrajectory,
                                                    queue_size=20)


### PR DESCRIPTION
## Summary of Changes
Increase the timeout for MoveGroupCommander(s) to 15 seconds to address an issue where MoveGroupCommander(s) are taking time quite sometime before they become responsive again after an operation has finished

## Verify
If you want to see the problem reset the timeouts of every _MoveGroupCommander_ to their default value of 5s and run the simulation against atacama and then run the reference mission (try more than one attempt).
```bash
roslaunch ow atacama_y1a.launch
```
and
```bash
roslaunch ow_autonomy autonomy_node.launch plan:=ReferenceMission1.plx
```
Pay attention to the ow_simulator logs and notice the RuntimeError is thrown at some point after the first guarded move attempt (Consequently the autonomy node may also fail).


Put back the timeouts implemented as part of this hotfix and notice the problem is gone!


**Linked Issue:** https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-493

