### PR TITLE
Oceanwater 592 remove qt4

### DIFF
--- a/ow_gazebo_plugins/CMakeLists.txt
+++ b/ow_gazebo_plugins/CMakeLists.txt
@@ -14,28 +14,6 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(gazebo REQUIRED)
 find_package(OGRE REQUIRED)
 
-if("${GAZEBO_MAJOR_VERSION}" STREQUAL "9")
-  message(STATUS "FOUND QT 5")
-  find_package(Qt5Widgets REQUIRED)
-  find_package(Qt5Xml REQUIRED)
-  if (Qt5_POSITION_INDEPENDENT_CODE)
-    SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
-  endif()
-  include_directories(SYSTEM "${Qt5Widgets_INCLUDE_DIRS}")
-  include_directories(SYSTEM "${Qt5Xml_INCLUDE_DIRS}")
-  set(QT_QTXML_LIBRARY Qt5::Xml)
-  set(QT_QTCORE_LIBRARY Qt5::Widgets)
-  set( RPGSIM_USE_QT5 TRUE )
-else()
-  message(STATUS "FOUND QT 4")
-  find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
-  include(${QT_USE_FILE})
-  include_directories(SYSTEM "${QT_INCLUDE_DIR}")
-  include_directories(SYSTEM "${QT_QTXML_INCLUDE_DIR}")
-  include_directories(SYSTEM "${QT_QTCORE_INCLUDE_DIR}")
-endif()
-
-
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️   | [Oceanwater-592](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-592) |
| ----------- | ----------- |
| EPIC ⚡| [Oceanwater-577](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-577) |


## Summary of Changes
* Removed Qt requirement from ow_gazebo_plugins as it is not being used.

## Test
* compile the workspace
