### PR TITLE
Implement Stow/Unstow using trajectory async executer + Add an arm stop command

### DIFF
--- a/ow_lander/CMakeLists.txt
+++ b/ow_lander/CMakeLists.txt
@@ -21,6 +21,7 @@ add_service_files(
   PublishTrajectory.srv
   Stow.srv
   Unstow.srv
+  Stop.srv
 )
 
 add_message_files(

--- a/ow_lander/srv/Stop.srv
+++ b/ow_lander/srv/Stop.srv
@@ -1,0 +1,3 @@
+---
+bool success
+string message


### PR DESCRIPTION
Add an Arm Stop command

## Linked Issues:
| EPIC ⚡| [OCEANWATER-518 / Switch to using effort_controllers/JointTrajectoryController](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-518) |
| :---------- | :---------- |
| Jira Ticket 🎟️   | [OCEANWATER-604 / Implement Stow/Unstow using TrajectoryAsyncExecuter](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-604) |
| Github :octocat:  |  related to #81  |


## Summary of Changes
* Implement **Stow** / **Unstow** arm services using TrajectoryAsyncExecuter
* Add an arm stop command

## Test
Launch the simulation
```bash
roslaunch ow atacama_y1a.launch
```
Execute either **Stow** or **Unstow** through RQT Service Call or using the commands 
```bash
rosservice call /arm/unstow 
rosservice call /arm/stow 
```
To stop the arm at any point (applies only to **Stow**, **Unstow** activities and the last segment of **MoveGuarded**), then open another terminal and invoke the following service:
```bash
rosservice call /arm/stop
```
