### PR TITLE
Utilize set_pose_target when using the grinder move_group

### DIFF
--- a/ow_lander/scripts/activity_full_digging_traj.py
+++ b/ow_lander/scripts/activity_full_digging_traj.py
@@ -12,12 +12,14 @@ from tf.transformations import quaternion_from_euler, euler_from_quaternion
 from utils import is_shou_yaw_goal_in_range
 
 
-def go_to_Z_coordinate(move_group, x_start, y_start, z_start):
+def go_to_Z_coordinate(move_group, x_start, y_start, z_start, approximate=True):
   """
+  :param approximate: use an approximate solution. default True
   :type move_group: class 'moveit_commander.move_group.MoveGroupCommander'
   :type x_start: float
   :type y_start: float
   :type z_start: float
+  :type approximate: bool
   """
   goal_pose = move_group.get_current_pose().pose
   goal_pose.position.x = x_start
@@ -25,8 +27,11 @@ def go_to_Z_coordinate(move_group, x_start, y_start, z_start):
   goal_pose.position.z = z_start
   # Ask the planner to generate a plan to the approximate joint values generated
   # by kinematics builtin IK solver. For more insight on this issue refer to:
-  # https://github.com/nasa/ow_simulator/pull/60 
-  move_group.set_joint_value_target(goal_pose, True)
+  # https://github.com/nasa/ow_simulator/pull/60
+  if approximate:
+    move_group.set_joint_value_target(goal_pose, True)
+  else
+    move_group.set_pose_target(goal_pose)
   plan = move_group.plan()
   if len(plan.joint_trajectory.points) == 0:  # If no plan found, abort
     return False

--- a/ow_lander/scripts/activity_full_digging_traj.py
+++ b/ow_lander/scripts/activity_full_digging_traj.py
@@ -30,7 +30,7 @@ def go_to_Z_coordinate(move_group, x_start, y_start, z_start, approximate=True):
   # https://github.com/nasa/ow_simulator/pull/60
   if approximate:
     move_group.set_joint_value_target(goal_pose, True)
-  else
+  else:
     move_group.set_pose_target(goal_pose)
   plan = move_group.plan()
   if len(plan.joint_trajectory.points) == 0:  # If no plan found, abort

--- a/ow_lander/scripts/activity_grind.py
+++ b/ow_lander/scripts/activity_grind.py
@@ -107,7 +107,7 @@ def grind(move_grinder, args):
 
   # entering terrain
   z_start = ground_position + constants.GRINDER_OFFSET - depth
-  go_to_Z_coordinate(move_grinder, x_start, y_start, z_start)
+  go_to_Z_coordinate(move_grinder, x_start, y_start, z_start, False)
 
   # grinding ice forward
   cartesian_plan, fraction = plan_cartesian_path(move_grinder, length, alpha, parallel)
@@ -123,7 +123,7 @@ def grind(move_grinder, args):
     z_now = move_grinder.get_current_pose().pose.position.z
     x_goal = x_now + 0.08*math.cos(alpha)
     y_goal = y_now + 0.08*math.sin(alpha)
-    go_to_Z_coordinate(move_grinder, x_goal, y_goal, z_now)
+    go_to_Z_coordinate(move_grinder, x_goal, y_goal, z_now, False)
 
   # grinding ice backwards
   cartesian_plan, fraction = plan_cartesian_path(move_grinder, -length, alpha, parallel)
@@ -133,6 +133,6 @@ def grind(move_grinder, args):
   # exiting terrain
   x_now = move_grinder.get_current_pose().pose.position.x
   y_now = move_grinder.get_current_pose().pose.position.y
-  go_to_Z_coordinate(move_grinder, x_start, y_start, 0.22)
+  go_to_Z_coordinate(move_grinder, x_start, y_start, 0.22, False)
 
   return True


### PR DESCRIPTION
## Summary of Changes
* Added a new parameter to go_to_Z_coordinate to indicate that you want to use the approximate solution or not:
  - default is to use the approximate solution to address the issue OCEANWATER-569 (Refer to https://github.com/nasa/ow_simulator/pull/60 for more details)
* Pass **False** to retain the previous functionality for the grind activity.


## Verify
Run [test case 2.8](https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/OW-TEST007+-+release-7-0)