### PR TITLE
Add the missing dependency

### DIFF
--- a/oceanwaters/doc/setup_dev_env.md
+++ b/oceanwaters/doc/setup_dev_env.md
@@ -164,6 +164,7 @@ sudo apt install git \
                  ros-melodic-joint-state-publisher \
                  ros-melodic-joint-state-controller \
                  ros-melodic-effort-controllers \
+                 ros-melodic-joint-trajectory-controller \
                  ros-melodic-dynamic-reconfigure \
                  ros-melodic-nodelet \
                  ros-melodic-nodelet-topic-tools \


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️   | [OCEANWATER-590 / add missing ros-melodic-joint-trajectory-controller dependency ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-590) |
| ----------- | ----------- |
| EPIC ⚡| [OCEANWATER-518 / Switch to using JointTrajectoryController ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-518) |
| Github :octocat:  | Closes #72 |


## Summary of Changes
* Add a missing dependency to the setup instructions `ros-melodic-joint-trajectory-controller`

## Test
* N/A
