### PR TITLE
Use default version of OpenCV on current platform + Use catkin default c++ standard

### DIFF
--- a/ow_dynamic_terrain/CMakeLists.txt
+++ b/ow_dynamic_terrain/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
   cv_bridge
 )
 
-find_package(OpenCV 3 REQUIRED
+find_package(OpenCV REQUIRED
   core
 )
 

--- a/ow_dynamic_terrain/CMakeLists.txt
+++ b/ow_dynamic_terrain/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ow_dynamic_terrain)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
-add_compile_options(-std=c++11)
-
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages

--- a/ow_ephemeris/CMakeLists.txt
+++ b/ow_ephemeris/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ow_ephemeris)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
-
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages

--- a/ow_faults/CMakeLists.txt
+++ b/ow_faults/CMakeLists.txt
@@ -3,9 +3,6 @@ project(ow_faults)
 
 set(EXEC_NAME faults)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++14)
-
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages

--- a/ow_power_system/CMakeLists.txt
+++ b/ow_power_system/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ow_power_system)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
-
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-577 / Support for ROS Noetic](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-577) |
| :----------- | :----------- |
| Jira Ticket 🎟️   | [OCEANWATER-578 / Remove strict requirement on OpenCV 3.0 in ow_dynamic_terrain ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-578) |
| Jira Ticket 🎟️   | [OCEANWATER-593 / Don't explicitly set a required C++ standard unless absolutely needed ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-593) |


## Summary of Changes
This is a single iteration at our effort to support **ROS Noetic**, these following changes are necessary and does't break **ROS Melodic** compilation: 
* Use default version of OpenCV on current platform 
* Use catkin default c++ standard

## Test
* Make sure the system still successfully compiles against **ROS Melodic**
* If you happen to have an Ubuntu 20.04 system with all the prerequisites for OceanWATERS then you may verify that ow_dynamic_terrain doesn't fail due to a requiring OpenCV 3.0 
