### PR TITLE
Use new proximal pitch stowed value

### DIFF
--- a/ow_lander/config/lander.srdf
+++ b/ow_lander/config/lander.srdf
@@ -33,7 +33,7 @@
     <group_state name="arm_stowed" group="arm">
         <joint name="j_dist_pitch" value="2.9" />
         <joint name="j_hand_yaw" value="0" />
-        <joint name="j_prox_pitch" value="-2.75" />
+        <joint name="j_prox_pitch" value="-2.65" />
         <joint name="j_scoop_yaw" value="0" />
         <joint name="j_shou_pitch" value="1.5708" />
         <joint name="j_shou_yaw" value="-1.5" />

--- a/ow_lander/launch/spawn.launch
+++ b/ow_lander/launch/spawn.launch
@@ -17,7 +17,7 @@
   <!-- These values should not be duplicated elsewhere, as that would lead to code maintainability problems. -->
   <arg name="stowed_shou_yaw" default="-1.5" />
   <arg name="stowed_shou_pitch" default="1.5708" />
-  <arg name="stowed_prox_pitch" default="-2.75" />
+  <arg name="stowed_prox_pitch" default="-2.65" />
   <arg name="stowed_dist_pitch" default="2.9" />
   <arg name="stowed_hand_yaw" default="0.0" />
   <arg name="stowed_scoop_yaw" default="0.0" />


### PR DESCRIPTION
This appears to avoid LCP internal errors from ODE on startup, but the arm still starts in slightly different positions each run. A careful investigation is needed to avoid this behavior.