### PR TITLE
Oceanwater 530 enable switching between arm controllers at runtime

### DIFF
--- a/ow_lander/config/fake_controllers.yaml
+++ b/ow_lander/config/fake_controllers.yaml
@@ -1,4 +1,8 @@
 controller_list:
+  - name: fake_antenna_controller
+    joints:
+      - j_ant_pan
+      - j_ant_tilt
   - name: fake_arm_controller
     joints:
       - j_shou_yaw
@@ -7,10 +11,6 @@ controller_list:
       - j_dist_pitch
       - j_hand_yaw
       - j_scoop_yaw
-  - name: fake_antenna_controller
-    joints:
-      - j_ant_pan
-      - j_ant_tilt
   - name: fake_limbs_controller
     joints:
       - j_shou_yaw

--- a/ow_lander/config/ros_controllers.yaml
+++ b/ow_lander/config/ros_controllers.yaml
@@ -43,6 +43,16 @@ controller_list:
       - j_dist_pitch
       - j_hand_yaw
       - j_scoop_yaw
+  - name: limbs_controller
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    default: true
+    joints:
+      - j_shou_yaw
+      - j_shou_pitch
+      - j_prox_pitch
+      - j_dist_pitch
+      - j_hand_yaw
   - name: grinder_controller
     action_ns: follow_joint_trajectory
     type: FollowJointTrajectory
@@ -118,6 +128,49 @@ arm_controller:
       j_dist_pitch: {trajectory: *goal_pos_constraint, goal: *trajectory_pos_constraint}
       j_hand_yaw: {trajectory: *goal_pos_constraint, goal: *trajectory_pos_constraint}
       j_scoop_yaw: {trajectory: *goal_pos_constraint, goal: *trajectory_pos_constraint}
+    stop_trajectory_duration: 1.0
+limbs_controller:
+  type: effort_controllers/JointTrajectoryController
+  joints:
+    - j_shou_yaw
+    - j_shou_pitch
+    - j_prox_pitch
+    - j_dist_pitch
+    - j_hand_yaw
+  gains:
+    j_shou_yaw:
+      p: *kp_default
+      d: *kd_default
+      i: *ki_default
+      i_clamp: *ki_clamp_default
+    j_shou_pitch:
+      p: *kp_default
+      d: *kd_default
+      i: *ki_default
+      i_clamp: *ki_clamp_default
+    j_prox_pitch:
+      p: *kp_default
+      d: *kd_default
+      i: *ki_default
+      i_clamp: *ki_clamp_default
+    j_dist_pitch:
+      p: *kp_default
+      d: *kd_default
+      i: *ki_default
+      i_clamp: *ki_clamp_default
+    j_hand_yaw:
+      p: *kp_default
+      d: *kd_default
+      i: *ki_default
+      i_clamp: *ki_clamp_default
+    constraints:
+      goal_time: *goal_time_constraint
+      stopped_velocity_tolerance: 0
+      j_shou_yaw: {trajectory: *goal_pos_constraint, goal: *trajectory_pos_constraint}
+      j_shou_pitch: {trajectory: *goal_pos_constraint, goal: *trajectory_pos_constraint}
+      j_prox_pitch: {trajectory: *goal_pos_constraint, goal: *trajectory_pos_constraint}
+      j_dist_pitch: {trajectory: *goal_pos_constraint, goal: *trajectory_pos_constraint}
+      j_hand_yaw: {trajectory: *goal_pos_constraint, goal: *trajectory_pos_constraint}
     stop_trajectory_duration: 1.0
 grinder_controller:
   type: effort_controllers/JointTrajectoryController

--- a/ow_lander/config/ros_controllers.yaml
+++ b/ow_lander/config/ros_controllers.yaml
@@ -43,18 +43,16 @@ controller_list:
       - j_dist_pitch
       - j_hand_yaw
       - j_scoop_yaw
-  # TODO: We probably need to move the grinder_controller to another file to
-  # ease the process of controller switching
-  # - name: grinder_controller
-  #   action_ns: follow_joint_trajectory
-  #   type: FollowJointTrajectory
-  #   joints:
-  #     - j_shou_yaw
-  #     - j_shou_pitch
-  #     - j_prox_pitch
-  #     - j_dist_pitch
-  #     - j_hand_yaw
-  #     - j_grinder
+  - name: grinder_controller
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    joints:
+      - j_shou_yaw
+      - j_shou_pitch
+      - j_prox_pitch
+      - j_dist_pitch
+      - j_hand_yaw
+      - j_grinder
 antenna_controller:
   type: effort_controllers/JointTrajectoryController
   joints:
@@ -85,7 +83,7 @@ arm_controller:
       p: &kp_default 16000
       d: &kd_default 5.0
       i: &ki_default 2
-      i_clamp: &ki_clamp_default 2
+      i_clamp: &ki_clamp_default 1
     j_shou_pitch:
       p: *kp_default
       d: *kd_default
