### PR TITLE
minor reformatting to the template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,7 @@
 ## Linked Issues:
-| Jira Ticket 🎟️   | [Oceanwater-XXX](url) |
-| ----------- | ----------- |
-| EPIC ⚡| [Oceanwater-XXX](url) |
+| EPIC ⚡| [OCEANWATER-XXX](url) |
+| :----------- | :----------- |
+| Jira Ticket 🎟️   | [OCEANWATER-XXX](url) |
 | Github :octocat:  | # |
 
 


### PR DESCRIPTION
## Linked Issues:
None

## Summary of Changes
* A minor reformatting to the pull request template in which the epic is moved to the top of the table for the following reasons:
  - GitHub renders the first line differently than the rest of the rows
  - It is unlikely that a PR would use more than one EPIC, meanwhile a PR can address multiple Jira Tickets
* Use left align for the text of first line  
* Use all caps for the tickets prefix (to be consistent with Jira)

## Test
* Refer to #74 for an example on how the template would look like after the restructuring
