### PR TITLE
set pid values once for all controllers +

### DIFF
--- a/ow_lander/config/ros_controllers.yaml
+++ b/ow_lander/config/ros_controllers.yaml
@@ -90,29 +90,29 @@ arm_controller:
   stop_trajectory_duration: 1.0
   gains:
     j_shou_yaw: 
-      p: 1000.0
-      d: 300.0
-      i: 10.0
+      p: &j_shou_yaw_p 1000.0
+      d: &j_shou_yaw_d 300.0
+      i: &j_shou_yaw_i 10.0
       i_clamp: &ki_clamp_default 2
     j_shou_pitch:
-      p: 2000.0
-      d: 150.0
-      i: 0.2
+      p: &j_shou_pitch_p 2000.0
+      d: &j_shou_pitch_d 150.0
+      i: &j_shou_pitch_i 0.2
       i_clamp: *ki_clamp_default
     j_prox_pitch:
-      p: 1100.0
-      d: 100.0
-      i: 2.0
+      p: &j_prox_pitch_p 1100.0
+      d: &j_prox_pitch_d 100.0
+      i: &j_prox_pitch_i 2.0
       i_clamp: 1
     j_dist_pitch:
-      p: 700.0
-      d: 20.0
-      i: 0.06
+      p: &j_dist_pitch_p 700.0
+      d: &j_dist_pitch_d 20.0
+      i: &j_dist_pitch_i 0.06
       i_clamp: 1
     j_hand_yaw:
-      p: 100.0
-      d: 10.0
-      i: 0.01
+      p: &j_hand_yaw_p 100.0
+      d: &j_hand_yaw_d 10.0
+      i: &j_hand_yaw_i 0.01
       i_clamp: 1
     j_scoop_yaw:
       p: 100.0
@@ -139,34 +139,33 @@ limbs_controller:
     j_prox_pitch: {trajectory: *traj_tolerance, goal: *goal_tolerance}
     j_dist_pitch: {trajectory: *traj_tolerance, goal: *goal_tolerance}
     j_hand_yaw: {trajectory: *traj_tolerance, goal: *goal_tolerance}
-    j_scoop_yaw: {trajectory: *traj_tolerance, goal: *goal_tolerance}
   # Time it takes to bring the current state (position and velocity) to a stop
   stop_trajectory_duration: 1.0
   gains:
     j_shou_yaw: 
-      p: 1000.0
-      d: 300.0
-      i: 10.0
+      p: *j_shou_yaw_p
+      d: *j_shou_yaw_d
+      i: *j_shou_yaw_i
       i_clamp: *ki_clamp_default
     j_shou_pitch:
-      p: 2000.0
-      d: 150.0
-      i: 0.2
+      p: *j_shou_pitch_p
+      d: *j_shou_pitch_d
+      i: *j_shou_pitch_i
       i_clamp: *ki_clamp_default
     j_prox_pitch:
-      p: 1100.0
-      d: 100.0
-      i: 2.0
+      p: *j_prox_pitch_p
+      d: *j_prox_pitch_d
+      i: *j_prox_pitch_i
       i_clamp: 1
     j_dist_pitch:
-      p: 700.0
-      d: 20.0
-      i: 0.06
+      p: *j_dist_pitch_p
+      d: *j_dist_pitch_d
+      i: *j_dist_pitch_i
       i_clamp: 1
     j_hand_yaw:
-      p: 100.0
-      d: 10.0
-      i: 0.01
+      p: *j_hand_yaw_p
+      d: *j_hand_yaw_d
+      i: *j_hand_yaw_i
       i_clamp: 1
 grinder_controller:
   type: effort_controllers/JointTrajectoryController
@@ -189,34 +188,34 @@ grinder_controller:
     j_prox_pitch: {trajectory: *traj_tolerance, goal: *goal_tolerance}
     j_dist_pitch: {trajectory: *traj_tolerance, goal: *goal_tolerance}
     j_hand_yaw: {trajectory: *traj_tolerance, goal: *goal_tolerance}
-    j_scoop_yaw: {trajectory: *traj_tolerance, goal: *goal_tolerance}
+    j_grinder: {trajectory: *traj_tolerance, goal: *goal_tolerance}
   # Time it takes to bring the current state (position and velocity) to a stop
   stop_trajectory_duration: 1.0
   gains:
     j_shou_yaw: 
-      p: 1000.0
-      d: 300.0
-      i: 10.0
+      p: *j_shou_yaw_p
+      d: *j_shou_yaw_d
+      i: *j_shou_yaw_i
       i_clamp: *ki_clamp_default
     j_shou_pitch:
-      p: 2000.0
-      d: 150.0
-      i: 0.2
+      p: *j_shou_pitch_p
+      d: *j_shou_pitch_d
+      i: *j_shou_pitch_i
       i_clamp: *ki_clamp_default
     j_prox_pitch:
-      p: 1100.0
-      d: 100.0
-      i: 2.0
+      p: *j_prox_pitch_p
+      d: *j_prox_pitch_d
+      i: *j_prox_pitch_i
       i_clamp: 1
     j_dist_pitch:
-      p: 700.0
-      d: 20.0
-      i: 0.06
+      p: *j_dist_pitch_p
+      d: *j_dist_pitch_d
+      i: *j_dist_pitch_i
       i_clamp: 1
     j_hand_yaw:
-      p: 100.0
-      d: 10.0
-      i: 0.01
+      p: *j_hand_yaw_p
+      d: *j_hand_yaw_d
+      i: *j_hand_yaw_i
       i_clamp: 1
     j_grinder:
       p: 10.0


### PR DESCRIPTION
## Summary of Changes
This is mainly a quick refactor of the `ros_controllers.yaml` to avoid setting different PID values for the same joint in different controllers.
* Set pid values once - of the same joint - for all controllers
* Reference only joints that belong to the controller in constraints section

## Test
```bash
roslaunch ow atacama_y1a.launch # if this starts then all good
```