@@ -95,22 +93,22 @@ arm_controller:
       p: *kp_default
       d: *kd_default
       i: *ki_default
-      i_clamp: 1
+      i_clamp: *ki_clamp_default
     j_dist_pitch:
       p: *kp_default
       d: *kd_default
       i: *ki_default
-      i_clamp: 1
+      i_clamp: *ki_clamp_default
     j_hand_yaw:
       p: *kp_default
       d: *kd_default
       i: *ki_default
-      i_clamp: 1
+      i_clamp: *ki_clamp_default
     j_scoop_yaw:
       p: *kp_default
       d: *kd_default
       i: *ki_default
-      i_clamp: 1
+      i_clamp: *ki_clamp_default
     constraints:
       goal_time: &goal_time_constraint 4.0
       stopped_velocity_tolerance: 0
@@ -121,45 +119,43 @@ arm_controller:
       j_hand_yaw: {trajectory: *goal_pos_constraint, goal: *trajectory_pos_constraint}
       j_scoop_yaw: {trajectory: *goal_pos_constraint, goal: *trajectory_pos_constraint}
     stop_trajectory_duration: 1.0
-# TODO: Same as above .. We may need to move the grinder_controller to another file to
-# ease the process of controller switching
-# grinder_controller:
-#   type: effort_controllers/JointTrajectoryController
-#   joints:
-#     - j_shou_yaw
-#     - j_shou_pitch
-#     - j_prox_pitch
-#     - j_dist_pitch
-#     - j_hand_yaw
-#     - j_grinder
-#   gains:
-#     j_shou_yaw:
-#       p: 100
-#       d: 1
-#       i: 1
-#       i_clamp: 1
-#     j_shou_pitch:
-#       p: 100
-#       d: 1
-#       i: 1
-#       i_clamp: 1
-#     j_prox_pitch:
-#       p: 100
-#       d: 1
-#       i: 1
-#       i_clamp: 1
-#     j_dist_pitch:
-#       p: 100
-#       d: 1
-#       i: 1
-#       i_clamp: 1
-#     j_hand_yaw:
-#       p: 100
-#       d: 1
-#       i: 1
-#       i_clamp: 1
-#     j_grinder:
-#       p: 100
-#       d: 1
-#       i: 1
-#       i_clamp: 1
+grinder_controller:
+  type: effort_controllers/JointTrajectoryController
+  joints:
+    - j_shou_yaw
+    - j_shou_pitch
+    - j_prox_pitch
+    - j_dist_pitch
+    - j_hand_yaw
+    - j_grinder
+  gains:
+    j_shou_yaw:
+      p: *kp_default
+      d: *kd_default
+      i: *ki_default
+      i_clamp: *ki_clamp_default
+    j_shou_pitch:
+      p: *kp_default
+      d: *kd_default
+      i: *ki_default
+      i_clamp: *ki_clamp_default
+    j_prox_pitch:
+      p: *kp_default
+      d: *kd_default
+      i: *ki_default
+      i_clamp: *ki_clamp_default
+    j_dist_pitch:
+      p: *kp_default
+      d: *kd_default
+      i: *ki_default
+      i_clamp: *ki_clamp_default
+    j_hand_yaw:
+      p: *kp_default
+      d: *kd_default
+      i: *ki_default
+      i_clamp: *ki_clamp_default
+    j_grinder:
+      p: *kp_default
+      d: *kd_default
+      i: *ki_default
+      i_clamp: *ki_clamp_default

--- a/ow_lander/launch/ros_controllers.launch
+++ b/ow_lander/launch/ros_controllers.launch
@@ -5,10 +5,13 @@
   <rosparam file="$(find ow_lander)/config/ros_controllers.yaml" command="load"/>
 
   <!-- Load the controllers -->
-  <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" args="arm_controller antenna_controller"/>
-
   <node name="joint_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
 		output="screen" args="joint_state_controller" />
+
+  <node name="controller_spawner_active" pkg="controller_manager" type="spawner" respawn="false"
+    output="screen" args="arm_controller antenna_controller"/>
+
+  <node name="controller_spawner_stopped" pkg="controller_manager" type="spawner" respawn="false"
+    output="screen" args="--stopped grinder_controller"/>
 
 </launch>

--- a/ow_lander/launch/ros_controllers.launch
+++ b/ow_lander/launch/ros_controllers.launch
@@ -8,9 +8,11 @@
   <node name="joint_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
 		output="screen" args="joint_state_controller" />
 
+  <!-- arm_controller is the default controller and is enabled by default -->
   <node name="controller_spawner_active" pkg="controller_manager" type="spawner" respawn="false"
     output="screen" args="arm_controller antenna_controller"/>
 
+  <!-- grinder_controller is enabled only when needed -->
   <node name="controller_spawner_stopped" pkg="controller_manager" type="spawner" respawn="false"
     output="screen" args="--stopped grinder_controller"/>
 

