### PR TITLE
Plan using an approximate joint value targets

### DIFF
--- a/ow_lander/scripts/activity_full_digging_traj.py
+++ b/ow_lander/scripts/activity_full_digging_traj.py
@@ -23,7 +23,7 @@ def go_to_Z_coordinate(move_group, x_start, y_start, z_start):
   goal_pose.position.x = x_start
   goal_pose.position.y = y_start
   goal_pose.position.z = z_start
-  move_group.set_pose_target(goal_pose)
+  move_group.set_joint_value_target(goal_pose, True)
   plan = move_group.plan()
   if len(plan.joint_trajectory.points) == 0:  # If no plan found, abort
     return False

--- a/ow_lander/scripts/activity_full_digging_traj.py
+++ b/ow_lander/scripts/activity_full_digging_traj.py
@@ -23,6 +23,9 @@ def go_to_Z_coordinate(move_group, x_start, y_start, z_start):
   goal_pose.position.x = x_start
   goal_pose.position.y = y_start
   goal_pose.position.z = z_start
+  # Ask the planner to generate a plan to the approximate joint values generated
+  # by kinematics builtin IK solver. For more insight on this issue refer to:
+  # https://github.com/nasa/ow_simulator/pull/60 
   move_group.set_joint_value_target(goal_pose, True)
   plan = move_group.plan()
   if len(plan.joint_trajectory.points) == 0:  # If no plan found, abort


### PR DESCRIPTION
## Linked Issue
[OCEANWATER-569 | RRTConnect: Unable to sample any valid states for goal tree](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-569)

## Summary of Changes
The changes may not seem like a lot but there is a lot more to it behind the scenes. This avoids the use of the planner to come with a plan to get to the specified pose during the call to **go_to_Z_coordinate**. What this code does instead is asking the planner (the current planner) to generate a plan to the approximate joint values generated by kinematics builtin IK solver. To me this is a workaround but so is https://github.com/nasa/ow_simulator/pull/59. The gain here is it directly addresses the issues with no side effects (yet :roll_eyes:)

## Test
>Note: To reproduce the issue that currently exists on **OCEANWATER-518** branch perform dig_circular activity as usual and alternate between "**parallel: True/False**" in the same session (**use_defaults** should be set to False).

First start the simulation
```bash
roslaunch ow atacama_y1a.launch
```
Then invoke the dig_circular service with the following configurations:
* (use_defaults: true)
* (use_defaults: false, x:1.65 +/- 0.2, y: 0 +/-0.5, z: 0 +/- 0.2, parallel: false/true, ground_position: -0.155)
```bash
rosservice call /arm/dig_circular ...
```
Verify that this totally address the issue **OCEANWATER-569** without a single side effect.