### PR TITLE
Oceanwater 603 power faults bitmask

### DIFF
--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -48,15 +48,16 @@ public:
     VelocityLimit=7, 
     NoForceData=8};
 
-	static constexpr std::bitset<9> isSystem{		0b0'0000'0001 };
-	static constexpr std::bitset<9> isArmGoalError{		0b0'0000'0010 };
-	static constexpr std::bitset<9> isArmExecutionError{		0b0'0000'0100 };
-	static constexpr std::bitset<9> isTaskGoalError{	0b0'000'1000 };
-	static constexpr std::bitset<9> isCamGoalError{	0b0'0001'0000 };
-	static constexpr std::bitset<9> isCamExecutionError{	0b0'0010'0000 };
-	static constexpr std::bitset<9> isPanTiltGoalError{		0b0'0100'0000 };
-	static constexpr std::bitset<9> isPanTiltExecutionError{	0b0'1000'0000 };
-	static constexpr std::bitset<9> isLanderExecutionError{	0b1'0000'0000 };
+	static constexpr std::bitset<10> isSystem{		0b00'0000'0001 };
+	static constexpr std::bitset<10> isArmGoalError{		0b00'0000'0010 };
+	static constexpr std::bitset<10> isArmExecutionError{		0b00'0000'0100 };
+	static constexpr std::bitset<10> isTaskGoalError{	0b00'000'1000 };
+	static constexpr std::bitset<10> isCamGoalError{	0b00'0001'0000 };
+	static constexpr std::bitset<10> isCamExecutionError{	0b00'0010'0000 };
+	static constexpr std::bitset<10> isPanTiltGoalError{		0b00'0100'0000 };
+	static constexpr std::bitset<10> isPanTiltExecutionError{	0b00'1000'0000 };
+	static constexpr std::bitset<10> isLanderExecutionError{	0b01'0000'0000 };
+	static constexpr std::bitset<10> isPowerSystemFault{	0b10'0000'0000 };
   
 private:
   float powerTemperatureOverloadValue;
@@ -69,7 +70,7 @@ private:
   void jointStateCb(const sensor_msgs::JointStateConstPtr& msg);
 
   //Setting the correct values for system faults and arm faults messages
-  void setSytemFaultsMessage(ow_faults::SystemFaults& msg, std::bitset<9> systemFaultsBitmask);
+  void setSytemFaultsMessage(ow_faults::SystemFaults& msg, std::bitset<10> systemFaultsBitmask);
   void setArmFaultsMessage(ow_faults::ArmFaults& msg, int value);
   void setPowerFaultsMessage(ow_faults::PowerFaults& msg, int value);
 

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -41,7 +41,7 @@ void FaultInjector::faultsConfigCb(ow_faults::FaultsConfig& faults, uint32_t lev
   m_faults = faults;
 }
 
-void FaultInjector::setSytemFaultsMessage(ow_faults::SystemFaults& msg, std::bitset<9> systemFaultsBitmask) {
+void FaultInjector::setSytemFaultsMessage(ow_faults::SystemFaults& msg, std::bitset<10> systemFaultsBitmask) {
   // for now only arm execution errors
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = "/world";

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -8,8 +8,9 @@
 using namespace std;
 using namespace ow_lander;
 
-constexpr std::bitset<9> FaultInjector::isPanTiltExecutionError;
-constexpr std::bitset<9> FaultInjector::isArmExecutionError;
+constexpr std::bitset<10> FaultInjector::isPanTiltExecutionError;
+constexpr std::bitset<10> FaultInjector::isArmExecutionError;
+constexpr std::bitset<10> FaultInjector::isPowerSystemFault;
 
 FaultInjector::FaultInjector(ros::NodeHandle node_handle)
 {
@@ -90,7 +91,7 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
 
   ComponentFaults hardwareFault = Hardware;
 
-  std::bitset<9> systemFaultsBitmask{};
+  std::bitset<10> systemFaultsBitmask{};
 
   //arm faults
   // Set failed sensor values to 0
@@ -180,7 +181,6 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
     setArmFaultsMessage(arm_faults_msg,hardwareFault);
   }
 
-  setSytemFaultsMessage(system_faults_msg, systemFaultsBitmask);
 
   std_msgs::Float64 soc_msg;
 
@@ -190,12 +190,14 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
     soc_msg.data = 2.2;
     m_fault_power_state_of_charge_pub.publish(soc_msg);
     setPowerFaultsMessage(power_faults_msg, hardwareFault);
+    systemFaultsBitmask |= isPowerSystemFault;
   }
   if(m_faults.instantaneous_capacity_loss_power_failure) {
     // (most recent and current). If the % difference is > 5% and no other tasks in progress, then fault. 
     soc_msg.data = 98.5; //random now but should be >5% more than the previous value
     m_fault_power_state_of_charge_pub.publish(soc_msg);
     setPowerFaultsMessage(power_faults_msg, hardwareFault);
+    systemFaultsBitmask |= isPowerSystemFault;
   }
   if(m_faults.thermal_power_failure){
     // if > 50 degrees C, then consider fault. 
@@ -204,9 +206,12 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
     thermal_msg.data = powerTemperatureOverloadValue;
     m_fault_power_temp_pub.publish(thermal_msg);
     setPowerFaultsMessage(power_faults_msg, hardwareFault);
+    systemFaultsBitmask |= isPowerSystemFault;
   } else {
     setPowerTemperatureFaultValue(false);
   }
+
+  setSytemFaultsMessage(system_faults_msg, systemFaultsBitmask);
 
   m_joint_state_pub.publish(output);
   m_fault_status_pub.publish(system_faults_msg);


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️   | [Oceanwater-603](urlhttps://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-603 |
| ----------- | ----------- |
| EPIC ⚡| [Oceanwater-551](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-551) |
| Github :octocat:  | depends on #82  |


## Summary of Changes
* added power faults to bitmask for System Faults

## Test
* launch any ow launch file
* rostopic echo /system_faults_status
* go into rqt dynamic reconfigure and check the power faults (or any others)
* observe the value change on rostopic echo
