### PR TITLE
Oceanwater-558 adding grinder fault for arm

### DIFF
--- a/ow_faults/cfg/Faults.cfg
+++ b/ow_faults/cfg/Faults.cfg
@@ -58,5 +58,8 @@ gen.add("hand_yaw_torque_sensor_failure", bool_t,   0, "Hand yaw torque sensor f
 gen.add("scoop_yaw_encoder_failure",       bool_t,   0, "Scoop yaw encoder failure",       False)
 gen.add("scoop_yaw_torque_sensor_failure", bool_t,   0, "Scoop yaw torque sensor failure", False)
 
+gen.add("grinder_encoder_failure",       bool_t,   0, "Grinder encoder failure",       False)
+gen.add("grinder_torque_sensor_failure", bool_t,   0, "Grinder torque sensor failure", False)
+
 exit(gen.generate(PACKAGE, "faults", "Faults"))
 

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -98,6 +98,13 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
     output.effort[index] = 0.0;
   }
 
+  if (m_faults.grinder_encoder_failure && findJointIndex(J_GRINDER, index)) {
+    output.position[index] = 0.0;
+  }
+  if (m_faults.grinder_torque_sensor_failure && findJointIndex(J_GRINDER, index)) {
+    output.effort[index] = 0.0;
+  }
+
   m_joint_state_pub.publish(output);
 }
 


### PR DESCRIPTION
Adding Grinder Fault per OW-558
![image](https://user-images.githubusercontent.com/3445834/101950261-d096fd00-3ba9-11eb-9a67-f2d1f19731e8.png)

Test
roslaunch project, 
go to dynamic config in rqt and click on either of the grinder faults
observe change in rostopic echo /joint_states 