### PR TITLE
Oceanwaters 576 power faults rqt

### DIFF
--- a/ow_faults/cfg/Faults.cfg
+++ b/ow_faults/cfg/Faults.cfg
@@ -11,43 +11,27 @@ joint_state_enum = gen.enum([gen.const("nominal",  int_t, 0, "Joint is functioni
                              gen.const("friction", int_t, 3, "Joint is consuming extra power")],
                             "An enum to set joint state")
 # ARM FAULTS
-#gen.add("ant_pan_state",                 int_t,    0, "Antenna pan joint state",           0, 0, 3, edit_method=joint_state_enum)
-#gen.add("ant_pan_friction",              double_t, 0, "Antenna pan joint friction",        0.1, 0, 1)
 gen.add("ant_pan_encoder_failure",       bool_t,   0, "Antenna pan encoder failure",       False)
 gen.add("ant_pan_torque_sensor_failure", bool_t,   0, "Antenna pan torque sensor failure", False)
 
-#gen.add("ant_tilt_state",                 int_t,    0, "Antenna tilt joint state",           0, 0, 3, edit_method=joint_state_enum)
-#gen.add("ant_tilt_friction",              double_t, 0, "Antenna tilt joint friction",        0.1, 0, 1)
 gen.add("ant_tilt_encoder_failure",       bool_t,   0, "Antenna tilt encoder failure",       False)
 gen.add("ant_tilt_torque_sensor_failure", bool_t,   0, "Antenna tilt torque sensor failure", False)
 
-#gen.add("shou_yaw_state",                 int_t,    0, "Shoulder yaw joint state",           0, 0, 3, edit_method=joint_state_enum)
-#gen.add("shou_yaw_friction",              double_t, 0, "Shoulder yaw joint friction",        0.1, 0, 1)
 gen.add("shou_yaw_encoder_failure",       bool_t,   0, "Shoulder yaw encoder failure",       False)
 gen.add("shou_yaw_torque_sensor_failure", bool_t,   0, "Shoulder yaw torque sensor failure", False)
 
-#gen.add("shou_pitch_state",                 int_t,    0, "Shoulder pitch joint state",           0, 0, 3, edit_method=joint_state_enum)
-#gen.add("shou_pitch_friction",              double_t, 0, "Shoulder pitch joint friction",        0.1, 0, 1)
 gen.add("shou_pitch_encoder_failure",       bool_t,   0, "Shoulder pitch encoder failure",       False)
 gen.add("shou_pitch_torque_sensor_failure", bool_t,   0, "Shoulder pitch torque sensor failure", False)
 
-#gen.add("prox_pitch_state",                 int_t,    0, "Proximal pitch joint state",           0, 0, 3, edit_method=joint_state_enum)
-#gen.add("prox_pitch_friction",              double_t, 0, "Proximal pitch joint friction",        0.1, 0, 1)
 gen.add("prox_pitch_encoder_failure",       bool_t,   0, "Proximal pitch encoder failure",       False)
 gen.add("prox_pitch_torque_sensor_failure", bool_t,   0, "Proximal pitch torque sensor failure", False)
 
-#gen.add("dist_pitch_state",                 int_t,    0, "Distal pitch joint state",           0, 0, 3, edit_method=joint_state_enum)
-#gen.add("dist_pitch_friction",              double_t, 0, "Distal pitch joint friction",        0.1, 0, 1)
 gen.add("dist_pitch_encoder_failure",       bool_t,   0, "Distal pitch encoder failure",       False)
 gen.add("dist_pitch_torque_sensor_failure", bool_t,   0, "Distal pitch torque sensor failure", False)
 
-#gen.add("hand_yaw_state",                 int_t,    0, "Hand yaw joint state",           0, 0, 3, edit_method=joint_state_enum)
-#gen.add("hand_yaw_friction",              double_t, 0, "Hand yaw joint friction",        0.1, 0, 1)
 gen.add("hand_yaw_encoder_failure",       bool_t,   0, "Hand yaw encoder failure",       False)
 gen.add("hand_yaw_torque_sensor_failure", bool_t,   0, "Hand yaw torque sensor failure", False)
 
-#gen.add("scoop_yaw_state",                 int_t,    0, "Scoop yaw joint state",           0, 0, 3, edit_method=joint_state_enum)
-#gen.add("scoop_yaw_friction",              double_t, 0, "Scoop yaw joint friction",        0.1, 0, 1)
 gen.add("scoop_yaw_encoder_failure",       bool_t,   0, "Scoop yaw encoder failure",       False)
 gen.add("scoop_yaw_torque_sensor_failure", bool_t,   0, "Scoop yaw torque sensor failure", False)
 

--- a/ow_faults/cfg/Faults.cfg
+++ b/ow_faults/cfg/Faults.cfg
@@ -10,14 +10,7 @@ joint_state_enum = gen.enum([gen.const("nominal",  int_t, 0, "Joint is functioni
                              gen.const("frozen",   int_t, 2, "Joint is frozen in position"),
                              gen.const("friction", int_t, 3, "Joint is consuming extra power")],
                             "An enum to set joint state")
-# Potential new Faults
-# gen.add("shou_yaw_position_controller_pid_state_fail", bool_t, 0, "testing shoulder yaw", False)
-# gen.add("shou_pitch_position_controller_pid_state_fail", bool_t, 0, "testing shoulder pitch", False)
-# gen.add("prox_pitch_position_controller_pid_state_fail", bool_t, 0, "testing prox pitch", False)
-# gen.add("dist_pitch_position_controller_pid_state_fail", bool_t, 0, "testing dist pitch", False)
-# gen.add("hand_yaw_position_controller_pid_state_fail", bool_t, 0, "testing hand yaw", False)
-# gen.add("scoop_yaw_position_controller_pid_state_fail", bool_t, 0, "testing scoop yaw", False)
-
+# ARM FAULTS
 #gen.add("ant_pan_state",                 int_t,    0, "Antenna pan joint state",           0, 0, 3, edit_method=joint_state_enum)
 #gen.add("ant_pan_friction",              double_t, 0, "Antenna pan joint friction",        0.1, 0, 1)
 gen.add("ant_pan_encoder_failure",       bool_t,   0, "Antenna pan encoder failure",       False)
@@ -57,6 +50,11 @@ gen.add("hand_yaw_torque_sensor_failure", bool_t,   0, "Hand yaw torque sensor f
 #gen.add("scoop_yaw_friction",              double_t, 0, "Scoop yaw joint friction",        0.1, 0, 1)
 gen.add("scoop_yaw_encoder_failure",       bool_t,   0, "Scoop yaw encoder failure",       False)
 gen.add("scoop_yaw_torque_sensor_failure", bool_t,   0, "Scoop yaw torque sensor failure", False)
+
+# POWER FAULTS
+gen.add("low_state_of_charge_power_failure", bool_t,   0, "Low state of charge power failure", False)
+gen.add("instantaneous_capacity_loss_power_failure", bool_t,   0, "Instantaneous capcity loss power failure", False)
+gen.add("thermal_power_failure", bool_t,   0, "Thermal power failure", False)
 
 exit(gen.generate(PACKAGE, "faults", "Faults"))
 

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -7,6 +7,7 @@
 
 
 #include <ros/ros.h>
+#include <std_msgs/Float64.h>
 #include <ow_faults/FaultsConfig.h>
 #include "ow_faults/SystemFaults.h"
 #include "ow_faults/ArmFaults.h"
@@ -75,6 +76,9 @@ private:
 
   ros::Subscriber m_joint_state_sub;
   ros::Publisher m_joint_state_pub;
+
+  ros::Publisher m_fault_power_state_of_charge_pub;
+  ros::Publisher m_fault_power_temp_pub;
 
   ros::Publisher m_fault_status_pub;
   ros::Publisher m_arm_fault_status_pub;

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -5,7 +5,8 @@
 #ifndef FaultInjector_h
 #define FaultInjector_h
 
-
+#include <ctime>
+#include <cstdlib>
 #include <ros/ros.h>
 #include <std_msgs/Float64.h>
 #include <ow_faults/FaultsConfig.h>
@@ -55,6 +56,10 @@ public:
     LanderExecutionError = 256};
 
 private:
+  float powerTemperatureOverload;
+  
+  void setPowerTemperatureFaultValue(bool b_getTemp);
+
   // Output /faults/joint_states, a modified version of /joint_states, injecting
   // simple message faults that don't need to be simulated at their source.
   void jointStateCb(const sensor_msgs::JointStateConstPtr& msg);

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -58,7 +58,7 @@ public:
 private:
   float powerTemperatureOverload;
   
-  void setPowerTemperatureFaultValue(bool b_getTemp);
+  void setPowerTemperatureFaultValue(bool getTempBool);
 
   // Output /faults/joint_states, a modified version of /joint_states, injecting
   // simple message faults that don't need to be simulated at their source.

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -49,12 +49,12 @@ void FaultInjector::setArmFaultMessage(ow_faults::ArmFaults& msg, int value) {
   msg.value = value; //should be HARDWARE for now
 }
 
-void FaultInjector::setPowerTemperatureFaultValue(bool b_getTemp){
+void FaultInjector::setPowerTemperatureFaultValue(bool getTempBool){
   float thermal_val;
   if (isnan(powerTemperatureOverload)) {
     thermal_val =  50.0 + static_cast <float> (rand()) /( static_cast <float> (RAND_MAX/(90.0-50.0)));
     powerTemperatureOverload = thermal_val;
-  } else if (!b_getTemp) {
+  } else if (!getTempBool) {
     powerTemperatureOverload = NAN;
   }
 }


### PR DESCRIPTION
*PLEASE NOTE THE BRANCH NAME IS INCORRECT, IT SHOULD BE TICKET 576* 

## Linked Issues:
| Jira Ticket 🎟️   | [Oceanwater-576](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-576) |
| ----------- | ----------- |
| EPIC ⚡| [Oceanwater-551](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-551) |
| Github :octocat:  | #NA |


## Summary of Changes
*  Added Power faults to rqt list, under dynamic reconfigure 
* added temprary publishers for power fault information as not all power features have been built yet
* on selection of power faults, temporary topics receive fake fault data. 

## Test
* TEST 1:
run any roslaunch file, open rqt, click on dynamic reconfigure and see the bottom 3 new power fault options
result:
![image](https://user-images.githubusercontent.com/3445834/105263848-53b25800-5b45-11eb-8a00-afd62a9c9e0d.png)

* TEST 2:
select  thermal power failure and in a termainl enter `rostopic echo temporary/power_fault/temp_increase`. You should see an output of > 50 (static). If you unclick and reclick, the value for high power failure will update. 
![image](https://user-images.githubusercontent.com/3445834/105395972-32e51380-5bd4-11eb-92bb-abdba27df3af.png)

* TEST 3:
select the low state of charge failure and enter into terminal `temporary/power_fault/state_of_charge` and observe the value of battery decreasing to below 10%. Currently static value, doesn't change. 
![image](https://user-images.githubusercontent.com/3445834/105396423-ba328700-5bd4-11eb-8318-516082283f35.png)

* TEST 4:
select the instantaneous capacity  failure and enter into terminal `temporary/power_fault/state_of_charge` and observe the battery state of charge change to a static value. Temporary value here since the battery state of charge itself feature isn't complete yet.
![image](https://user-images.githubusercontent.com/3445834/105396500-d1717480-5bd4-11eb-81b6-724daa704079.png)
