### PR TITLE
OCEANWATER-509 guarded move works for any direction

### DIFF
--- a/ow_lander/scripts/activity_guarded_move.py
+++ b/ow_lander/scripts/activity_guarded_move.py
@@ -114,7 +114,7 @@ def guarded_move_plan(move_arm, args):
   goal_pose.position.x -= direction_x*search_distance
   goal_pose.position.y -= direction_y*search_distance
   goal_pose.position.z -= direction_z*search_distance
-  move_arm.set_pose_target(goal_pose)
-  plan = move_arm.plan()
+  waypoints = [goal_pose]
+  plan, _ = move_arm.compute_cartesian_path(waypoints, 0.01, 0.0)
   print "Done planning safe part of guarded_move"
   return plan

--- a/ow_lander/scripts/ground_detection.py
+++ b/ow_lander/scripts/ground_detection.py
@@ -115,11 +115,9 @@ class GroundDetector:
       return False
     else:
       r = copy.deepcopy(self._reference_velocity)
-      r_norm = np.linalg.norm(r)
-      r /= r_norm
+      r /= np.linalg.norm(r)
       t = copy.deepcopy(self._trending_velocity.value)
-      t_norm = np.linalg.norm(t)
-      t /= t_norm
+      t /= np.linalg.norm(t)
       r_x_t = np.dot(r, t)
       return r_x_t < GroundDetector.DIRECTION_TOLERANCE
 


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️ | [OCEANWATER-509 / Guarded Move works for any direction](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-509) |
|:------- |:-------- |
| Jira Ticket 🎟️ | [OCEANWATER-587 / Guarded move works even when simulation has an increased real time update rate](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-509) |
| EPIC ⚡ | [OCEANWATER-87 / Arm Control](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-87) |

## Summary of Changes
* Implemented a mechanism to detect if the arm met the ground (or any obstacle) that works in any direction.
* Added the ability to skip a number of sample to avoid the initial set of outliers before establishing the threshold (renamed to reference vector).

## Test

### 1) Test guarded move under no speed up
1. Launch the simulation with your favorite world
```bash
roslaunch ow (atacama_y1a.launch | europa_terminator_workspace.launch | ...)
```

2. Invoke guarded move with varying sets of valid arguments (run multiple times in same session).
Use the following list as a guide but don't limit your imagination:
```bash
rosservice call /arm/guarded_move -- False 1.7 0.3 0.5 0 0 1 0.7
rosservice call /arm/guarded_move -- False 1.7 -0.3 0.5 0 0 1 0.7
rosservice call /arm/guarded_move -- False 1.9 -0.4 0.5 0 0 1 0.7
rosservice call /arm/guarded_move -- False 1.9 0.5 0.5 0 0 1 0.7
rosservice call /arm/guarded_move -- False 1.7 0.0 0.5 1 1 1 0.7
rosservice call /arm/guarded_move -- False 1.7 0.0 0.5 0.5 -0.5 1 0.8
```
### 2) Test guarded move with simulation speed up
Set **real_time_update_rate** to zero in the world file (within ow_europa) that matches the launch script and repeat steps in first test