### PR TITLE
Resumed PositionController for ant_pan and tilt

### DIFF
--- a/ow_lander/config/ros_controllers.yaml
+++ b/ow_lander/config/ros_controllers.yaml
@@ -55,22 +55,14 @@ controller_list:
   #     - j_dist_pitch
   #     - j_hand_yaw
   #     - j_grinder
-antenna_controller:
-  type: effort_controllers/JointTrajectoryController
-  joints:
-    - j_ant_pan
-    - j_ant_tilt
-  gains:
-    j_ant_pan:
-      p: 100
-      d: 1
-      i: 1
-      i_clamp: 1
-    j_ant_tilt:
-      p: 100
-      d: 1
-      i: 1
-      i_clamp: 1
+ant_pan_position_controller:
+  type: effort_controllers/JointPositionController
+  joint: j_ant_pan
+  pid: {p: 100.0, i: 0.01, d: 15.0}
+ant_tilt_position_controller:
+  type: effort_controllers/JointPositionController
+  joint: j_ant_tilt
+  pid: {p: 550.0, i: 0.01, d: 70.0}
 arm_controller:
   type: effort_controllers/JointTrajectoryController
   joints:

--- a/ow_lander/config/ros_controllers.yaml
+++ b/ow_lander/config/ros_controllers.yaml
@@ -6,7 +6,6 @@ moveit_sim_hw_interface:
 generic_hw_control_loop:
   loop_hz: 300
   cycle_time_error_threshold: 0.01
-
 # Settings for ros_control hardware interface
 hardware_interface:
   joints:
@@ -20,6 +19,11 @@ hardware_interface:
     - j_grinder
     - j_scoop_yaw
   sim_control_mode: 1  # 0: position, 1: velocity
+# Publish all joint states
+# Creates the /joint_states topic necessary in ROS
+joint_state_controller:
+  type: joint_state_controller/JointStateController
+  publish_rate: 50
 controller_list:
   - name: arm_controller
     action_ns: follow_joint_trajectory
@@ -32,20 +36,34 @@ controller_list:
       - j_dist_pitch
       - j_hand_yaw
       - j_scoop_yaw
-  # TODO: We probably need to move the grinder_controller to another file to
-  # ease the process of controller switching
-  # - name: grinder_controller
-  #   action_ns: follow_joint_trajectory
-  #   type: FollowJointTrajectory
-  #   joints:
-  #     - j_shou_yaw
-  #     - j_shou_pitch
-  #     - j_prox_pitch
-  #     - j_dist_pitch
-  #     - j_hand_yaw
-  #     - j_grinder
-# Publish all joint states
-# Creates the /joint_states topic necessary in ROS
+  - name: limbs_controller
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    default: true
+    joints:
+      - j_shou_yaw
+      - j_shou_pitch
+      - j_prox_pitch
+      - j_dist_pitch
+      - j_hand_yaw
+  - name: grinder_controller
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    joints:
+      - j_shou_yaw
+      - j_shou_pitch
+      - j_prox_pitch
+      - j_dist_pitch
+      - j_hand_yaw
+      - j_grinder
+ant_pan_position_controller:
+  type: effort_controllers/JointPositionController
+  joint: j_ant_pan
+  pid: {p: 100.0, i: 0.01, d: 15.0}
+ant_tilt_position_controller:
+  type: effort_controllers/JointPositionController
+  joint: j_ant_tilt
+  pid: {p: 550.0, i: 0.01, d: 70.0}
 arm_controller:
   type: effort_controllers/JointTrajectoryController
   joints:
@@ -179,14 +197,3 @@ grinder_controller:
       d: *kd_default
       i: *ki_default
       i_clamp: *ki_clamp_default
-joint_state_controller:
-  type: joint_state_controller/JointStateController
-  publish_rate: 300
-ant_pan_position_controller:
-  type: effort_controllers/JointPositionController
-  joint: j_ant_pan
-  pid: {p: 100.0, i: 0.01, d: 15.0}
-ant_tilt_position_controller:
-  type: effort_controllers/JointPositionController
-  joint: j_ant_tilt
-  pid: {p: 550.0, i: 0.01, d: 70.0}

--- a/ow_lander/config/ros_controllers.yaml
+++ b/ow_lander/config/ros_controllers.yaml
@@ -25,12 +25,17 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: 50
 controller_list:
-  - name: antenna_controller
+  - name: ant_pan_position_controller
     action_ns: follow_joint_trajectory
     type: FollowJointTrajectory
     default: true
     joints:
       - j_ant_pan
+  - name: ant_tilt_position_controller
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    default: true
+    joints:
       - j_ant_tilt
   - name: arm_controller
     action_ns: follow_joint_trajectory

--- a/ow_lander/config/ros_controllers.yaml
+++ b/ow_lander/config/ros_controllers.yaml
@@ -6,6 +6,7 @@ moveit_sim_hw_interface:
 generic_hw_control_loop:
   loop_hz: 300
   cycle_time_error_threshold: 0.01
+
 # Settings for ros_control hardware interface
 hardware_interface:
   joints:
@@ -19,24 +20,7 @@ hardware_interface:
     - j_grinder
     - j_scoop_yaw
   sim_control_mode: 1  # 0: position, 1: velocity
-# Publish all joint states
-# Creates the /joint_states topic necessary in ROS
-joint_state_controller:
-  type: joint_state_controller/JointStateController
-  publish_rate: 50
 controller_list:
-  - name: ant_pan_position_controller
-    action_ns: follow_joint_trajectory
-    type: FollowJointTrajectory
-    default: true
-    joints:
-      - j_ant_pan
-  - name: ant_tilt_position_controller
-    action_ns: follow_joint_trajectory
-    type: FollowJointTrajectory
-    default: true
-    joints:
-      - j_ant_tilt
   - name: arm_controller
     action_ns: follow_joint_trajectory
     type: FollowJointTrajectory
@@ -60,14 +44,8 @@ controller_list:
   #     - j_dist_pitch
   #     - j_hand_yaw
   #     - j_grinder
-ant_pan_position_controller:
-  type: effort_controllers/JointPositionController
-  joint: j_ant_pan
-  pid: {p: 100.0, i: 0.01, d: 15.0}
-ant_tilt_position_controller:
-  type: effort_controllers/JointPositionController
-  joint: j_ant_tilt
-  pid: {p: 550.0, i: 0.01, d: 70.0}
+# Publish all joint states
+# Creates the /joint_states topic necessary in ROS
 arm_controller:
   type: effort_controllers/JointTrajectoryController
   joints:
@@ -201,3 +179,14 @@ grinder_controller:
       d: *kd_default
       i: *ki_default
       i_clamp: *ki_clamp_default
+joint_state_controller:
+  type: joint_state_controller/JointStateController
+  publish_rate: 300
+ant_pan_position_controller:
+  type: effort_controllers/JointPositionController
+  joint: j_ant_pan
+  pid: {p: 100.0, i: 0.01, d: 15.0}
+ant_tilt_position_controller:
+  type: effort_controllers/JointPositionController
+  joint: j_ant_tilt
+  pid: {p: 550.0, i: 0.01, d: 70.0}

--- a/ow_lander/launch/ros_controllers.launch
+++ b/ow_lander/launch/ros_controllers.launch
@@ -6,7 +6,7 @@
 
   <!-- Load the controllers -->
   <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" args="arm_controller antenna_controller"/>
+    output="screen" args="arm_controller ant_pan_position_controller ant_tilt_position_controller"/>
 
   <node name="joint_controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
 		output="screen" args="joint_state_controller" />


### PR DESCRIPTION
Ticket: https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-559

There are two antenna joints: pan and tilt. Both of them don't need planning and are moved independently. So there's no need to switch to the JointTrajectoryController. In this branch I resumed the JointPositionController only for the antenna. 

Test:
- launch europa_terminator_workspace.launch
- in rqt>Control and Viz>Message Publisher click to expand the /ant_pan_position_controller/command topic. Tick the box. Change rate to 100. In the 'expression' field write float numbers such as: 0.5, 0.8, -0.5, one at a time. Observe antenna reaching the goal positions in Gazebo.
- make sure your ow_autonomy is in the OW-518 branch.
- run ReferenceMission1 : roslaunch ow_autonomy autonomy_node.launch plan:="ReferenceMission1.plx"
- observe antenna motion (you'll get an error when Unstow is called, that's normal). 
- Let me know if the antenna moves as expected please