--- a/ow_lander/launch/ros_controllers.launch
+++ b/ow_lander/launch/ros_controllers.launch
@@ -12,8 +12,8 @@
   <node name="controller_spawner_active" pkg="controller_manager" type="spawner" respawn="false"
     output="screen" args="arm_controller antenna_controller"/>
 
-  <!-- grinder_controller is enabled only when needed -->
+  <!-- limbs_controller and grinder_controller is enabled only when needed -->
   <node name="controller_spawner_stopped" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" args="--stopped grinder_controller"/>
+    output="screen" args="--stopped limbs_controller grinder_controller"/>
 
 </launch>

--- a/ow_lander/scripts/activity_full_digging_traj.py
+++ b/ow_lander/scripts/activity_full_digging_traj.py
@@ -53,17 +53,14 @@ def arg_parsing_lin(req):
     depth=0.01
     length=0.1
     ground_position=constants.DEFAULT_GROUND_HEIGHT
-    delete_prev_traj=False
-
   else :
     x_start=req.x
     y_start=req.y
     depth=req.depth
     length=req.length
     ground_position=req.ground_position
-    delete_prev_traj=req.delete_prev_traj
 
-  return [req.use_defaults, x_start, y_start, depth, length, ground_position, delete_prev_traj]
+  return [req.use_defaults, x_start, y_start, depth, length, ground_position]
 
 def arg_parsing_circ(req):     
   """
@@ -76,17 +73,14 @@ def arg_parsing_circ(req):
     depth=0.01
     parallel=True
     ground_position=constants.DEFAULT_GROUND_HEIGHT
-    delete_prev_traj=False
-
   else :
     x_start=req.x
     y_start=req.y
     depth=req.depth
     parallel=req.parallel
     ground_position=req.ground_position
-    delete_prev_traj=req.delete_prev_traj
 
-  return [req.use_defaults, x_start, y_start, depth, parallel, ground_position, delete_prev_traj]
+  return [req.use_defaults, x_start, y_start, depth, parallel, ground_position]
 
 def move_to_pre_trench_configuration(move_arm, x_start, y_start):     
   """

--- a/ow_lander/scripts/activity_full_digging_traj.py
+++ b/ow_lander/scripts/activity_full_digging_traj.py
@@ -42,46 +42,6 @@ def change_joint_value(move_group, joint_index, target_value):
   move_group.go(joint_goal, wait=True)
   move_group.stop()
 
-def arg_parsing_lin(req):      
-  """
-  :type req: class 'ow_lander.srv._DigLinear.DigLinearRequest'
-  """
-  if req.use_defaults :
-    # Default trenching values
-    x_start=1.46
-    y_start=0
-    depth=0.01
-    length=0.1
-    ground_position=constants.DEFAULT_GROUND_HEIGHT
-  else :
-    x_start=req.x
-    y_start=req.y
-    depth=req.depth
-    length=req.length
-    ground_position=req.ground_position
-
-  return [req.use_defaults, x_start, y_start, depth, length, ground_position]
-
-def arg_parsing_circ(req):     
-  """
-  :type req: class 'ow_lander.srv._DigCircular.DigCircularRequest' 
-  """
-  if req.use_defaults :
-    # Default trenching values
-    x_start=1.65
-    y_start=0
-    depth=0.01
-    parallel=True
-    ground_position=constants.DEFAULT_GROUND_HEIGHT
-  else :
-    x_start=req.x
-    y_start=req.y
-    depth=req.depth
-    parallel=req.parallel
-    ground_position=req.ground_position
-
-  return [req.use_defaults, x_start, y_start, depth, parallel, ground_position]
-
 def move_to_pre_trench_configuration(move_arm, x_start, y_start):     
   """
   :type move_arm: class 'moveit_commander.move_group.MoveGroupCommander'
@@ -132,11 +92,30 @@ def plan_cartesian_path_lin(move_arm, length, alpha):
 
   return plan, fraction
 
-def dig_linear(move_arm, move_limbs, args):          
+def arg_parsing_lin(req):      
+  """
+  :type req: class 'ow_lander.srv._DigLinear.DigLinearRequest'
+  """
+  if req.use_defaults :
+    # Default trenching values
+    x_start=1.46
+    y_start=0
+    depth=0.01
+    length=0.1
+    ground_position=constants.DEFAULT_GROUND_HEIGHT
+  else :
+    x_start=req.x
+    y_start=req.y
+    depth=req.depth
+    length=req.length
+    ground_position=req.ground_position
+
+  return [req.use_defaults, x_start, y_start, depth, length, ground_position]
+
+def dig_linear(move_arm, args, controller_switcher):          
   """
   :type move_arm: class 'moveit_commander.move_group.MoveGroupCommander'
