### PR TITLE
Oceanwater 480 antenna twitching

### DIFF
--- a/ow_lander/config/lander_control.yaml
+++ b/ow_lander/config/lander_control.yaml
@@ -31,11 +31,11 @@ scoop_yaw_position_controller:
 ant_pan_position_controller:
   type: effort_controllers/JointPositionController
   joint: j_ant_pan
-  pid: {p: 100.0, i: 0.01, d: 10.0}
+  pid: {p: 100.0, i: 0.01, d: 15.0}
 ant_tilt_position_controller:
   type: effort_controllers/JointPositionController
   joint: j_ant_tilt
-  pid: {p: 100.0, i: 0.01, d: 10.0}
+  pid: {p: 550.0, i: 0.01, d: 70.0}
 grinder_yaw_position_controller:
   type: effort_controllers/JointPositionController
   joint: j_grinder

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -654,7 +654,6 @@
       <surface>
         <contact>
           <collide_bitmask>0x0001</collide_bitmask> <!-- Enable collision with the terrain by matching the bitmask -->
-
         </contact>
       </surface>
     </collision>
@@ -743,8 +742,8 @@
       link="l_ant_foot" />
     <axis
       xyz="0 0 -1" />
-    <dynamics damping="50" />
-    <limit effort="1000.0" velocity="0.4" />
+    <dynamics damping="10.0" />
+    <limit effort="80.0" velocity="0.2" />
   </joint>
   <transmission name="ant_pan_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -819,8 +818,8 @@
       link="l_ant_panel" />
     <axis
       xyz="0 0 -1" />
-    <dynamics damping="50" />
-    <limit effort="1000.0" velocity="0.4" />
+    <dynamics damping="10.0" />
+    <limit effort="100.0" velocity="0.2" />
   </joint>
   <transmission name="ant_tilt_transmission">
     <type>transmission_interface/SimpleTransmission</type>


### PR DESCRIPTION
Ticket: https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-480

The problem was that the quick solver made europa_test_dem unstable. The quick solver was introduced to reduce the instability between terrain and scoop at the end of guarded_move. Since this problem has already been solved using the kp and kd parameters, we can switch back to the world solver. Here is what I did in these ow_simulator and ow_europa branches: 
- I changed the solver to world in atacama, terminator and test_dem.
- lowered maximum effort and velocity for ant_pan and ant_tilt
- decreased damping for ant_pan and ant_tilt
- Re-tuned PID
- Tested that switching back to world solver doesn't affect sim stability in all three worlds: atacama, terminator, test_dem.

Test 

Required:
- roslaunch ow europa_test_dem.launch : check that antenna doesn't twitch anymore
- run plan: roslaunch ow_autonomy autonomy_node.launch plan:=ReferenceMission1.plx : check that antenna movements are fine. Check that guarded_move successfully finds ground and scoop-terrain contact is stable. Kill the sim after ground is found. Note: dynamic terrain doesn't work in test_dem, so the grind/scoop cannot penetrate terrain.

Optional:
- Do the above for terminator and atacama worlds. 



