### PR TITLE
Added kp, kd to grinder contact, reduced scoop rotation during dig_ci…

### DIFF
--- a/ow_lander/scripts/activity_full_digging_traj.py
+++ b/ow_lander/scripts/activity_full_digging_traj.py
@@ -211,7 +211,7 @@ def dig_circular(move_arm, move_limbs, args):
     go_to_Z_coordinate(move_limbs, x_start, y_start, z_start)
 
     # Rotate hand perpendicular to arm direction
-    change_joint_value(move_arm, constants.J_HAND_YAW, -0.29*math.pi)
+    change_joint_value(move_arm, constants.J_HAND_YAW, -0.23*math.pi)
 
   else:
     # Rotate hand so scoop is in middle point

--- a/ow_lander/scripts/activity_full_digging_traj.py
+++ b/ow_lander/scripts/activity_full_digging_traj.py
@@ -211,7 +211,7 @@ def dig_circular(move_arm, move_limbs, args):
     go_to_Z_coordinate(move_limbs, x_start, y_start, z_start)
 
     # Rotate hand perpendicular to arm direction
-    change_joint_value(move_arm, constants.J_HAND_YAW, -0.23*math.pi)
+    change_joint_value(move_arm, constants.J_HAND_YAW, -0.29*math.pi)
 
   else:
     # Rotate hand so scoop is in middle point

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -654,7 +654,10 @@
       <surface>
         <contact>
           <collide_bitmask>0x0001</collide_bitmask> <!-- Enable collision with the terrain by matching the bitmask -->
-
+          <ode>
+            <kp>1e+10</kp>
+            <kd>1e+10</kd>
+          </ode>
         </contact>
       </surface>
     </collision>

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -623,18 +623,49 @@
           filename="package://ow_lander/meshes/l_grinder.STL" />
       </geometry>
       <material
-        name="">
-        <color
-          rgba="0.6 0.6 0.6 1" />
-      </material>
+       name="">
+       <color
+         rgba="0.6 0.6 0.6 1" />
+     </material>
     </visual>
     <collision>
       <origin
-        xyz="0 0 0"
-        rpy="0 0 0" />
+        xyz="0.08 0 0"
+        rpy="1.57 1.57 1.57" />
       <geometry>
-        <mesh
-          filename="package://ow_lander/meshes/l_grinder.STL" />
+        <cylinder radius="0.04" length="0.16"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin
+        xyz="0.06 0 0"
+        rpy="1.57 1.57 1.57" />
+      <geometry>
+        <cylinder radius="0.05" length="0.12"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin
+        xyz="0.04 0 0"
+        rpy="1.57 1.57 1.57" />
+      <geometry>
+        <cylinder radius="0.06" length="0.08"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin
+        xyz="0.02 0 0"
+        rpy="1.57 1.57 1.57" />
+      <geometry>
+        <cylinder radius="0.07" length="0.04"/>
+      </geometry>
+    </collision>
+    <collision>
+      <origin
+        xyz="0.005 0 0"
+        rpy="1.57 1.57 1.57" />
+      <geometry>
+        <cylinder radius="0.075" length="0.01"/>
       </geometry>
     </collision>
   </link>


### PR DESCRIPTION
Ticket: https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-454

Problem: when dig_circular is called with parallel=False, at the end of the hand rotation the grinder would 1) collide with the terrain before it visually touches the ground and 2) bounce.

Solution: part 2) of problem above is solved introducing kp and kd for the grinder, as it's been done for the scoop. part 1) is solved replacing the mesh with a series of co-axial cylinders only in the *collision* model.

Approaches tried for part 1) of the problem:
- I re-drew in SolidWorks the grinder model, saved the STL using the highest number of triangles (resolution), replaced the old one with this new model. Nothing changed.
- Replaced the grinder with the scoop model and the problem disappears. The scoop mesh collides with the ground when there is visual contact.
- Replaced grinder with cylinder and the problem disappears. Here is a video: https://www.youtube.com/watch?v=NAZGdhlEyT8

Test: 
- launch europa_terminator_workspace 
- $ rosservice call /planning/arm/grind -- False 2.0 0.0 0.10 0.4 False -0.155 False
- publish trajectory
- $ rosservice call /planning/arm/dig_circular -- False 2.0 0.02 0.1 False -0.155 False
- publish trajectory
- check that, at the end of dig_circular, the grinder doesn't bounce anymore and it actually touches the terrain. 

I did this test setting the depth of "modify_terrain_circle_message" in modify_terrain_grinder_pub.py to 0.16 to observe that shape of the trench. The shape of the trench doesn't change. I did also play around with the Message Publisher in rqt, getting the grinder to approach the terrain from the sides, and checked if the grinder touches the terrain when collision is detected. And it does!