### PR TITLE
Faults remapping

### DIFF
--- a/ow/launch/common.launch
+++ b/ow/launch/common.launch
@@ -4,6 +4,7 @@
   <arg name="world_name" default="$(find ow_europa)/worlds/terminator.world"/>
   <arg name="arm_sim_enable" default="false" />
   <arg name="gazebo" default="true"/>
+  <arg name="extra_gazebo_args" value="joint_states:=/og_joint_states" />
   <arg name="gzclient" default="true"/>  <!-- Only has effect if gazebo = true -->
   <arg name="record_bag" default="false"/>
   <arg name="power_draw_csv_file" default="onewatt.csv"/>  <!-- options: onewatt.csv, eightwatt.csv, sixteenwatt.csv -->
@@ -26,6 +27,7 @@
     <arg name="headless" value="false"/>
     <arg name="debug" value="false"/>
     <arg name="verbose" value="true"/>
+    <arg name="extra_gazebo_args" value="joint_states:=/og_joint_states"/>
   </include>
 
   <!-- == publish celestial body frames ==================== -->
@@ -70,7 +72,7 @@
   </node>
 
   <!-- Start faults node -->
-  <node name="faults" pkg="ow_faults" type="faults" output="screen"/>
+  <node name="faults" pkg="ow_faults" type="faults" output="screen" />
 
   <!-- ====== simulate changes to the terrain caused by the scoop   ======= -->
   <node name="modify_terrain_scoop" pkg="ow_dynamic_terrain" type="modify_terrain_scoop_pub.py" output="screen"/>
@@ -92,8 +94,7 @@
     launch-prefix="bash -c 'sleep 5; $0 $@' "
     args="&#45;&#45;perspective-file $(find ow)/config/default.perspective"/>
   <!-- == launch the mechanical power publishing node ========= -->
-  <node pkg="ow_lander" name="mechanical_power_arm" type="mechanical_power_arm.py" output="screen">
-    </node>
+  <node pkg="ow_lander" name="mechanical_power_arm" type="mechanical_power_arm.py" output="screen" />
 
   <!-- == start bag_recorder_node =========== -->
   <node if="$(arg record_bag)" name="bag_recorder_node" 

--- a/ow/launch/europa_terminator.launch
+++ b/ow/launch/europa_terminator.launch
@@ -7,9 +7,6 @@
   <arg name="record_bag" default="false"/>
   <arg name="power_draw_csv_file" default="onewatt.csv"/>  <!-- options: onewatt.csv, eightwatt.csv, sixteenwatt.csv -->
 
-  <!-- <remap from="/joint_states" to="/faults/joint_states"/> -->
-  <!-- <remap from="/faults/joint_states" to="/joint_states" /> -->
-
   <include file="$(find ow)/launch/common.launch" >
     <arg name="world_name" value="$(find ow_europa)/worlds/terminator.world"/>
     <arg name="init_x" value="0"/>

--- a/ow/launch/europa_terminator.launch
+++ b/ow/launch/europa_terminator.launch
@@ -7,6 +7,9 @@
   <arg name="record_bag" default="false"/>
   <arg name="power_draw_csv_file" default="onewatt.csv"/>  <!-- options: onewatt.csv, eightwatt.csv, sixteenwatt.csv -->
 
+  <!-- <remap from="/joint_states" to="/faults/joint_states"/> -->
+  <!-- <remap from="/faults/joint_states" to="/joint_states" /> -->
+
   <include file="$(find ow)/launch/common.launch" >
     <arg name="world_name" value="$(find ow_europa)/worlds/terminator.world"/>
     <arg name="init_x" value="0"/>

