### PR TITLE
Invoke dig_circular using arm_controller + remove all refs to limbs_controllers

### DIFF
--- a/ow_lander/config/fake_controllers.yaml
+++ b/ow_lander/config/fake_controllers.yaml
@@ -11,13 +11,6 @@ controller_list:
       - j_dist_pitch
       - j_hand_yaw
       - j_scoop_yaw
-  - name: fake_limbs_controller
-    joints:
-      - j_shou_yaw
-      - j_shou_pitch
-      - j_prox_pitch
-      - j_dist_pitch
-      - j_hand_yaw
   - name: fake_grinder_controller
     joints:
       - j_shou_yaw

--- a/ow_lander/config/kinematics.yaml
+++ b/ow_lander/config/kinematics.yaml
@@ -6,10 +6,6 @@ antenna:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
-limbs:
-  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
-  kinematics_solver_search_resolution: 0.005
-  kinematics_solver_timeout: 0.005
 grinder:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005

--- a/ow_lander/config/lander.srdf
+++ b/ow_lander/config/lander.srdf
@@ -15,9 +15,6 @@
     <group name="antenna">
         <chain base_link="base_link" tip_link="l_ant_panel" />
     </group>
-    <group name="limbs">
-        <chain base_link="base_link" tip_link="l_hand" />
-    </group>
     <group name="grinder">
         <chain base_link="base_link" tip_link="l_grinder" />
     </group>

--- a/ow_lander/config/ompl_planning.yaml
+++ b/ow_lander/config/ompl_planning.yaml
@@ -177,34 +177,6 @@ antenna:
     - SPARStwo
   projection_evaluator: joints(j_ant_pan,j_ant_tilt)
   longest_valid_segment_fraction: 0.005
-limbs:
-  default_planner_config: RRTConnect
-  planner_configs:
-    - SBL
-    - EST
-    - LBKPIECE
-    - BKPIECE
-    - KPIECE
-    - RRT
-    - RRTConnect
-    - RRTstar
-    - TRRT
-    - PRM
-    - PRMstar
-    - FMT
-    - BFMT
-    - PDST
-    - STRIDE
-    - BiTRRT
-    - LBTRRT
-    - BiEST
-    - ProjEST
-    - LazyPRM
-    - LazyPRMstar
-    - SPARS
-    - SPARStwo
-  projection_evaluator: joints(j_shou_yaw,j_shou_pitch)
-  longest_valid_segment_fraction: 0.005
 grinder:
   default_planner_config: RRTstar
   planner_configs:

--- a/ow_lander/config/ros_controllers.yaml
+++ b/ow_lander/config/ros_controllers.yaml
@@ -36,16 +36,6 @@ controller_list:
       - j_dist_pitch
       - j_hand_yaw
       - j_scoop_yaw
-  - name: limbs_controller
-    action_ns: follow_joint_trajectory
-    type: FollowJointTrajectory
-    default: true
-    joints:
-      - j_shou_yaw
-      - j_shou_pitch
-      - j_prox_pitch
-      - j_dist_pitch
-      - j_hand_yaw
   - name: grinder_controller
     action_ns: follow_joint_trajectory
     type: FollowJointTrajectory
@@ -118,54 +108,6 @@ arm_controller:
       p: 100.0
       d: 10.0
       i: 0.01
-      i_clamp: 1
-limbs_controller:
-  type: effort_controllers/JointTrajectoryController
-  joints:
-    - j_shou_yaw
-    - j_shou_pitch
-    - j_prox_pitch
-    - j_dist_pitch
-    - j_hand_yaw
-  constraints:
-    # If the timestamp of the goal trajectory point is t, then following the trajectory 
-    # succeeds if it reaches the goal within t +/- goal_time, and aborts otherwise.
-    goal_time: 50.0 
-    # Velocity to be considered approximately equal to zero.
-    stopped_velocity_tolerance: 0.001
-    # Position tolerance for a particular joint to reach the goal and throughout the trajectory
-    j_shou_yaw: {trajectory: *traj_tolerance, goal: *goal_tolerance}
-    j_shou_pitch: {trajectory: *traj_tolerance, goal: *goal_tolerance}
-    j_prox_pitch: {trajectory: *traj_tolerance, goal: *goal_tolerance}
-    j_dist_pitch: {trajectory: *traj_tolerance, goal: *goal_tolerance}
-    j_hand_yaw: {trajectory: *traj_tolerance, goal: *goal_tolerance}
-  # Time it takes to bring the current state (position and velocity) to a stop
-  stop_trajectory_duration: *traj_stop_duration
-  gains:
-    j_shou_yaw: 
-      p: *j_shou_yaw_p
-      d: *j_shou_yaw_d
-      i: *j_shou_yaw_i
-      i_clamp: *ki_clamp_default
-    j_shou_pitch:
-      p: *j_shou_pitch_p
-      d: *j_shou_pitch_d
-      i: *j_shou_pitch_i
-      i_clamp: *ki_clamp_default
-    j_prox_pitch:
-      p: *j_prox_pitch_p
-      d: *j_prox_pitch_d
-      i: *j_prox_pitch_i
-      i_clamp: 1
-    j_dist_pitch:
-      p: *j_dist_pitch_p
-      d: *j_dist_pitch_d
-      i: *j_dist_pitch_i
-      i_clamp: 1
-    j_hand_yaw:
-      p: *j_hand_yaw_p
-      d: *j_hand_yaw_d
-      i: *j_hand_yaw_i
       i_clamp: 1
 grinder_controller:
   type: effort_controllers/JointTrajectoryController

