### PR TITLE
Oceanwater 605 antennae faults in rqt

### DIFF
--- a/ow_faults/CMakeLists.txt
+++ b/ow_faults/CMakeLists.txt
@@ -54,6 +54,7 @@ add_message_files(
   SystemFaults.msg
   ArmFaults.msg
   PowerFaults.msg
+  PTFaults.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/ow_faults/cfg/Faults.cfg
+++ b/ow_faults/cfg/Faults.cfg
@@ -10,13 +10,14 @@ joint_state_enum = gen.enum([gen.const("nominal",  int_t, 0, "Joint is functioni
                              gen.const("frozen",   int_t, 2, "Joint is frozen in position"),
                              gen.const("friction", int_t, 3, "Joint is consuming extra power")],
                             "An enum to set joint state")
-# ARM FAULTS
+# ANTENNAE FAULTS
 gen.add("ant_pan_encoder_failure",       bool_t,   0, "Antenna pan encoder failure",       False)
 gen.add("ant_pan_torque_sensor_failure", bool_t,   0, "Antenna pan torque sensor failure", False)
 
 gen.add("ant_tilt_encoder_failure",       bool_t,   0, "Antenna tilt encoder failure",       False)
 gen.add("ant_tilt_torque_sensor_failure", bool_t,   0, "Antenna tilt torque sensor failure", False)
 
+# ARM FAULTS
 gen.add("shou_yaw_encoder_failure",       bool_t,   0, "Shoulder yaw encoder failure",       False)
 gen.add("shou_yaw_torque_sensor_failure", bool_t,   0, "Shoulder yaw torque sensor failure", False)
 
@@ -39,10 +40,6 @@ gen.add("scoop_yaw_torque_sensor_failure", bool_t,   0, "Scoop yaw torque sensor
 gen.add("low_state_of_charge_power_failure", bool_t,   0, "Low state of charge power failure", False)
 gen.add("instantaneous_capacity_loss_power_failure", bool_t,   0, "Instantaneous capcity loss power failure", False)
 gen.add("thermal_power_failure", bool_t,   0, "Thermal power failure", False)
-
-# ANTENNAE FAULTS
-gen.add("antennae_pan_failure", bool_t,   0, "Antennae pan failure", False)
-gen.add("antennae_tilt_failure", bool_t,   0, "Antennae tilt failure", False)
 
 exit(gen.generate(PACKAGE, "faults", "Faults"))
 

--- a/ow_faults/cfg/Faults.cfg
+++ b/ow_faults/cfg/Faults.cfg
@@ -40,5 +40,9 @@ gen.add("low_state_of_charge_power_failure", bool_t,   0, "Low state of charge p
 gen.add("instantaneous_capacity_loss_power_failure", bool_t,   0, "Instantaneous capcity loss power failure", False)
 gen.add("thermal_power_failure", bool_t,   0, "Thermal power failure", False)
 
+# ANTENNAE FAULTS
+gen.add("antennae_pan_failure", bool_t,   0, "Antennae pan failure", False)
+gen.add("antennae_tilt_failure", bool_t,   0, "Antennae tilt failure", False)
+
 exit(gen.generate(PACKAGE, "faults", "Faults"))
 

--- a/ow_faults/cfg/Faults.cfg
+++ b/ow_faults/cfg/Faults.cfg
@@ -10,7 +10,7 @@ joint_state_enum = gen.enum([gen.const("nominal",  int_t, 0, "Joint is functioni
                              gen.const("frozen",   int_t, 2, "Joint is frozen in position"),
                              gen.const("friction", int_t, 3, "Joint is consuming extra power")],
                             "An enum to set joint state")
-# ANTENNAE FAULTS
+# ANTENNA FAULTS
 gen.add("ant_pan_encoder_failure",       bool_t,   0, "Antenna pan encoder failure",       False)
 gen.add("ant_pan_torque_sensor_failure", bool_t,   0, "Antenna pan torque sensor failure", False)
 
@@ -42,4 +42,3 @@ gen.add("instantaneous_capacity_loss_power_failure", bool_t,   0, "Instantaneous
 gen.add("thermal_power_failure", bool_t,   0, "Thermal power failure", False)
 
 exit(gen.generate(PACKAGE, "faults", "Faults"))
-

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -74,7 +74,7 @@ private:
   // simple message faults that don't need to be simulated at their source.
   void jointStateCb(const sensor_msgs::JointStateConstPtr& msg);
 
-  //Setting the correct values for system faults and arm faults messages
+  //Setting the correct values for faults messages via function overloading
   //System Faults
   void setFaultsMessage(ow_faults::SystemFaults& msg, std::bitset<10> systemFaultsBitmask);
   // Arm Faults

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -9,6 +9,7 @@
 #include <ctime>
 #include <cstdlib>
 #include <ros/ros.h>
+#include <cstdint>
 #include <std_msgs/Float64.h>
 #include <ow_faults/FaultsConfig.h>
 #include "ow_faults/SystemFaults.h"
@@ -38,7 +39,7 @@ public:
 
   enum Nominal { None=0 };
 
-  enum class ComponentFaults : int {
+  enum class ComponentFaults : uint {
     // general
     Hardware = 1, 
     //pt

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -29,6 +29,7 @@
 // placeholder fault estimator.
 class FaultInjector
 {
+
 public:
   FaultInjector(ros::NodeHandle node_handle);
   ~FaultInjector(){}
@@ -74,10 +75,14 @@ private:
   void jointStateCb(const sensor_msgs::JointStateConstPtr& msg);
 
   //Setting the correct values for system faults and arm faults messages
-  void setSytemFaultsMessage(ow_faults::SystemFaults& msg, std::bitset<10> systemFaultsBitmask);
-  void setArmFaultsMessage(ow_faults::ArmFaults& msg, int value);
-  void setPowerFaultsMessage(ow_faults::PowerFaults& msg, int value);
-  void setPTFaultsMessage(ow_faults::PTFaults& msg, int value);
+  //System Faults
+  void setFaultsMessage(ow_faults::SystemFaults& msg, std::bitset<10> systemFaultsBitmask);
+  // Arm Faults
+  void setFaultsMessage(ow_faults::ArmFaults& msg, ComponentFaults value);
+  //Power Faults
+  void setFaultsMessage(ow_faults::PowerFaults& msg, ComponentFaults value);
+  //Pan Tilt Faults
+  void setFaultsMessage(ow_faults::PTFaults& msg, ComponentFaults value);
 
   // Find an item in an std::vector or other find-able data structure, and
   // return its index. Return -1 if not found.
@@ -107,6 +112,5 @@ private:
   // Map ow_lander::joint_t enum values to indices in JointState messages
   std::vector<unsigned int> m_joint_state_indices;
 };
-
 
 #endif

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -14,6 +14,7 @@
 #include "ow_faults/SystemFaults.h"
 #include "ow_faults/ArmFaults.h"
 #include "ow_faults/PowerFaults.h"
+#include "ow_faults/PTFaults.h"
 #include <ow_lander/lander_joints.h>
 #include <sensor_msgs/JointState.h>
 #include <unordered_map>
@@ -39,14 +40,17 @@ public:
   enum ComponentFaults {
     // general
     Hardware=1, 
+    //pt
+    JointLimit = 2,
     //arm 
-    TrajectoryGeneration=2, 
+    TrajectoryGeneration = 2,
     Collision=3, 
     Estop=4, 
     PositionLimit=5, 
     TorqueLimit=6, 
     VelocityLimit=7, 
-    NoForceData=8};
+    NoForceData=8
+    };
 
 	static constexpr std::bitset<10> isSystem{		0b00'0000'0001 };
 	static constexpr std::bitset<10> isArmGoalError{		0b00'0000'0010 };
@@ -73,6 +77,7 @@ private:
   void setSytemFaultsMessage(ow_faults::SystemFaults& msg, std::bitset<10> systemFaultsBitmask);
   void setArmFaultsMessage(ow_faults::ArmFaults& msg, int value);
   void setPowerFaultsMessage(ow_faults::PowerFaults& msg, int value);
+  void setPTFaultsMessage(ow_faults::PTFaults& msg, int value);
 
   // Find an item in an std::vector or other find-able data structure, and
   // return its index. Return -1 if not found.
@@ -97,6 +102,7 @@ private:
   ros::Publisher m_fault_status_pub;
   ros::Publisher m_arm_fault_status_pub;
   ros::Publisher m_power_fault_status_pub;
+  ros::Publisher m_antennae_fault_status_pub;
 
   // Map ow_lander::joint_t enum values to indices in JointState messages
   std::vector<unsigned int> m_joint_state_indices;

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -39,17 +39,17 @@ public:
 
   enum class ComponentFaults : int {
     // general
-    Hardware=1, 
+    Hardware = 1, 
     //pt
     JointLimit = 2,
     //arm 
     TrajectoryGeneration = 2,
-    Collision=3, 
-    Estop=4, 
-    PositionLimit=5, 
-    TorqueLimit=6, 
-    VelocityLimit=7, 
-    NoForceData=8
+    Collision = 3, 
+    Estop = 4, 
+    PositionLimit = 5, 
+    TorqueLimit = 6, 
+    VelocityLimit = 7, 
+    NoForceData = 8
     };
 
 	static constexpr std::bitset<10> isSystem{		0b00'0000'0001 };

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -37,7 +37,7 @@ public:
 
   enum Nominal { None=0 };
 
-  enum ComponentFaults {
+  enum class ComponentFaults : int {
     // general
     Hardware=1, 
     //pt

--- a/ow_faults/msg/ArmFaults.msg
+++ b/ow_faults/msg/ArmFaults.msg
@@ -1,3 +1,4 @@
 # Arm Fault Status 
+# Value is the fault classification. See enums class in FaultInjector.h
 Header header
 uint32 value

--- a/ow_faults/msg/PTFaults.msg
+++ b/ow_faults/msg/PTFaults.msg
@@ -1,0 +1,3 @@
+#Pan/Tilt fault status
+Header header
+int32 value

--- a/ow_faults/msg/PTFaults.msg
+++ b/ow_faults/msg/PTFaults.msg
@@ -1,3 +1,3 @@
 #Pan/Tilt fault status
 Header header
-int32 value
+uint32 value

--- a/ow_faults/msg/PTFaults.msg
+++ b/ow_faults/msg/PTFaults.msg
@@ -1,3 +1,4 @@
 #Pan/Tilt fault status
+# Value is the fault classification. See enums class in FaultInjector.h
 Header header
 uint32 value

--- a/ow_faults/msg/PowerFaults.msg
+++ b/ow_faults/msg/PowerFaults.msg
@@ -1,3 +1,4 @@
 # Power Fault Status 
+# Value is the fault classification. See enums class in FaultInjector.h
 Header header
 uint32 value

--- a/ow_faults/msg/SystemFaults.msg
+++ b/ow_faults/msg/SystemFaults.msg
@@ -1,7 +1,5 @@
 # System Fault Status Mask
-Header header
-uint64 value
-
+# Value is the fault classification. See bitmask in FaultInjector.h for implementation of the following:
 # System=1, 
 # ArmGoalError=2, 
 # ArmExecutionError=4,
@@ -11,3 +9,6 @@ uint64 value
 # PtGoalError=64, 
 # PtExecutionError=128, 
 # LanderExecutionError = 256
+Header header
+uint64 value
+

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -67,7 +67,7 @@ void FaultInjector::setPowerFaultsMessage(ow_faults::PowerFaults& msg, int value
 void FaultInjector::setPTFaultsMessage(ow_faults::PTFaults& msg, int value) {
   // for now only arm execution errors
   msg.header.stamp = ros::Time::now();
-  msg.header.frame_id = "/world";
+  msg.header.frame_id = "world";
   msg.value = value; //should be HARDWARE for now
 }
 

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -221,15 +221,10 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
     setPowerTemperatureFaultValue(false);
   }
 
-  if (m_faults.antennae_pan_failure){
+  if (m_faults.antennae_pan_failure || m_faults.antennae_tilt_failure) {
     systemFaultsBitmask |= isPanTiltExecutionError;
     setPTFaultsMessage(pt_faults_msg,hardwareFault);
   }
-  if (m_faults.antennae_tilt_failure) {
-    systemFaultsBitmask |= isPanTiltExecutionError;
-    setPTFaultsMessage(pt_faults_msg,hardwareFault);
-  }
-
   setSytemFaultsMessage(system_faults_msg, systemFaultsBitmask);
 
   m_joint_state_pub.publish(output);

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -43,32 +43,36 @@ void FaultInjector::faultsConfigCb(ow_faults::FaultsConfig& faults, uint32_t lev
   m_faults = faults;
 }
 
-void FaultInjector::setSytemFaultsMessage(ow_faults::SystemFaults& msg, std::bitset<10> systemFaultsBitmask) {
-  // for now only arm execution errors
-  msg.header.stamp = ros::Time::now();
-  msg.header.frame_id = "/world";
-  msg.value = systemFaultsBitmask.to_ullong(); 
-}
-
-void FaultInjector::setArmFaultsMessage(ow_faults::ArmFaults& msg, int value) {
-  // for now only arm execution errors
-  msg.header.stamp = ros::Time::now();
-  msg.header.frame_id = "/world";
-  msg.value = value; //should be HARDWARE for now
-}
-
-void FaultInjector::setPowerFaultsMessage(ow_faults::PowerFaults& msg, int value) {
-  // for now only arm execution errors
-  msg.header.stamp = ros::Time::now();
-  msg.header.frame_id = "/world";
-  msg.value = value; //should be HARDWARE for now
-}
-
-void FaultInjector::setPTFaultsMessage(ow_faults::PTFaults& msg, int value) {
+//Setting System Faults Message
+void FaultInjector::setFaultsMessage(ow_faults::SystemFaults& msg, std::bitset<10> systemFaultsBitmask) {
   // for now only arm execution errors
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = "world";
-  msg.value = value; //should be HARDWARE for now
+  msg.value = systemFaultsBitmask.to_ullong(); 
+}
+
+//Setting Arm Faults Message
+void FaultInjector::setFaultsMessage(ow_faults::ArmFaults& msg, ComponentFaults value) {
+  // for now only arm execution errors
+  msg.header.stamp = ros::Time::now();
+  msg.header.frame_id = "world";
+  msg.value = static_cast<int>(value); //should be HARDWARE for now
+}
+
+//Setting Power Faults Message
+void FaultInjector::setFaultsMessage(ow_faults::PowerFaults& msg, ComponentFaults value) {
+  // for now only arm execution errors
+  msg.header.stamp = ros::Time::now();
+  msg.header.frame_id = "world";
+  msg.value = static_cast<int>(value); //should be HARDWARE for now
+}
+
+//Setting Pant Tilt Faults Message
+void FaultInjector::setFaultsMessage(ow_faults::PTFaults& msg, ComponentFaults value) {
+  // for now only arm execution errors
+  msg.header.stamp = ros::Time::now();
+  msg.header.frame_id = "world";
+  msg.value = static_cast<int>(value); //should be HARDWARE for now
 }
 
 void FaultInjector::setPowerTemperatureFaultValue(bool getTempBool){
@@ -94,119 +98,122 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
   }
 
   sensor_msgs::JointState output(*msg);
+  std_msgs::Float64 soc_msg;
+
   ow_faults::SystemFaults system_faults_msg;
   ow_faults::ArmFaults arm_faults_msg;
   ow_faults::PowerFaults power_faults_msg;
   ow_faults::PTFaults pt_faults_msg;
 
-  ComponentFaults hardwareFault = Hardware;
-
+  ComponentFaults hardwareFault =  ComponentFaults::Hardware;
   std::bitset<10> systemFaultsBitmask{};
 
-  //arm faults
   // Set failed sensor values to 0
   unsigned int index;
+
+  //pant tilt faults
   if (m_faults.ant_pan_encoder_failure && findJointIndex(J_ANT_PAN, index)) {
     output.position[index] = 0.0;
     systemFaultsBitmask |= isPanTiltExecutionError;
+    setFaultsMessage(pt_faults_msg,hardwareFault);
   }
   if (m_faults.ant_pan_torque_sensor_failure && findJointIndex(J_ANT_PAN, index)) {
     output.effort[index] = 0.0;
     systemFaultsBitmask |= isPanTiltExecutionError;
+    setFaultsMessage(pt_faults_msg,hardwareFault);
   }
 
   if (m_faults.ant_tilt_encoder_failure && findJointIndex(J_ANT_TILT, index)) {
     output.position[index] = 0.0;
     systemFaultsBitmask |= isPanTiltExecutionError;
-
+    setFaultsMessage(pt_faults_msg,hardwareFault);
   }
   if (m_faults.ant_tilt_torque_sensor_failure && findJointIndex(J_ANT_TILT, index)) {
     output.effort[index] = 0.0;
     systemFaultsBitmask |= isPanTiltExecutionError;
+    setFaultsMessage(pt_faults_msg,hardwareFault);
   }
 
+  //arm faults
   if (m_faults.shou_yaw_encoder_failure && findJointIndex(J_SHOU_YAW, index)) {
     output.position[index] = 0.0;
     systemFaultsBitmask |= isArmExecutionError;
-    setArmFaultsMessage(arm_faults_msg,hardwareFault);
+    setFaultsMessage(arm_faults_msg,hardwareFault);
   }
   if (m_faults.shou_yaw_torque_sensor_failure && findJointIndex(J_SHOU_YAW, index)) {
     output.effort[index] = 0.0;
     systemFaultsBitmask |= isArmExecutionError;
-    setArmFaultsMessage(arm_faults_msg,hardwareFault);
+    setFaultsMessage(arm_faults_msg,hardwareFault);
   }
 
   if (m_faults.shou_pitch_encoder_failure && findJointIndex(J_SHOU_PITCH, index)) {
     output.position[index] = 0.0;
     systemFaultsBitmask |= isArmExecutionError;
-    setArmFaultsMessage(arm_faults_msg,hardwareFault);
+    setFaultsMessage(arm_faults_msg,hardwareFault);
   }
   if (m_faults.shou_pitch_torque_sensor_failure && findJointIndex(J_SHOU_PITCH, index)) {
     output.effort[index] = 0.0;
     systemFaultsBitmask |= isArmExecutionError;
-    setArmFaultsMessage(arm_faults_msg,hardwareFault);
+    setFaultsMessage(arm_faults_msg,hardwareFault);
   }
 
   if (m_faults.prox_pitch_encoder_failure && findJointIndex(J_PROX_PITCH, index)) {
     output.position[index] = 0.0;
     systemFaultsBitmask |= isArmExecutionError;
-    setArmFaultsMessage(arm_faults_msg,hardwareFault);
+    setFaultsMessage(arm_faults_msg,hardwareFault);
   }
   if (m_faults.prox_pitch_torque_sensor_failure && findJointIndex(J_PROX_PITCH, index)) {
     output.effort[index] = 0.0;
     systemFaultsBitmask |= isArmExecutionError;
-    setArmFaultsMessage(arm_faults_msg,hardwareFault);
+    setFaultsMessage(arm_faults_msg,hardwareFault);
   }
 
   if (m_faults.dist_pitch_encoder_failure && findJointIndex(J_DIST_PITCH, index)) {
     output.position[index] = 0.0;
     systemFaultsBitmask |= isArmExecutionError;
-    setArmFaultsMessage(arm_faults_msg,hardwareFault);
+    setFaultsMessage(arm_faults_msg,hardwareFault);
   }
   if (m_faults.dist_pitch_torque_sensor_failure && findJointIndex(J_DIST_PITCH, index)) {
     output.effort[index] = 0.0;
     systemFaultsBitmask |= isArmExecutionError;
-    setArmFaultsMessage(arm_faults_msg,hardwareFault);
+    setFaultsMessage(arm_faults_msg,hardwareFault);
   }
 
   if (m_faults.hand_yaw_encoder_failure && findJointIndex(J_HAND_YAW, index)) {
     output.position[index] = 0.0;
     systemFaultsBitmask |= isArmExecutionError;
-    setArmFaultsMessage(arm_faults_msg,hardwareFault);
+    setFaultsMessage(arm_faults_msg,hardwareFault);
   }
   if (m_faults.hand_yaw_torque_sensor_failure && findJointIndex(J_HAND_YAW, index)) {
     output.effort[index] = 0.0;
     systemFaultsBitmask |= isArmExecutionError;
-    setArmFaultsMessage(arm_faults_msg,hardwareFault);
+    setFaultsMessage(arm_faults_msg,hardwareFault);
   }
 
   if (m_faults.scoop_yaw_encoder_failure && findJointIndex(J_SCOOP_YAW, index)) {
     output.position[index] = 0.0;
     systemFaultsBitmask |= isArmExecutionError;
-    setArmFaultsMessage(arm_faults_msg,hardwareFault);
+    setFaultsMessage(arm_faults_msg,hardwareFault);
   }
   if (m_faults.scoop_yaw_torque_sensor_failure && findJointIndex(J_SCOOP_YAW, index)) {
     output.effort[index] = 0.0;
     systemFaultsBitmask |= isArmExecutionError;
-    setArmFaultsMessage(arm_faults_msg,hardwareFault);
+    setFaultsMessage(arm_faults_msg,hardwareFault);
   }
-
-
-  std_msgs::Float64 soc_msg;
 
   // power faults
   if(m_faults.low_state_of_charge_power_failure) {
     // Fault is a range ( anything < 10%)
     soc_msg.data = 2.2;
     m_fault_power_state_of_charge_pub.publish(soc_msg);
-    setPowerFaultsMessage(power_faults_msg, hardwareFault);
+    setFaultsMessage(power_faults_msg, hardwareFault);
     systemFaultsBitmask |= isPowerSystemFault;
   }
   if(m_faults.instantaneous_capacity_loss_power_failure) {
     // (most recent and current). If the % difference is > 5% and no other tasks in progress, then fault. 
     soc_msg.data = 98.5; //random now but should be >5% more than the previous value
     m_fault_power_state_of_charge_pub.publish(soc_msg);
-    setPowerFaultsMessage(power_faults_msg, hardwareFault);
+    setFaultsMessage(power_faults_msg, hardwareFault);
     systemFaultsBitmask |= isPowerSystemFault;
   }
   if(m_faults.thermal_power_failure){
@@ -215,17 +222,13 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
     setPowerTemperatureFaultValue(true);
     thermal_msg.data = powerTemperatureOverloadValue;
     m_fault_power_temp_pub.publish(thermal_msg);
-    setPowerFaultsMessage(power_faults_msg, hardwareFault);
+    setFaultsMessage(power_faults_msg, hardwareFault);
     systemFaultsBitmask |= isPowerSystemFault;
   } else {
     setPowerTemperatureFaultValue(false);
   }
 
-  if (m_faults.antennae_pan_failure || m_faults.antennae_tilt_failure) {
-    systemFaultsBitmask |= isPanTiltExecutionError;
-    setPTFaultsMessage(pt_faults_msg,hardwareFault);
-  }
-  setSytemFaultsMessage(system_faults_msg, systemFaultsBitmask);
+  setFaultsMessage(system_faults_msg, systemFaultsBitmask);
 
   m_joint_state_pub.publish(output);
   m_fault_status_pub.publish(system_faults_msg);

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -56,7 +56,7 @@ void FaultInjector::setFaultsMessage(ow_faults::ArmFaults& msg, ComponentFaults 
   // for now only arm execution errors
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = "world";
-  msg.value = static_cast<int>(value); //should be HARDWARE for now
+  msg.value = static_cast<uint>(value); //should be HARDWARE for now
 }
 
 //Setting Power Faults Message
@@ -64,7 +64,7 @@ void FaultInjector::setFaultsMessage(ow_faults::PowerFaults& msg, ComponentFault
   // for now only arm execution errors
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = "world";
-  msg.value = static_cast<int>(value); //should be HARDWARE for now
+  msg.value = static_cast<uint>(value); //should be HARDWARE for now
 }
 
 //Setting Pant Tilt Faults Message
@@ -72,7 +72,7 @@ void FaultInjector::setFaultsMessage(ow_faults::PTFaults& msg, ComponentFaults v
   // for now only arm execution errors
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = "world";
-  msg.value = static_cast<int>(value); //should be HARDWARE for now
+  msg.value = static_cast<uint>(value); //should be HARDWARE for now
 }
 
 void FaultInjector::setPowerTemperatureFaultValue(bool getTempBool){


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️   | [Oceanwater-605](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-605) |
| ----------- | ----------- |
| EPIC ⚡| [Oceanwater-551](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-551) |
| Github :octocat:  | na |


## Summary of Changes
* New pant and tilt faults in Rqt
* on select, populate JPL messages for pan/tilt message in /pt_faults_status

## Test
* open any roslaunch
* go to rqt, dynamic recongfigure, and select from either a pan or tilt fault
* rosoptic echo /pt_faults_status and see the value update to 1 (hardware fault)