--- a/ow_faults/cfg/Faults.cfg
+++ b/ow_faults/cfg/Faults.cfg
@@ -10,6 +10,13 @@ joint_state_enum = gen.enum([gen.const("nominal",  int_t, 0, "Joint is functioni
                              gen.const("frozen",   int_t, 2, "Joint is frozen in position"),
                              gen.const("friction", int_t, 3, "Joint is consuming extra power")],
                             "An enum to set joint state")
+# Potential new Faults
+# gen.add("shou_yaw_position_controller_pid_state_fail", bool_t, 0, "testing shoulder yaw", False)
+# gen.add("shou_pitch_position_controller_pid_state_fail", bool_t, 0, "testing shoulder pitch", False)
+# gen.add("prox_pitch_position_controller_pid_state_fail", bool_t, 0, "testing prox pitch", False)
+# gen.add("dist_pitch_position_controller_pid_state_fail", bool_t, 0, "testing dist pitch", False)
+# gen.add("hand_yaw_position_controller_pid_state_fail", bool_t, 0, "testing hand yaw", False)
+# gen.add("scoop_yaw_position_controller_pid_state_fail", bool_t, 0, "testing scoop yaw", False)
 
 #gen.add("ant_pan_state",                 int_t,    0, "Antenna pan joint state",           0, 0, 3, edit_method=joint_state_enum)
 #gen.add("ant_pan_friction",              double_t, 0, "Antenna pan joint friction",        0.1, 0, 1)

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -32,6 +32,7 @@ private:
   // Output /faults/joint_states, a modified version of /joint_states, injecting
   // simple message faults that don't need to be simulated at their source.
   void jointStateCb(const sensor_msgs::JointStateConstPtr& msg);
+  void testFxn(const sensor_msgs::JointStateConstPtr& msg);
 
   // Find an item in an std::vector or other find-able data structure, and
   // return its index. Return -1 if not found.
@@ -46,6 +47,9 @@ private:
 
   ros::Subscriber m_joint_state_sub;
   ros::Publisher m_joint_state_pub;
+
+  ros::Subscriber test_sub;
+  ros::Publisher test_pub;
 
   // Map ow_lander::joint_t enum values to indices in JointState messages
   std::vector<unsigned int> m_joint_state_indices;

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -51,6 +51,11 @@ private:
   ros::Subscriber test_sub;
   ros::Publisher test_pub;
 
+  ros::Subscriber test_sub1;
+  ros::Publisher test_pub1;
+
+  ros::Subscriber test_sub2;
+  ros::Publisher test_pub2;
   // Map ow_lander::joint_t enum values to indices in JointState messages
   std::vector<unsigned int> m_joint_state_indices;
 };

--- a/ow_faults/package.xml
+++ b/ow_faults/package.xml
@@ -8,6 +8,7 @@
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="terence.m.welsh@nasa.gov">Terry Welsh</maintainer>
+  <maintainer email="lanssie.ma@nasa.gov">Lanssie Ma</maintainer>
 
 
   <!-- One license tag required, multiple allowed, one license per tag -->

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -12,12 +12,8 @@ using namespace ow_lander;
 
 FaultInjector::FaultInjector(ros::NodeHandle node_handle)
 {
-  m_joint_state_sub = node_handle.subscribe("/faults/joint_states", 10, &FaultInjector::jointStateCb, this);
-  m_joint_state_pub = node_handle.advertise<sensor_msgs::JointState>("/faults/joint_states", 10);
-
-  test_sub = node_handle.subscribe("/faults/joint_states", 10, &FaultInjector::testFxn, this);
-  test_pub = node_handle.advertise<sensor_msgs::JointState>("/faults/should_be_faults", 10);
-
+  m_joint_state_sub = node_handle.subscribe("/og_joint_states", 10, &FaultInjector::jointStateCb, this);
+  m_joint_state_pub = node_handle.advertise<sensor_msgs::JointState>("/joint_states", 10); // 'new' joint states topic where fault data is now publishes on
 }
 
 void FaultInjector::faultsConfigCb(ow_faults::FaultsConfig& faults, uint32_t level)

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -12,8 +12,12 @@ using namespace ow_lander;
 
 FaultInjector::FaultInjector(ros::NodeHandle node_handle)
 {
-  m_joint_state_sub = node_handle.subscribe("/joint_states", 10, &FaultInjector::jointStateCb, this);
+  m_joint_state_sub = node_handle.subscribe("/faults/joint_states", 10, &FaultInjector::jointStateCb, this);
   m_joint_state_pub = node_handle.advertise<sensor_msgs::JointState>("/faults/joint_states", 10);
+
+  test_sub = node_handle.subscribe("/faults/joint_states", 10, &FaultInjector::testFxn, this);
+  test_pub = node_handle.advertise<sensor_msgs::JointState>("/faults/should_be_faults", 10);
+
 }
 
 void FaultInjector::faultsConfigCb(ow_faults::FaultsConfig& faults, uint32_t level)
@@ -25,6 +29,13 @@ void FaultInjector::faultsConfigCb(ow_faults::FaultsConfig& faults, uint32_t lev
   m_faults = faults;
 }
 