-  :type move_limbs: class 'moveit_commander.move_group.MoveGroupCommander'
-  :type args: List[bool, float, int, float, float, float, bool]
+  :type args: List[bool, float, int, float, float, float]
   """
   x_start = args[1]
   y_start = args[2]
@@ -182,11 +161,31 @@ def dig_linear(move_arm, move_limbs, args):
 
   return True
 
-def dig_circular(move_arm, move_limbs, args): 
+def arg_parsing_circ(req):     
+  """
+  :type req: class 'ow_lander.srv._DigCircular.DigCircularRequest' 
+  """
+  if req.use_defaults :
+    # Default trenching values
+    x_start=1.65
+    y_start=0
+    depth=0.01
+    parallel=True
+    ground_position=constants.DEFAULT_GROUND_HEIGHT
+  else :
+    x_start=req.x
+    y_start=req.y
+    depth=req.depth
+    parallel=req.parallel
+    ground_position=req.ground_position
+
+  return [req.use_defaults, x_start, y_start, depth, parallel, ground_position]
+
+def dig_circular(move_arm, move_limbs, args, controller_switcher): 
   """
   :type move_arm: class 'moveit_commander.move_group.MoveGroupCommander'
   :type move_limbs: class 'moveit_commander.move_group.MoveGroupCommander'
-  :type args: List[bool, float, int, float, bool, float, bool]
+  :type args: List[bool, float, int, float, bool, float]
   """
   x_start = args[1]
   y_start = args[2]
@@ -202,7 +201,9 @@ def dig_circular(move_arm, move_limbs, args):
 
     # Once aligned to trench goal, place hand above trench middle point
     z_start = ground_position + constants.R_PARALLEL_FALSE - depth
+    controller_switcher('limbs_controller', 'arm_controller')
     go_to_Z_coordinate(move_limbs, x_start, y_start, z_start)
+    controller_switcher('arm_controller', 'limbs_controller')
 
     # Rotate hand perpendicular to arm direction
     change_joint_value(move_arm, constants.J_HAND_YAW, -0.29*math.pi)
@@ -219,7 +220,9 @@ def dig_circular(move_arm, move_limbs, args):
 
     # Once aligned to trench goal, place hand above trench middle point
     z_start = ground_position + constants.R_PARALLEL_FALSE - depth
+    controller_switcher('limbs_controller', 'arm_controller')
     go_to_Z_coordinate(move_limbs, x_start, y_start, z_start)
+    controller_switcher('arm_controller', 'limbs_controller')
 
     # Rotate dist to dig
     joint_goal = move_arm.get_current_joint_values()

--- a/ow_lander/scripts/activity_full_digging_traj.py
+++ b/ow_lander/scripts/activity_full_digging_traj.py
@@ -112,7 +112,7 @@ def arg_parsing_lin(req):
 
   return [req.use_defaults, x_start, y_start, depth, length, ground_position]
 
-def dig_linear(move_arm, args, controller_switcher):          
+def dig_linear(move_arm, args):          
   """
   :type move_arm: class 'moveit_commander.move_group.MoveGroupCommander'
   :type args: List[bool, float, int, float, float, float]

--- a/ow_lander/scripts/activity_grind.py
+++ b/ow_lander/scripts/activity_grind.py
@@ -58,10 +58,8 @@ def plan_cartesian_path(move_group, length, alpha, parallel):
 
   return plan, fraction
 
-def grind(move_arm, move_limbs, move_grinder, args):          
+def grind(move_grinder, args):          
   """
-  :type move_arm: class 'moveit_commander.move_group.MoveGroupCommander' 
-  :type move_limbs: class 'moveit_commander.move_group.MoveGroupCommander' 
   :type move_grinder: class 'moveit_commander.move_group.MoveGroupCommander'
   :type args: List[bool, float, float, float, float, bool, float, bool]
   """

--- a/ow_lander/scripts/activity_grind.py
+++ b/ow_lander/scripts/activity_grind.py
@@ -22,8 +22,6 @@ def arg_parsing(req):
     length = 0.6
     parallel = True
     ground_position = constants.DEFAULT_GROUND_HEIGHT
-    delete_prev_traj = False
-
   else :
     x_start = req.x
     y_start = req.y
@@ -31,9 +29,8 @@ def arg_parsing(req):
     length = req.length
     parallel = req.parallel
     ground_position = req.ground_position
-    delete_prev_traj = req.delete_prev_traj
 
