### PR TITLE
Implement a force torque sensor for the lander arm

### DIFF
--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -404,6 +404,17 @@
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
+  <gazebo reference="j_dist_pitch">
+    <provideFeedback>true</provideFeedback>
+  </gazebo>
+  <gazebo>
+    <plugin name="ft_sensor" filename="libgazebo_ros_ft_sensor.so">
+      <jointName>j_dist_pitch</jointName>
+      <topicName>ft_sensor_dist_pitch</topicName>
+      <updateRate>30.0</updateRate>
+      <gaussianNoise>0.0</gaussianNoise>
+    </plugin>
+  </gazebo>
   <link name="l_hand">
     <inertial>
       <origin


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡| [OCEANWATER-614 / Implement a force torque sensor for the lander arm ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-614) |
| :----------- | :----------- |
| Jira Ticket 🎟️   | ~[OCEANWATER-615 / Introduce a force torque sensor for the dist_patch joint ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-615)~ |
| Jira Ticket 🎟️   | [OCEANWATER-616 / Implement guarded move using the ft sensor ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-616) |
| Jira Ticket 🎟️   | [OCEANWATER-617 / Introduce sufficient noise to model a realistic sensor ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-617) |
| Jira Ticket 🎟️   | [OCEANWATER-618 / Model potential faults or failure for the ft sensor ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-618) |
| Jira Ticket 🎟️   | [OCEANWATER-619 / Update the user guide to include utilization of the FT Sensor ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-619) |
| Jira Ticket 🎟️   | [OCEANWATER-620 / Document sensor response when loading a sample with varying mass into scoop ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-620) |
| Github :octocat:  | N/A |


## Summary of Changes
* Introduced a force torque sensor for the dist_patch joint

## Test
* 