+void FaultInjector::testFxn(const sensor_msgs::JointStateConstPtr& msg)
+{
+
+  sensor_msgs::JointState output(*msg);
+  test_pub.publish(output);
+
+}
 void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
 {
   // Populate the map once here.

--- a/ow_faults/src/FaultTestSub.cpp
+++ b/ow_faults/src/FaultTestSub.cpp
@@ -1,0 +1,65 @@
+#include "ros/ros.h"
+#include "std_msgs/String.h"
+
+/**
+ * This tutorial demonstrates simple receipt of messages over the ROS system.
+ */
+// %Tag(CALLBACK)%
+void chatterCallback(const std_msgs::String::ConstPtr& msg)
+{
+  ROS_INFO("I heard: [%s]", msg->data.c_str());
+}
+// %EndTag(CALLBACK)%
+
+int main(int argc, char **argv)
+{
+  /**
+   * The ros::init() function needs to see argc and argv so that it can perform
+   * any ROS arguments and name remapping that were provided at the command line.
+   * For programmatic remappings you can use a different version of init() which takes
+   * remappings directly, but for most command-line programs, passing argc and argv is
+   * the easiest way to do it.  The third argument to init() is the name of the node.
+   *
+   * You must call one of the versions of ros::init() before using any other
+   * part of the ROS system.
+   */
+  ros::init(argc, argv, "faultsTestSub");
+
+  /**
+   * NodeHandle is the main access point to communications with the ROS system.
+   * The first NodeHandle constructed will fully initialize this node, and the last
+   * NodeHandle destructed will close down the node.
+   */
+  ros::NodeHandle n;
+
+  /**
+   * The subscribe() call is how you tell ROS that you want to receive messages
+   * on a given topic.  This invokes a call to the ROS
+   * master node, which keeps a registry of who is publishing and who
+   * is subscribing.  Messages are passed to a callback function, here
+   * called chatterCallback.  subscribe() returns a Subscriber object that you
+   * must hold on to until you want to unsubscribe.  When all copies of the Subscriber
+   * object go out of scope, this callback will automatically be unsubscribed from
+   * this topic.
+   *
+   * The second parameter to the subscribe() function is the size of the message
+   * queue.  If messages are arriving faster than they are being processed, this
+   * is the number of messages that will be buffered up before beginning to throw
+   * away the oldest ones.
+   */
+// %Tag(SUBSCRIBER)%
+  ros::Subscriber sub = n.subscribe("/joint_states", 10, chatterCallback);
+// %EndTag(SUBSCRIBER)%
+
+  /**
+   * ros::spin() will enter a loop, pumping callbacks.  With this version, all
+   * callbacks will be called from within this thread (the main one).  ros::spin()
+   * will exit when Ctrl-C is pressed, or the node is shutdown by the master.
+   */
+// %Tag(SPIN)%
+  ros::spin();
+// %EndTag(SPIN)%
+
+  return 0;
+}
+// %EndTag(FULLTEXT)%

--- a/ow_lander/launch/planning.launch
+++ b/ow_lander/launch/planning.launch
@@ -27,7 +27,7 @@
       <param name="zeros/j_hand_yaw" value="$(arg stowed_hand_yaw)"/>
       <param name="zeros/j_scoop_yaw" value="$(arg stowed_scoop_yaw)"/>
       <param name="zeros/j_grinder" value="$(arg stowed_grinder_yaw)"/>
-      
+
       <rosparam param="source_list">[move_group/fake_controller_joint_states]</rosparam>
     </node>
 

--- a/ow_lander/launch/spawn.launch
+++ b/ow_lander/launch/spawn.launch
@@ -44,7 +44,7 @@
     prox_pitch_position_controller dist_pitch_position_controller
     hand_yaw_position_controller scoop_yaw_position_controller
     ant_pan_position_controller ant_tilt_position_controller
-     grinder_yaw_position_controller"/> 
+     grinder_yaw_position_controller" /> 
    
 
   <!-- Convert joint states from Gazebo to tf-tree for rviz -->

--- a/ow_testbed/launch/spawn.launch
+++ b/ow_testbed/launch/spawn.launch
@@ -25,6 +25,7 @@
   <!-- Convert joint states from Gazebo to tf-tree for rviz -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" >
     <param name="publish_frequency" value="30" />
+    <remap from="/joint_states" to="/faults2/joint_states" />
   </node>
 
   <!-- Spawn testbed in gazebo -->


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3445834/101217030-717b3a80-3635-11eb-8870-9f9e7369349d.png)
New Faults structure
/og_joint_states has original data from gazebo, pristine
/joint_states is now published by faults node, and relevant subscribers listen to it. 

What the node and topic connection looks like now
![image](https://user-images.githubusercontent.com/3445834/101217797-ce2b2500-3636-11eb-8db9-9989c6f9eec3.png)
