### PR TITLE
Use cartesian path planning to position the arm for dig_circular

### DIFF
--- a/ow_lander/scripts/activity_full_digging_traj.py
+++ b/ow_lander/scripts/activity_full_digging_traj.py
@@ -209,7 +209,11 @@ def arg_parsing_circ(req):
 
   return [req.use_defaults, x_start, y_start, depth, parallel, ground_position]
 
-
+# During dig_circular, the code alternates between arm and limbs controller,
+# RRTConnect planner quite often reports a problem of being "Unable to sample any
+#  valid states for goal". Due to the error, the code employs `go_to_Z_cartesian`
+# instead of `go_to_Z_coordinate` which avoid this issue. For more background
+# refer to https://github.com/nasa/ow_simulator/pull/59
 def dig_circular(move_arm, move_limbs, args, controller_switcher):
   """
   :type move_arm: class 'moveit_commander.move_group.MoveGroupCommander'

--- a/ow_lander/scripts/path_planning_commander.py
+++ b/ow_lander/scripts/path_planning_commander.py
@@ -103,7 +103,7 @@ class PathPlanningCommander(object):
       switch_controller = rospy.ServiceProxy(
           '/controller_manager/switch_controller', SwitchController)
       success = switch_controller(
-          [start_controller], [stop_controller], 2, False, 1.0)
+          [start_controller], [stop_controller], 2, True, 0.0)
     except rospy.ServiceException, e:
       print("switch_controllers error: %s" % e)
     finally:


### PR DESCRIPTION
## Summary of Changes
This addresses the issue [OCEANWATER-569 | RRTConnect: Unable to sample any valid states for goal tree ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-569) by using to Cartesian path planning on the _limbs_controller_ when positioning the arm for digging within a dig_circular activity.

## Test
First start the simulation
```bash
roslaunch ow atacama_y1a.launch
```
Then invoke the dig_circular service with the following configurations:
* (use_defaults: true)
* (use_defaults: false, x:1.65 +/- 0.2, y: 0 +/-0.5, z: 0 +/- 0.2, parallel: false/true, ground_position: -0.155)
```bash
roservice call /arm/dig_circular ...
```
Check for any errors and any deviations in expected behavior.
Check if this resolves issue **OCEANWATER-569**