--- a/ow_lander/launch/ros_controllers.launch
+++ b/ow_lander/launch/ros_controllers.launch
@@ -12,8 +12,8 @@
   <node name="controller_spawner_active" pkg="controller_manager" type="spawner" respawn="false"
     output="screen" args="arm_controller ant_pan_position_controller ant_tilt_position_controller"/>
 
-  <!-- limbs_controller and grinder_controller is enabled only when needed -->
+  <!-- grinder_controller is enabled only when needed -->
   <node name="controller_spawner_stopped" pkg="controller_manager" type="spawner" respawn="false"
-    output="screen" args="--stopped limbs_controller grinder_controller"/>
+    output="screen" args="--stopped grinder_controller"/>
 
 </launch>

--- a/ow_lander/scripts/activity_full_digging_traj.py
+++ b/ow_lander/scripts/activity_full_digging_traj.py
@@ -192,10 +192,9 @@ def arg_parsing_circ(req):
   return [req.use_defaults, x_start, y_start, depth, parallel, ground_position]
 
 
-def dig_circular(move_arm, move_limbs, args, controller_switcher):
+def dig_circular(move_arm, args):
   """
   :type move_arm: class 'moveit_commander.move_group.MoveGroupCommander'
-  :type move_limbs: class 'moveit_commander.move_group.MoveGroupCommander'
   :type args: List[bool, float, int, float, bool, float]
   """
   x_start = args[1]
@@ -210,32 +209,21 @@ def dig_circular(move_arm, move_limbs, args, controller_switcher):
     return False
 
   if not parallel:
-
     # Once aligned to trench goal, place hand above trench middle point
     z_start = ground_position + constants.R_PARALLEL_FALSE - depth
-    controller_switcher('limbs_controller', 'arm_controller')
-    go_to_Z_coordinate(move_limbs, x_start, y_start, z_start)
-    controller_switcher('arm_controller', 'limbs_controller')
-
+    go_to_Z_coordinate(move_arm, x_start, y_start, z_start)
     # Rotate hand perpendicular to arm direction
     change_joint_value(move_arm, constants.J_HAND_YAW, -0.29*math.pi)
-
   else:
     # Rotate hand so scoop is in middle point
     change_joint_value(move_arm, constants.J_HAND_YAW, 0.0)
-
     # Rotate scoop
     change_joint_value(move_arm, constants.J_SCOOP_YAW, math.pi/2)
-
     # Rotate dist so scoop is back
     change_joint_value(move_arm, constants.J_DIST_PITCH, -19.0/54.0*math.pi)
-
     # Once aligned to trench goal, place hand above trench middle point
     z_start = ground_position + constants.R_PARALLEL_FALSE - depth
-    controller_switcher('limbs_controller', 'arm_controller')
-    go_to_Z_coordinate(move_limbs, x_start, y_start, z_start)
-    controller_switcher('arm_controller', 'limbs_controller')
-
+    go_to_Z_coordinate(move_arm, x_start, y_start, z_start)
     # Rotate dist to dig
     joint_goal = move_arm.get_current_joint_values()
     dist_now = joint_goal[3]

--- a/ow_lander/scripts/path_planning_commander.py
+++ b/ow_lander/scripts/path_planning_commander.py
@@ -28,7 +28,6 @@ class PathPlanningCommander(object):
     super(PathPlanningCommander, self).__init__()
     moveit_commander.roscpp_initialize(sys.argv)
     self.arm_move_group = moveit_commander.MoveGroupCommander("arm", wait_for_servers=10.0)
-    self.limbs_move_group = moveit_commander.MoveGroupCommander("limbs", wait_for_servers=10.0)
     self.grinder_move_group = moveit_commander.MoveGroupCommander("grinder", wait_for_servers=10.0)
     self.trajectory_async_executer = TrajectoryAsyncExecuter()
 
@@ -77,9 +76,7 @@ class PathPlanningCommander(object):
     dig_circular_args = activity_full_digging_traj.arg_parsing_circ(req)
     success = activity_full_digging_traj.dig_circular(
         self.arm_move_group,
-        self.limbs_move_group,
-        dig_circular_args,
-        self.switch_controllers)
+        dig_circular_args)
     print("Dig Circular arm activity completed")
     return success, "Done"
 
@@ -113,7 +110,7 @@ class PathPlanningCommander(object):
     """
     :type req: class 'ow_lander.srv._Grind.GrindRequest'
     """
-    print("Grinde arm activity started")
+    print("Grind arm activity started")
     grind_args = activity_grind.arg_parsing(req)
     success = self.switch_controllers('grinder_controller', 'arm_controller')
     if not success:
@@ -122,7 +119,7 @@ class PathPlanningCommander(object):
         self.grinder_move_group,
         grind_args)
     self.switch_controllers('arm_controller', 'grinder_controller')
-    print("Grinde arm activity completed")
+    print("Grind arm activity completed")
     return success, "Done"
 
   def handle_guarded_move_done(self, state, result):


### PR DESCRIPTION
## Linked Issues:
* [OCEANWATER-570 | Use arm_controller for performing the dig_circular activity](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-570)
* [OCEANWATER-569 | RRTConnect: Unable to sample any valid states for goal tree ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-569)

## Summary of Changes
* Invoke dig_circular using arm_controller
* Remove all refs to limbs_controllers

## Test
First start the simulation
```bash
roslaunch ow atacama_y1a.launch
```
Then invoke the dig_circular service (use_defaults: true, parallel: false/true)
```bash
roservice call /arm/dig_circular ...
```
Check for any errors and any deviations in expected behavior.
Check if this resolves issue **OCEANWATER-569**

## TODOs
@damianacatanoso I think the values set to dip down the arm before it does the rotation needs to be revised