### PR TITLE
Oceanwater 580 power faults messages

### DIFF
--- a/ow_faults/CMakeLists.txt
+++ b/ow_faults/CMakeLists.txt
@@ -56,6 +56,7 @@ add_message_files(
   FILES
   SystemFaults.msg
   ArmFaults.msg
+  PowerFaults.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -12,6 +12,7 @@
 #include <ow_faults/FaultsConfig.h>
 #include "ow_faults/SystemFaults.h"
 #include "ow_faults/ArmFaults.h"
+#include "ow_faults/PowerFaults.h"
 #include <ow_lander/lander_joints.h>
 #include <sensor_msgs/JointState.h>
 #include <unordered_map>
@@ -34,8 +35,10 @@ public:
 
   enum Nominal { None=0 };
 
-  enum ArmFaults {
+  enum ComponentFaults {
+    // general
     Hardware=1, 
+    //arm 
     TrajectoryGeneration=2, 
     Collision=3, 
     Estop=4, 
@@ -43,9 +46,6 @@ public:
     TorqueLimit=6, 
     VelocityLimit=7, 
     NoForceData=8};
-
-  enum PowerFaults {
-    Execution=1}; //may need to be expanded
 
   enum SystemFaults {
     System=1, 
@@ -71,7 +71,7 @@ private:
   //Setting the correct values for system faults and arm faults messages
   void setSytemFaultsMessage(ow_faults::SystemFaults& msg, int value);
   void setArmFaultsMessage(ow_faults::ArmFaults& msg, int value);
-  void setPowerFaultMessage(ow_faults::PowerFaults& msg, int value);
+  void setPowerFaultsMessage(ow_faults::PowerFaults& msg, int value);
 
   // Find an item in an std::vector or other find-able data structure, and
   // return its index. Return -1 if not found.

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -44,6 +44,9 @@ public:
     VelocityLimit=7, 
     NoForceData=8};
 
+  enum PowerFaults {
+    Execution=1}; //may need to be expanded
+
   enum SystemFaults {
     System=1, 
     ArmGoalError=2, 
@@ -56,8 +59,9 @@ public:
     LanderExecutionError = 256};
 
 private:
-  float powerTemperatureOverload;
+  float powerTemperatureOverloadValue;
   
+  // renders new temperature when thermal power fault is re-triggered
   void setPowerTemperatureFaultValue(bool b_getTemp);
 
   // Output /faults/joint_states, a modified version of /joint_states, injecting
@@ -66,7 +70,8 @@ private:
 
   //Setting the correct values for system faults and arm faults messages
   void setSytemFaultsMessage(ow_faults::SystemFaults& msg, int value);
-  void setArmFaultMessage(ow_faults::ArmFaults& msg, int value);
+  void setArmFaultsMessage(ow_faults::ArmFaults& msg, int value);
+  void setPowerFaultMessage(ow_faults::PowerFaults& msg, int value);
 
   // Find an item in an std::vector or other find-able data structure, and
   // return its index. Return -1 if not found.
@@ -79,14 +84,18 @@ private:
 
   ow_faults::FaultsConfig m_faults;
 
+  // arm faults
   ros::Subscriber m_joint_state_sub;
   ros::Publisher m_joint_state_pub;
 
+  // temporary placeholder publishers until power feautre is finished
   ros::Publisher m_fault_power_state_of_charge_pub;
   ros::Publisher m_fault_power_temp_pub;
 
+  // publishers for sending ros messages for component failures
   ros::Publisher m_fault_status_pub;
   ros::Publisher m_arm_fault_status_pub;
+  ros::Publisher m_power_fault_status_pub;
 
   // Map ow_lander::joint_t enum values to indices in JointState messages
   std::vector<unsigned int> m_joint_state_indices;

--- a/ow_faults/msg/PowerFaults.msg
+++ b/ow_faults/msg/PowerFaults.msg
@@ -1,0 +1,3 @@
+# Power Fault Status 
+Header header
+uint32 value

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -51,7 +51,7 @@ void FaultInjector::setArmFaultsMessage(ow_faults::ArmFaults& msg, int value) {
   msg.value = value; //should be HARDWARE for now
 }
 
-void FaultInjector::setPowerFaultMessage(ow_faults::PowerFaults& msg, int value) {
+void FaultInjector::setPowerFaultsMessage(ow_faults::PowerFaults& msg, int value) {
   // for now only arm execution errors
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = "/world";
@@ -85,8 +85,7 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
   ow_faults::ArmFaults arm_faults_msg;
   ow_faults::PowerFaults power_faults_msg;
   SystemFaults sf = ArmExecutionError;
-  ArmFaults af = Hardware;
-  PowerFaults pf = Execution;
+  ComponentFaults hardwareFault = Hardware;
 
   //arm faults
   // Set failed sensor values to 0
@@ -112,67 +111,67 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
   if (m_faults.shou_yaw_encoder_failure && findJointIndex(J_SHOU_YAW, index)) {
     output.position[index] = 0.0;
     setSytemFaultsMessage(system_faults_msg, sf);
-    setArmFaultsMessage(arm_faults_msg, af);
+    setArmFaultsMessage(arm_faults_msg,hardwareFault);
   }
   if (m_faults.shou_yaw_torque_sensor_failure && findJointIndex(J_SHOU_YAW, index)) {
     output.effort[index] = 0.0;
     setSytemFaultsMessage(system_faults_msg, sf);
-    setArmFaultsMessage(arm_faults_msg, af);
+    setArmFaultsMessage(arm_faults_msg,hardwareFault);
   }
 
   if (m_faults.shou_pitch_encoder_failure && findJointIndex(J_SHOU_PITCH, index)) {
     output.position[index] = 0.0;
     setSytemFaultsMessage(system_faults_msg, sf);
-    setArmFaultsMessage(arm_faults_msg, af);
+    setArmFaultsMessage(arm_faults_msg,hardwareFault);
   }
   if (m_faults.shou_pitch_torque_sensor_failure && findJointIndex(J_SHOU_PITCH, index)) {
     output.effort[index] = 0.0;
     setSytemFaultsMessage(system_faults_msg, sf);
-    setArmFaultsMessage(arm_faults_msg, af);
+    setArmFaultsMessage(arm_faults_msg,hardwareFault);
   }
 
   if (m_faults.prox_pitch_encoder_failure && findJointIndex(J_PROX_PITCH, index)) {
     output.position[index] = 0.0;
     setSytemFaultsMessage(system_faults_msg, sf);
-    setArmFaultsMessage(arm_faults_msg, af);
+    setArmFaultsMessage(arm_faults_msg,hardwareFault);
   }
   if (m_faults.prox_pitch_torque_sensor_failure && findJointIndex(J_PROX_PITCH, index)) {
     output.effort[index] = 0.0;
     setSytemFaultsMessage(system_faults_msg, sf);
-    setArmFaultsMessage(arm_faults_msg, af);
+    setArmFaultsMessage(arm_faults_msg,hardwareFault);
   }
 
   if (m_faults.dist_pitch_encoder_failure && findJointIndex(J_DIST_PITCH, index)) {
     output.position[index] = 0.0;
     setSytemFaultsMessage(system_faults_msg, sf);
-    setArmFaultsMessage(arm_faults_msg, af);
+    setArmFaultsMessage(arm_faults_msg,hardwareFault);
   }
   if (m_faults.dist_pitch_torque_sensor_failure && findJointIndex(J_DIST_PITCH, index)) {
     output.effort[index] = 0.0;
     setSytemFaultsMessage(system_faults_msg, sf);
-    setArmFaultsMessage(arm_faults_msg, af);
+    setArmFaultsMessage(arm_faults_msg,hardwareFault);
   }
 
   if (m_faults.hand_yaw_encoder_failure && findJointIndex(J_HAND_YAW, index)) {
     output.position[index] = 0.0;
     setSytemFaultsMessage(system_faults_msg, sf);
-    setArmFaultsMessage(arm_faults_msg, af);
+    setArmFaultsMessage(arm_faults_msg,hardwareFault);
   }
   if (m_faults.hand_yaw_torque_sensor_failure && findJointIndex(J_HAND_YAW, index)) {
     output.effort[index] = 0.0;
     setSytemFaultsMessage(system_faults_msg, sf);
-    setArmFaultsMessage(arm_faults_msg, af);
+    setArmFaultsMessage(arm_faults_msg,hardwareFault);
   }
 
   if (m_faults.scoop_yaw_encoder_failure && findJointIndex(J_SCOOP_YAW, index)) {
     output.position[index] = 0.0;
     setSytemFaultsMessage(system_faults_msg, sf);
-    setArmFaultsMessage(arm_faults_msg, af);
+    setArmFaultsMessage(arm_faults_msg,hardwareFault);
   }
   if (m_faults.scoop_yaw_torque_sensor_failure && findJointIndex(J_SCOOP_YAW, index)) {
     output.effort[index] = 0.0;
     setSytemFaultsMessage(system_faults_msg, sf);
-    setArmFaultsMessage(arm_faults_msg, af);
+    setArmFaultsMessage(arm_faults_msg,hardwareFault);
   }
 
   std_msgs::Float64 soc_msg;
@@ -182,13 +181,13 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
     // Fault is a range ( anything < 10%)
     soc_msg.data = 2.2;
     m_fault_power_state_of_charge_pub.publish(soc_msg);
-    setPowerFaultsMessage(power_faults_msg, pf);
+    setPowerFaultsMessage(power_faults_msg, hardwareFault);
   }
   if(m_faults.instantaneous_capacity_loss_power_failure) {
     // (most recent and current). If the % difference is > 5% and no other tasks in progress, then fault. 
     soc_msg.data = 98.5; //random now but should be >5% more than the previous value
     m_fault_power_state_of_charge_pub.publish(soc_msg);
-    setPowerFaultsMessage(power_faults_msg, pf);
+    setPowerFaultsMessage(power_faults_msg, hardwareFault);
   }
   if(m_faults.thermal_power_failure){
     // if > 50 degrees C, then consider fault. 
@@ -196,7 +195,7 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
     setPowerTemperatureFaultValue(true);
     thermal_msg.data = powerTemperatureOverloadValue;
     m_fault_power_temp_pub.publish(thermal_msg);
-    setPowerFaultsMessage(power_faults_msg, pf);
+    setPowerFaultsMessage(power_faults_msg, hardwareFault);
   } else {
     setPowerTemperatureFaultValue(false);
   }


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️   | [Oceanwater-580](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-580) |
| ----------- | ----------- |
| EPIC ⚡| [Oceanwater-575](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-575) |
| Github :octocat:  | #68 (pre)  |


## Summary of Changes
* Added new ros msg file for Power Faults and new publisher /power_faults_status. This emulates the similar JPL messages that we build for the arm. JPL doesn't have their own messages for battery however, so we have only a shortlist of what to display, currently only Hardware errors. 

## Test
* click on faults for power and in another terminal type `rostopic echo /power_faults_status`. Value in message should be 1
* 
![image](https://user-images.githubusercontent.com/3445834/105411972-f4a61f00-5be8-11eb-9877-7fe7e1cebe4f.png)