-  return [req.use_defaults, x_start, y_start, depth, length, parallel, ground_position, delete_prev_traj]
+  return [req.use_defaults, x_start, y_start, depth, length, parallel, ground_position]
 
 def plan_cartesian_path(move_group, length, alpha, parallel):   
   """

--- a/ow_lander/scripts/path_planning_commander.py
+++ b/ow_lander/scripts/path_planning_commander.py
@@ -36,11 +36,11 @@ class PathPlanningCommander(object):
     """
     :type req: class 'ow_lander.srv._Stow.StowRequest'
     """
-    print("Unstow arm activity started")
+    print("Stow arm activity started")
     goal = self.arm_move_group.get_named_target_values("arm_stowed")
     self.arm_move_group.go(goal, wait=True)
     self.arm_move_group.stop()
-    print("Unstow arm activity completed")
+    print("Stow arm activity completed")
     return True, "Done"
 
   # === SERVICE ACTIVITIES - Unstow =============================
@@ -48,11 +48,11 @@ class PathPlanningCommander(object):
     """
     :type req: class 'ow_lander.srv._Unstow.UnstowRequest'
     """
-    print("Stow arm activity started")
+    print("Unstow arm activity started")
     goal = self.arm_move_group.get_named_target_values("arm_unstowed")
     self.arm_move_group.go(goal, wait=True)
     self.arm_move_group.stop()
-    print("Stow arm activity completed")
+    print("Unstow arm activity completed")
     return True, "Done"
 
   # === SERVICE ACTIVITIES - guarded move =============================

--- a/ow_lander/scripts/path_planning_commander.py
+++ b/ow_lander/scripts/path_planning_commander.py
@@ -102,7 +102,6 @@ class PathPlanningCommander(object):
     dig_linear_args = activity_full_digging_traj.arg_parsing_lin(req)
     success = activity_full_digging_traj.dig_linear(
       self.arm_move_group,
-      self.limbs_move_group,
       dig_linear_args)
     print "Dig linear arm motion executed!"
     return success, "Done"

--- a/ow_lander/scripts/path_planning_commander.py
+++ b/ow_lander/scripts/path_planning_commander.py
@@ -89,7 +89,8 @@ class PathPlanningCommander(object):
     success = activity_full_digging_traj.dig_circular(
       self.arm_move_group,
       self.limbs_move_group,
-      dig_circular_args)
+      dig_circular_args,
+      self.switch_controllers)
     print("Dig Circular arm activity completed")
     return success, "Done"
 

--- a/ow_lander/scripts/path_planning_commander.py
+++ b/ow_lander/scripts/path_planning_commander.py
@@ -14,9 +14,8 @@ import geometry_msgs.msg
 from std_msgs.msg import String
 from sensor_msgs.msg import JointState
 from moveit_commander.conversions import pose_to_list
+from controller_manager_msgs.srv import SwitchController
 from ow_lander.srv import *
-import datetime
-import time
 
 import constants
 import utils
@@ -30,27 +29,24 @@ class PathPlanningCommander(object):
   def __init__(self):
     super(PathPlanningCommander, self).__init__()
     moveit_commander.roscpp_initialize(sys.argv)
-    robot = moveit_commander.RobotCommander()
-    scene = moveit_commander.PlanningSceneInterface()
 
-    move_arm = moveit_commander.MoveGroupCommander("arm")
-    # move_limbs = moveit_commander.MoveGroupCommander("limbs")
-    # move_grinder = moveit_commander.MoveGroupCommander("grinder")
-    display_trajectory_publisher = rospy.Publisher('/move_group/display_planned_path',
-                                                   moveit_msgs.msg.DisplayTrajectory,
-                                                   queue_size=20)
-    self.arm_move_group = move_arm
-    # self.move_limbs = move_limbs
-    # self.move_grinder = move_grinder
+    self.arm_move_group = moveit_commander.MoveGroupCommander("arm")
+    self.limbs_move_group = moveit_commander.MoveGroupCommander("limbs")
+    self.grinder_move_group = moveit_commander.MoveGroupCommander("grinder")
+    self.display_trajectory = rospy.Publisher('/move_group/display_planned_path',
+                                              moveit_msgs.msg.DisplayTrajectory,
+                                              queue_size=20)
 
   # === SERVICE ACTIVITIES - Stow =============================
-  def handle_stow(self, req): 
+  def handle_stow(self, req):
     """
     :type req: class 'ow_lander.srv._Stow.StowRequest'
     """
+    print("Unstow arm activity started")
     goal = self.arm_move_group.get_named_target_values("arm_stowed")
     self.arm_move_group.go(goal, wait=True)
     self.arm_move_group.stop()
+    print("Unstow arm activity completed")
     return True, "Done"
 
   # === SERVICE ACTIVITIES - Unstow =============================
@@ -58,9 +54,11 @@ class PathPlanningCommander(object):
     """
     :type req: class 'ow_lander.srv._Unstow.UnstowRequest'
     """
+    print("Stow arm activity started")
     goal = self.arm_move_group.get_named_target_values("arm_unstowed")
     self.arm_move_group.go(goal, wait=True)
     self.arm_move_group.stop()
+    print("Stow arm activity completed")
     return True, "Done"
 
   # === SERVICE ACTIVITIES - guarded move =============================
@@ -68,128 +66,92 @@ class PathPlanningCommander(object):
     """
     :type req: class 'ow_lander.srv._GuardedMove.GuardedMoveRequest'
     """
-    print "Starting guarded move planning session"
+    print("Guarded Move arm activity started")
     guarded_move_args = activity_guarded_move.arg_parsing(req)
-    activity_guarded_move.pre_guarded_move(self.arm_move_group, guarded_move_args)
-    activity_guarded_move.guarded_move(self.arm_move_group, guarded_move_args)
-    print "Finished guarded move planning session succesfully..."
-    return True, "Done"
+    success = activity_guarded_move.pre_guarded_move(self.arm_move_group, guarded_move_args)
+    if success:
+      success = activity_guarded_move.guarded_move(self.arm_move_group, guarded_move_args)
+    print("Guarded Move arm activity completed")
+    return success, "Done"
 
   # === SERVICE ACTIVITIES - deliver sample =============================
   def handle_deliver_sample(self, req):
     """
     :type req: class 'ow_lander.srv._DeliverSample.DeliverSampleRequest'
     """
-    print "Starting sample delivery session"
+    print("Deliver Sample arm activity started")
     deliver_sample_args = activity_deliver_sample.arg_parsing(req)
-    activity_deliver_sample.deliver_sample(self.arm_move_group, deliver_sample_args)
-    print "Sample succesfully delivered..."
-    return True, "Done"
+    success = activity_deliver_sample.deliver_sample(self.arm_move_group, deliver_sample_args)
+    print("Deliver Sample arm activity completed")
+    return success, "Done"
+
+  # === SERVICE ACTIVITIES - Dig Linear Trench =============================
+  def handle_dig_circular(self, req):
+    """
+    :type req: class 'ow_lander.srv._DigCircular.DigCircularRequest'
+    """
+    print("Dig Cicular arm activity started")
+    dig_circular_args = activity_full_digging_traj.arg_parsing_circ(req)
+    success = activity_full_digging_traj.dig_circular(
+      self.arm_move_group,
+      self.limbs_move_group,
+      dig_circular_args)
+    print("Dig Circular arm activity completed")
+    return success, "Done"
+
+  # === SERVICE ACTIVITIES - Dig Linear Trench =============================
+  def handle_dig_linear(self, req):
+    """
+    :type req: class 'ow_lander.srv._DigLinear.DigLinearRequest'
+    """
+    dig_linear_args = activity_full_digging_traj.arg_parsing_lin(req)
+    success = activity_full_digging_traj.dig_linear(
+      self.arm_move_group,
+      self.limbs_move_group,
+      dig_linear_args)
+    print "Dig linear arm motion executed!"
+    return success, "Done"
+
+  def switch_controllers(self, start_controller, stop_controller):
+    rospy.wait_for_service('/controller_manager/switch_controller')
+    success = False
+    try:
+      switch_controller = rospy.ServiceProxy('/controller_manager/switch_controller', SwitchController)
+      success = switch_controller([start_controller], [stop_controller], 2, False, 1.0)
+    except rospy.ServiceException, e:
+      print("switch_controllers error: %s" % e)
+    finally:
+      return success
+
+  # === SERVICE ACTIVITIES - Grind =============================
+  def handle_grind(self, req):
+    """
+    :type req: class 'ow_lander.srv._Grind.GrindRequest'
+    """
+    print("Grinde arm activity started")
+    grind_args = activity_grind.arg_parsing(req)
+    success = self.switch_controllers('grinder_controller', 'arm_controller')
+    if not success:
+      return False, "Failed"
+    success = activity_grind.grind(
+      self.grinder_move_group,
+      grind_args)
+    self.switch_controllers('arm_controller', 'grinder_controller')
+    print("Grinde arm activity completed")
+    return success, "Done"
 
   def run(self):
     rospy.init_node('path_planning_commander', anonymous=True)
     self.stow_srv = rospy.Service('arm/stow', Stow, self.handle_stow)
     self.unstow_srv = rospy.Service('arm/unstow', Unstow, self.handle_unstow)
-    # self.dig_circular_srv = rospy.Service('arm/dig_circular', DigCircular, self.handle_dig_circular)
-    # dig_linear_srv = rospy.Service('arm/dig_linear', DigLinear, handle_dig_linear)
+    self.dig_circular_srv = rospy.Service('arm/dig_circular', DigCircular, self.handle_dig_circular)
+    self.dig_linear_srv = rospy.Service('arm/dig_linear', DigLinear, self.handle_dig_linear)
     self.guarded_move_srv = rospy.Service('arm/guarded_move', GuardedMove, self.handle_guarded_move)
     self.deliver_sample_srv = rospy.Service('arm/deliver_sample', DeliverSample, self.handle_deliver_sample)
-    # grind_srv = rospy.Service('arm/grind', Grind, handle_grind)
+    self.grind_srv = rospy.Service('arm/grind', Grind, self.handle_grind)
     print("path_planning_commander has started!")
     rospy.spin()
 
-# === SERVICE ACTIVITIES - Dig circular trench =============================
-def handle_dig_circular(req): 
-  """
-  :type req: class 'ow_lander.srv._DigCircular.DigCircularRequest'
-  """
-  try:
-    interface = MoveGroupPythonInteface()
-    print "Starting full traj planning session"
-    dig_circular_args = activity_full_digging_traj.arg_parsing_circ(req)
-
-    if utils.check_arguments(dig_circular_args[1], dig_circular_args[2], dig_circular_args[3]) != True:
-      print "[ERROR] Invalid trench input arguments. Exiting path_planning_commander..."
-      return
-
-    currentDT = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    location = "full_traj_"
-    bagname = location + currentDT
-
-    utils.start_traj_recording(dig_circular_args[6], bagname)
-    result = activity_full_digging_traj.dig_circular(interface.move_arm, interface.move_limbs, dig_circular_args)
-    utils.stop_traj_recording(result, bagname)
-
-  except rospy.ROSInterruptException:
-    return
-  except KeyboardInterrupt:
-    return
-
-  print "Finished planning session succesfully..."
-
-  return True, "Done"
-
-# === SERVICE ACTIVITIES - Dig Linear Trench =============================
-def handle_dig_linear(req):
-  """
-  :type req: class 'ow_lander.srv._DigLinear.DigLinearRequest'
-  """
-  try:
-    interface = MoveGroupPythonInteface()
-    print "Starting full traj planning session"
-    dig_linear_args = activity_full_digging_traj.arg_parsing_lin(req)
-
-    if utils.check_arguments(dig_linear_args[1], dig_linear_args[2], dig_linear_args[3]) != True:
-      print "[ERROR] Invalid trench input arguments. Exiting path_planning_commander..."
-      return
-
-    currentDT = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    location = "full_traj_"
-    bagname = location + currentDT
-
-    utils.start_traj_recording(dig_linear_args[6], bagname)
-    result = activity_full_digging_traj.dig_linear(interface.move_arm, interface.move_limbs, dig_linear_args)
-    utils.stop_traj_recording(result, bagname)
-
-  except rospy.ROSInterruptException:
-    return
-  except KeyboardInterrupt:
-    return
-
-  print "Finished planning session for linear trenching succesfully..."
-
-  return True, "Done"
-
-  # === SERVICE ACTIVITIES - Grind =============================
-def handle_grind(req): 
-  """
-  :type req: class 'ow_lander.srv._Grind.GrindRequest'
-  """
-  try:
-    interface = MoveGroupPythonInteface()
-    print "Starting grinder planning session"
-    grind_args = activity_grind.arg_parsing(req)
-
-    if utils.check_arguments(grind_args[1], grind_args[2], grind_args[3]) != True:
-      print "[ERROR] Invalid grinder trajectory input arguments. Exiting path_planning_commander..."
-      return
-
-    currentDT = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    location = "full_traj_"
-    bagname = location + currentDT
-
-    utils.start_traj_recording(grind_args[6], bagname)
-    result = activity_grind.grind(interface.move_arm, interface.move_limbs, interface.move_grinder, grind_args)
-    utils.stop_traj_recording(result, bagname)
-
-  except rospy.ROSInterruptException:
-    return
-  except KeyboardInterrupt:
-    return
-
-  print "Grinder planning succesfully finished..."
-
-  return True, "Done"
 
 if __name__ == '__main__':
   ppc = PathPlanningCommander()

--- a/ow_lander/scripts/path_planning_commander.py
+++ b/ow_lander/scripts/path_planning_commander.py
@@ -5,20 +5,14 @@
 # this repository.
 
 import sys
-import rosbag
-import copy
 import rospy
 import moveit_commander
 import moveit_msgs.msg
 import geometry_msgs.msg
 from std_msgs.msg import String
-from sensor_msgs.msg import JointState
-from moveit_commander.conversions import pose_to_list
 from controller_manager_msgs.srv import SwitchController
 from ow_lander.srv import *
 
-import constants
-import utils
 import activity_full_digging_traj
 import activity_guarded_move
 import activity_deliver_sample

--- a/ow_lander/scripts/utils.py
+++ b/ow_lander/scripts/utils.py
@@ -13,64 +13,6 @@ import rospy
 import roslib; roslib.load_manifest('urdfdom_py')
 from urdf_parser_py.urdf import URDF
 
-# Basic check if input trench arguments are numbers
-def check_arguments(tx, ty, td):
-  """
-  :type tx: float
-  :type ty: float
-  :type td: float
-  """
-
-  try:
-    float(tx)
-    float(ty)
-    float(td)
-    return True
-
-  except ValueError:
-    return False
-
-def start_traj_recording(delete_prev_traj, bagname):  
-  """
-  :type delete_prev_traj: bool
-  :type bagname: str
-  """
-  # If argument is true, delete all traj files in /.ros, to prevent sending wrong traj
-  if delete_prev_traj == True:
-    os.system("rm ~/.ros/*.csv")
-
-  # Start rosbag recording
-  command = "rosbag record -O " + bagname + " /planning/joint_states"
-  p = subprocess.Popen(command, stdin=subprocess.PIPE, shell=True, cwd='.')
-
-def stop_traj_recording(result, bagname):   
-  """
-  :type result: bool
-  :type bagname: str
-  """
-  time.sleep(1)
-  # Stop rosbag recording (TODO: clean process)
-  os.system("killall -s SIGINT record")
-
-  if result == False :
-    time.sleep(1)
-    print "[ERROR] No plan found. Exiting path_planning_commander..."
-    command = "rm " + bagname + ".bag"
-    os.system(command)
-    return
-
-  time.sleep(1)
-
-  # rosbag to csv
-  trajname = bagname + ".csv"
-  command = "rostopic echo -p -b " + bagname + ".bag /planning/joint_states > " + trajname
-  os.system(command)
-  time.sleep(1)
-
-  # Cleanup bag and csv
-  command = "rm " + bagname + ".bag"
-  os.system(command)
-
 def is_shou_yaw_goal_in_range(joint_goal):      
   """
   # type joint_goal: List[float, float, float, float, float, float]

