### PR TITLE
Oceanwater 544 ensure rrt star planner is set during arm operations

### DIFF
--- a/ow_lander/config/ompl_planning.yaml
+++ b/ow_lander/config/ompl_planning.yaml
@@ -122,7 +122,7 @@ planner_configs:
     dense_delta_fraction: 0.001  # delta fraction for interface detection. default: 0.001
     max_failures: 5000  # maximum consecutive failure limit. default: 5000
 arm:
-  default_planner_config: RRTConnect
+  default_planner_config: RRTstar
   planner_configs:
     - SBL
     - EST
@@ -178,7 +178,7 @@ antenna:
   projection_evaluator: joints(j_ant_pan,j_ant_tilt)
   longest_valid_segment_fraction: 0.005
 limbs:
-  default_planner_config: RRTConnect
+  default_planner_config: RRTstar
   planner_configs:
     - SBL
     - EST


### PR DESCRIPTION
Changed default planner for arm and limbs to RRTstar because:
- it's optimal planner
- optimizes for mechanical work so uses less power
- avoids unnecessary arm motions when reaching a target position

Test:
-  europa_terminator_workspace.launch
- roslaunch ow_autonomy autonomy_node.launch plan:="ReferenceMission1.plx"
- Check that all services run correctly