### PR TITLE
Require C++17 for ow_dynamic_terrain on Noetic

### DIFF
--- a/ow_dynamic_terrain/CMakeLists.txt
+++ b/ow_dynamic_terrain/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ow_dynamic_terrain)
 
+## libiginition-math6-dev which is a dependency of this module seem to require
+## the C++17 standard when compiling against ros noetic distro.
+if("$ENV{ROS_DISTRO}" STREQUAL "noetic")
+  add_compile_options(-std=c++17)
+endif()
+
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡| [Oceanwater-577 / Support for ROS Noetic ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-577) |
| :---------- | :---------- |
| Jira Ticket 🎟️   | [Oceanwater-597 / Resolve compile errors stemming from ignite library against ros noetic](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-597) |


## Summary of Changes
* Require C++17 for ow_dynamic_terrain on Noetic only

## Test
* Using a clean build, make sure the project still compiles with no issues towards **ros-melodic**
* If you happen to have an Ubuntu 20.04 with **ros-noetic** installed, verify that **ow_dynamic_terrain** package can compile successfully.