--- a/ow_lander/scripts/utils.py
+++ b/ow_lander/scripts/utils.py
@@ -5,11 +5,6 @@
 # this repository.
 
 import constants
-import math
-import time
-import subprocess, os, signal
-from std_msgs.msg import String
-import rospy
 import roslib; roslib.load_manifest('urdfdom_py')
 from urdf_parser_py.urdf import URDF
 

--- a/ow_lander/srv/DigCircular.srv
+++ b/ow_lander/srv/DigCircular.srv
@@ -4,7 +4,6 @@ float32 y               # Trench starting point - Y coordinate
 float32 depth           # Desired depth
 bool parallel           # If True, resulting trench is parallel to arm. If False, perpendicular to arm
 float32 ground_position # Z coordinate of ground level in base_link frame
-bool delete_prev_traj   # Set to true to cleanup ~/.ros
 ---
 bool success
 string message

--- a/ow_lander/srv/DigLinear.srv
+++ b/ow_lander/srv/DigLinear.srv
@@ -4,7 +4,6 @@ float32 y               # Trench starting point - Y coordinate
 float32 depth           # Desired depth
 float32 length          # Desired length
 float32 ground_position # Z coordinate of ground level in base_link frame
-bool delete_prev_traj   # Set to true to cleanup ~/.ros
 ---
 bool success
 string message

