### PR TITLE
Oceanwater 544 ensure RRTstar planner is set during arm operations

### DIFF
--- a/ow_lander/config/ompl_planning.yaml
+++ b/ow_lander/config/ompl_planning.yaml
@@ -122,7 +122,7 @@ planner_configs:
     dense_delta_fraction: 0.001  # delta fraction for interface detection. default: 0.001
     max_failures: 5000  # maximum consecutive failure limit. default: 5000
 arm:
-  default_planner_config: RRTConnect
+  default_planner_config: RRTstar
   planner_configs:
     - SBL
     - EST
@@ -178,7 +178,7 @@ antenna:
   projection_evaluator: joints(j_ant_pan,j_ant_tilt)
   longest_valid_segment_fraction: 0.005
 limbs:
-  default_planner_config: RRTConnect
+  default_planner_config: RRTstar
   planner_configs:
     - SBL
     - EST

--- a/ow_lander/config/ros_controllers.yaml
+++ b/ow_lander/config/ros_controllers.yaml
@@ -90,7 +90,7 @@ arm_controller:
   stop_trajectory_duration: &traj_stop_duration 0.5
   gains:
     j_shou_yaw: 
-      p: &j_shou_yaw_p 9000.0
+      p: &j_shou_yaw_p 8300.0
       d: &j_shou_yaw_d 300.0
       i: &j_shou_yaw_i 10.0
       i_clamp: &ki_clamp_default 2
@@ -105,13 +105,13 @@ arm_controller:
       i: &j_prox_pitch_i 2.0
       i_clamp: 1
     j_dist_pitch:
-      p: &j_dist_pitch_p 1400.0
+      p: &j_dist_pitch_p 2000.0
       d: &j_dist_pitch_d 20.0
       i: &j_dist_pitch_i 0.06
       i_clamp: 1
     j_hand_yaw:
-      p: &j_hand_yaw_p 200.0
-      d: &j_hand_yaw_d 10.0
+      p: &j_hand_yaw_p 1000.0
+      d: &j_hand_yaw_d 60.0
       i: &j_hand_yaw_i 0.01
       i_clamp: 1
     j_scoop_yaw:

--- a/ow_lander/scripts/activity_deliver_sample.py
+++ b/ow_lander/scripts/activity_deliver_sample.py
@@ -9,6 +9,7 @@ from tf.transformations import euler_from_quaternion
 from moveit_msgs.msg import PositionConstraint
 from geometry_msgs.msg import Quaternion
 from shape_msgs.msg import SolidPrimitive
+import rospy
 
 
 def arg_parsing(req):
@@ -33,6 +34,7 @@ def deliver_sample(move_arm, args):
   :type move_arm: class 'moveit_commander.move_group.MoveGroupCommander'
   :type args: List[bool, float, float, float]
   """
+  default_planner_id = rospy.get_param("/move_group/arm/default_planner_config")
   move_arm.set_planner_id("RRTstar")
 
   x_delivery = args[1]
@@ -102,5 +104,7 @@ def deliver_sample(move_arm, args):
   plan = move_arm.go(wait=True)
   move_arm.stop()
   move_arm.clear_pose_targets()
+
+  move_arm.set_planner_id(default_planner_id)
 
   return True

--- a/ow_lander/scripts/activity_deliver_sample.py
+++ b/ow_lander/scripts/activity_deliver_sample.py
@@ -103,6 +103,4 @@ def deliver_sample(move_arm, args):
   move_arm.stop()
   move_arm.clear_pose_targets()
 
-  move_arm.set_planner_id("RRTconnect")
-
   return True


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️   | [Oceanwater-544](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-544) |
| ----------- | ----------- |
| EPIC ⚡| [Oceanwater-87](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-87) |
| Github :octocat:  | # |


## Summary of Changes
* Changed default planner for arm and limbs move_group to RRTstar
* While testing I noticed some of the PID gains could have been improved, so I adjusted the P gain for yaw pitch and hand
* I did the following tests to verify RRTstar reliability (please keep in mind that grind and deliver_sample were already using RRTstar, so no testing is required for them):
- roslaunch ow_autonomy autonomy_node.launch plan:=ReferenceMission1.plx
- Guarded_move:
rosservice call /arm/guarded_move -- False 1.7 0.3 0.5 0 0 1 0.7
rosservice call /arm/guarded_move -- False 1.7 -0.3 0.5 0 0 1 0.7
rosservice call /arm/guarded_move -- False 1.9 -0.4 0.5 0 0 1 0.7
rosservice call /arm/guarded_move -- False 1.9 0.5 0.5 0 0 1 0.7
rosservice call /arm/guarded_move -- False 1.7 0.0 0.5 1 1 1 0.7
rosservice call /arm/guarded_move -- False 1.7 0.0 0.5 0.5 -0.5 1 0.8
- Dig_circular:
rosservice call /arm/dig_circular -- False 2.0 0.3 0.05 False -0.155
rosservice call /arm/dig_circular -- False 2.0 -0.3 0.05 True -0.155
rosservice call /arm/dig_circular -- False 2.0 0.1 0.05 True -0.155
rosservice call /arm/dig_circular -- False 2.0 -0.1 0.05 False -0.155
rosservice call /arm/dig_circular -- False 2.0 -0.1 0.05 True -0.155
- Dig_linear:
rosservice call /arm/dig_linear -- False 1.6 -0.1 0.05 0.3 -0.155
rosservice call /arm/dig_linear -- False 1.55 -0.3 0.05 0.3 -0.155
rosservice call /arm/dig_linear -- False 1.55 -0.6 0.05 0.2 -0.155
rosservice call /arm/dig_linear -- False 1.3 -0.5 0.05 0.3 -0.155



## Test
* You may repeat the tests above, including ReferenceMission1, and/or try different input values. Before you test dig_circular and dig_linear, I suggest you disable collision between scoop and terrain, here is how: go to lander.xacro, line 549, replace 0x0001 with 0x0002. Because otherwise, since we are not grinding before, the scoop will not penetrate the terrain.
