### PR TITLE
updated Plexil install instructions

### DIFF
--- a/oceanwaters/doc/setup_dev_env.md
+++ b/oceanwaters/doc/setup_dev_env.md
@@ -55,15 +55,7 @@ distributions on sourceforge.net are not always kept up to date.
 git clone https://git.code.sf.net/p/plexil/git plexil
 ```
 
-The default git branch is `releases/plexil-4`, which is the latest stable version
-of PLEXIL.  On rare occasions the latest version of this branch won't be
-compatible with OceanWATERS and you will need to check out a particular commit.
-We plan to simplify the workflow needed to keep these two software systems compatible.
-
-NOTE: The current release of OceanWATERS was tested with the git tag
-`2020-11-17` of PLEXIL's `releases/plexil-4` branch, though it should work with
-the head of this branch.  If you encounter problems, please revert to the
-`2020-11-17` tag and contact the OceanWATERS team.
+The default git branch of PLEXIL is `releases/plexil-4`, which is maintained as a stable version of PLEXIL compatible with OceanWATERS and suitable for general use.
 
 * Install any of the following build prerequisites needed. If you're not sure
 which are missing, try the build, see where it breaks, and install new packages
@@ -108,11 +100,14 @@ cd src
 * Build PLEXIL.
 ```
 cd $PLEXIL_HOME
-make
+make universalExec plexil-compiler checkpoint
 ```
 
-* If you have problems, see additional build information
+* Note that this is a minimal build of PLEXIL including only what is needed by
+OceanWATERS.  Additional build information is available
 [here](http://plexil.sourceforge.net/wiki/index.php/Installation).
+
+* Also note that the latest version of this branch tested with OceanWATERS is tagged `OceanWATERS-v7.1`.  
 
 
 ### ROS

--- a/oceanwaters/doc/setup_dev_env.md
+++ b/oceanwaters/doc/setup_dev_env.md
@@ -55,7 +55,9 @@ distributions on sourceforge.net are not always kept up to date.
 git clone https://git.code.sf.net/p/plexil/git plexil
 ```
 
-The default git branch of PLEXIL is `releases/plexil-4`, which is maintained as a stable version of PLEXIL compatible with OceanWATERS and suitable for general use.
+The default git branch of PLEXIL is `releases/plexil-4`, which is maintained as
+a stable version of PLEXIL compatible with OceanWATERS and suitable for general
+use.
 
 * Install any of the following build prerequisites needed. If you're not sure
 which are missing, try the build, see where it breaks, and install new packages
@@ -70,8 +72,11 @@ sudo apt install make \
                  g++ \
                  ant \
                  gperf \
-                 openjdk-8-jdk
+                 default-jre
 ```
+
+Note that PLEXIL (specifically the plan compiler) requires the Java compiler and
+runtime environment, version 8 or newer.
 
 * Define the `PLEXIL_HOME` environment variable as the location of your PLEXIL
   installation, e.g.


### PR DESCRIPTION
## Summary of Changes
* Plexil install instructions only.  This update is urgent because the current instructions build Plexil in a way that won't work with Release 7.

## Test
* Delete your existing Plexil installation ($PLEXIL_HOME directory)
* Follow the instructions in the README to re-install/build Plexil.
* Rebuild ow_autonomy:
```
rm -rf <ow_workspace>/build/ow_autonomy
catkin build ow_autonomy
```
* Run a bit of ReferenceMission1.  Just getting to the antenna pan/tilt at the start is enough.
`roslaunch ow_autonomy autonomy_node.launch plan:=ReferenceMission1.plx`