--- a/ow_lander/srv/Grind.srv
+++ b/ow_lander/srv/Grind.srv
@@ -5,7 +5,6 @@ float32 depth           # Desired depth
 float32 length          # Desired length
 bool parallel           # If True, resulting trench is parallel to arm. If False, perpendicular to arm
 float32 ground_position # Z coordinate of ground level in base_link frame
-bool delete_prev_traj   # Set to true to cleanup ~/.ros
 ---
 bool success
 string message


### PR DESCRIPTION
## Linked Issues:
Linked PR: https://github.com/nasa/ow_autonomy/pull/15
Epic Link: https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-518
Linked Issues:
* https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-530
* https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-536
* https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-537
* https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-483 (api enhacements: remove delete_prev_traj)
* https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-526 (remove dependence on trajectory recording)

## Summary of Changes
* Added back the grinder_controller (deactivated by default)
* Created a method that enables switching between two sets of controllers at runtime
* Successfully ported the remaining services to using _JointTrajectoryController_:
  - **DigCircular**
  - **DigLinear**
  - **Grind**
* Removed `delete_prev_traj` from these services definitions as part of [OCEANWATER-483](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-483)
* Removed deprecated code that performs trajectory recording as part of [OCEANWATER-526](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-526)

## Test
>Note: During the review of [PR: OCEANWATER-525](https://github.com/nasa/ow_simulator/pull/39) @mogumbo reported a problem were [the arm shakes during unstow activity](https://github.com/nasa/ow_simulator/pull/39#issuecomment-736892425). The solution to that was simply [resetting the physics step size to the previous state](https://github.com/nasa/ow_simulator/pull/39#issuecomment-736894028). I have accidentally :eyes:  pushed this fix to [ow_europa](https://github.com/nasa/ow_europa) for the _melodic-devel_ branch so make sure you update that repo while testing this PR.

```bash
roslaunch ow (atacama_y1a.launch | europa_terminator.launch | europa_terminator_workspace.launch)
```
Then either rqt_service_caller interface or launch a separate terminal (with the workspace sourced) and invoked any of the ported commands
```bash
rosservice call /arm/dig_linear ...
rosservice call /arm/dig_circular ...
rosservice call /arm/grind ...
```
### Test Objectives
* Make sure all services (newly ported and previous ones) are performing as expected.
* Note any improvements that can be made within the scope of this and linked PR.