### PR TITLE
Oceanwater 562 refine camera exposure and energy conversion

### DIFF
--- a/ow_lander/urdf/stereo_camera_triggered.xacro
+++ b/ow_lander/urdf/stereo_camera_triggered.xacro
@@ -158,8 +158,8 @@
       <!-- TODO: Figure out why lens flare is causing black camera images. -->
       <!--plugin name="LensFlare" filename="libLensFlareSensorPlugin.so"/-->
       <plugin name="CameraSim" filename="libIRGCameraSimSensorPlugin.so" >
-        <exposure>0.02</exposure>
-        <energy_conversion>0.01625</energy_conversion>
+        <exposure>0.05</exposure>
+        <energy_conversion>0.005</energy_conversion>
       </plugin>
     </sensor>
   </gazebo>  


### PR DESCRIPTION
I updated IRGCameraSim plugin params based on refined camera estimates documented in the "energy_conversion parameter" section of this page: https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/Visuals