### PR TITLE
Another solution to rrtconnect unable to sample any valid states for goal tree

### DIFF
--- a/ow_lander/config/ompl_planning.yaml
+++ b/ow_lander/config/ompl_planning.yaml
@@ -122,7 +122,7 @@ planner_configs:
     dense_delta_fraction: 0.001  # delta fraction for interface detection. default: 0.001
     max_failures: 5000  # maximum consecutive failure limit. default: 5000
 arm:
-  default_planner_config: RRTConnect
+  default_planner_config: RRTstar
   planner_configs:
     - SBL
     - EST
@@ -178,7 +178,7 @@ antenna:
   projection_evaluator: joints(j_ant_pan,j_ant_tilt)
   longest_valid_segment_fraction: 0.005
 limbs:
-  default_planner_config: RRTConnect
+  default_planner_config: RRTstar
   planner_configs:
     - SBL
     - EST

--- a/ow_lander/config/ompl_planning.yaml
+++ b/ow_lander/config/ompl_planning.yaml
@@ -122,7 +122,7 @@ planner_configs:
     dense_delta_fraction: 0.001  # delta fraction for interface detection. default: 0.001
     max_failures: 5000  # maximum consecutive failure limit. default: 5000
 arm:
-  default_planner_config: RRTstar
+  default_planner_config: RRTConnect
   planner_configs:
     - SBL
     - EST
@@ -178,7 +178,7 @@ antenna:
   projection_evaluator: joints(j_ant_pan,j_ant_tilt)
   longest_valid_segment_fraction: 0.005
 limbs:
-  default_planner_config: RRTstar
+  default_planner_config: RRTConnect
   planner_configs:
     - SBL
     - EST

--- a/ow_lander/config/ros_controllers.yaml
+++ b/ow_lander/config/ros_controllers.yaml
@@ -90,27 +90,27 @@ arm_controller:
   stop_trajectory_duration: &traj_stop_duration 0.5
   gains:
     j_shou_yaw: 
-      p: &j_shou_yaw_p 1000.0
+      p: &j_shou_yaw_p 10000.0
       d: &j_shou_yaw_d 300.0
       i: &j_shou_yaw_i 10.0
       i_clamp: &ki_clamp_default 2
     j_shou_pitch:
-      p: &j_shou_pitch_p 2000.0
+      p: &j_shou_pitch_p 20000.0
       d: &j_shou_pitch_d 150.0
       i: &j_shou_pitch_i 0.2
       i_clamp: *ki_clamp_default
     j_prox_pitch:
-      p: &j_prox_pitch_p 1100.0
+      p: &j_prox_pitch_p 11000.0
       d: &j_prox_pitch_d 100.0
       i: &j_prox_pitch_i 2.0
       i_clamp: 1
     j_dist_pitch:
-      p: &j_dist_pitch_p 700.0
+      p: &j_dist_pitch_p 7000.0
       d: &j_dist_pitch_d 20.0
       i: &j_dist_pitch_i 0.06
       i_clamp: 1
     j_hand_yaw:
-      p: &j_hand_yaw_p 100.0
+      p: &j_hand_yaw_p 1000.0
       d: &j_hand_yaw_d 10.0
       i: &j_hand_yaw_i 0.01
       i_clamp: 1

--- a/ow_lander/scripts/activity_full_digging_traj.py
+++ b/ow_lander/scripts/activity_full_digging_traj.py
@@ -231,6 +231,8 @@ def dig_circular(move_arm, move_limbs, args, controller_switcher):
     # Once aligned to trench goal, place hand above trench middle point
     z_start = ground_position + constants.R_PARALLEL_FALSE - depth
     controller_switcher('limbs_controller', 'arm_controller')
+    z_now = move_limbs.get_current_pose().pose.position.z
+    go_to_Z_coordinate(move_limbs, x_start, y_start, z_now)
     go_to_Z_cartesian(move_limbs, z_start)
     controller_switcher('arm_controller', 'limbs_controller')
     # Rotate hand perpendicular to arm direction
@@ -245,6 +247,8 @@ def dig_circular(move_arm, move_limbs, args, controller_switcher):
     # Once aligned to trench goal, place hand above trench middle point
     z_start = ground_position + constants.R_PARALLEL_FALSE - depth
     controller_switcher('limbs_controller', 'arm_controller')
+    z_now = move_limbs.get_current_pose().pose.position.z
+    go_to_Z_coordinate(move_limbs, x_start, y_start, z_now)
     go_to_Z_cartesian(move_limbs, z_start)
     controller_switcher('arm_controller', 'limbs_controller')
     # Rotate dist to dig

--- a/ow_lander/scripts/path_planning_commander.py
+++ b/ow_lander/scripts/path_planning_commander.py
@@ -103,7 +103,7 @@ class PathPlanningCommander(object):
       switch_controller = rospy.ServiceProxy(
           '/controller_manager/switch_controller', SwitchController)
       success = switch_controller(
-          [start_controller], [stop_controller], 2, False, 1.0)
+          [start_controller], [stop_controller], 2, True, 0.0)
     except rospy.ServiceException, e:
       print("switch_controllers error: %s" % e)
     finally:


### PR DESCRIPTION
This is a simple solution to the "RRTConnect unable to sample any valid states for goal tree" problem and the offset that was introduced by adopting the cartesian planner.

Test:
- europa_terminator_workspace.launch
- roslaunch ow_autonomy autonomy_node.launch plan:="ReferenceMission1.plx"
- Check that there's no more offset between the trench resulting from the grind service and the scoop circular trajectory. 