### PR TITLE
Reduced joints damping. For scoop collision: removed kp, reduced kd, …

### DIFF
--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -544,12 +544,11 @@
     </visual>
     <selfCollide>1</selfCollide>
     <collision>
-      <max_contacts>1</max_contacts>
       <surface>
         <contact>
           <collide_bitmask>0x0001</collide_bitmask> <!-- Enable collision with the terrain by matching the bitmask -->
           <ode>
-            <kd>5e11</kd>
+            <kd>1e12</kd>
           </ode>
         </contact>
       </surface>

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -164,7 +164,7 @@
       link="l_shou" />
     <axis
       xyz="0 0 -1" />
-    <dynamics damping="50.0" friction="2.6"/>
+    <dynamics damping="10.0" friction="2.6"/>
     <limit effort="70.9" velocity="0.15" lower="-1.8" upper="1.8"/>
   </joint>
   <transmission name="shou_yaw_transmission">
@@ -240,7 +240,7 @@
       link="l_prox" />
     <axis
       xyz="0 0 -1" />
-    <dynamics damping="50.0" friction="4.6"/>
+    <dynamics damping="10.0" friction="4.6"/>
     <limit effort="101.0" velocity="0.2" lower="0.05" upper="2.2"/>
   </joint>
   <transmission name="shou_pitch_transmission">
@@ -316,7 +316,7 @@
       link="l_dist" />
     <axis
       xyz="0 0 -1" />
-    <dynamics damping="50.0" friction="2.7"/>
+    <dynamics damping="10.0" friction="2.7"/>
     <limit effort="73.0" velocity="0.2"/>
   </joint>
   <transmission name="prox_pitch_transmission">
@@ -392,7 +392,7 @@
       link="l_wrist" />
     <axis
       xyz="0 0 1" />
-    <dynamics damping="50.0" friction="0.3"/>
+    <dynamics damping="10.0" friction="0.3"/>
     <limit effort="25.7" velocity="0.2" />
   </joint>
   <transmission name="dist_pitch_transmission">
@@ -480,7 +480,7 @@
       link="l_hand" />
     <axis
       xyz="0 0 -1" />
-    <dynamics damping="50.0" friction="0.3"/>
+    <dynamics damping="10.0" friction="0.3"/>
     <limit effort="25.7" velocity="0.2" />
   </joint>
   <transmission name="hand_yaw_transmission">
@@ -544,12 +544,12 @@
     </visual>
     <selfCollide>1</selfCollide>
     <collision>
+      <max_contacts>1</max_contacts>
       <surface>
         <contact>
           <collide_bitmask>0x0001</collide_bitmask> <!-- Enable collision with the terrain by matching the bitmask -->
           <ode>
-            <kp>1e+15</kp>
-            <kd>1e+13</kd>
+            <kd>5e11</kd>
           </ode>
         </contact>
       </surface>
@@ -586,7 +586,7 @@
       link="l_scoop" />
     <axis
       xyz="0 0 -1" />
-    <dynamics damping="50.0" friction="0.5"/>
+    <dynamics damping="10.0" friction="0.5"/>
     <limit effort="20.0" velocity="0.2" />
   </joint>
   <transmission name="scoop_yaw_transmission">


### PR DESCRIPTION
**Ticket:** 
https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-513

**Aim of this work:** 
Speed up simulation --> lower the real time update rate and increase the max step size to keep the real time factor equal to 1. 

**What I did and learnt:**
Decreasing the real_time_update_rate introduces instability in the physics. A proper tuning of collision/contact related parameters can make the system stable. These parameters are defined in lander.xacro and are: damping of the arm joints, kp and kd, maximum number of contacts. In this PR, I lower the real_time_update_rate from 400 to 160 Hz, which translates into an increase of the max_time_step from 0.0025 to 0.00625 s. I do this in all the four worlds in ow_europa. To compensate for instability I decreased the "damping" factor for the arm joints from 50 to 10. Even though, after decreasing the damping, the simulation was stable, I noticed that this error message would appear on terminal while there was contact between the scoop and the terrain (in ReferenceMission1, between the end of guarded move and the beginning of grind):
`ODE Message 3: LCP internal error, s <= 0`
I did some research and this is what I found out:
- ODE, the physics engine, solves a Linear Complementarity Problem. When the contact force between two objects is too large (high impact speed, high mass, etc.) ODE cannot solve the problem. In the past we saw this error after guarded_move would find the ground and bounce.
- Another source of this error can be a too large number of contact points for a specific contact (scoop-ground for instance)
- When getting this error, the sim doesn't crash. From my observation, I think this is what happens: the solver throws the error because it doesn't find a solution for that specific time step, so the arm freezes temporarily until a new solution is found. This results in a less smooth motion, which is anyway almost imperceptible.

This is how I got rid of this error:
- forcing the scoop to have a single point of contact with the terrain
- removing kp and decreasing kd for the scoop-terrain contact

I tried to decrease the real_time_update_rate below 160Hz but I got too much instability: the lander would explode right after launching the sim. 

**Test:**
- launch europa_terminator_workspace or atacama
- $ roslaunch ow_autonomy autonomy_node.launch plan:=ReferenceMission1.plx
- check that the sim is visually stable and check that there's no ODE error shows up. Let me know how it goes. 
- General thoughts/feedback is appreciated, thanks!


