### PR TITLE
add an ft sensor to the dist_patch joint

### DIFF
--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -404,6 +404,17 @@
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
+  <gazebo reference="j_dist_pitch">
+    <provideFeedback>true</provideFeedback>
+  </gazebo>
+  <gazebo>
+    <plugin name="ft_sensor" filename="libgazebo_ros_ft_sensor.so">
+      <jointName>j_dist_pitch</jointName>
+      <topicName>ft_sensor_dist_pitch</topicName>
+      <updateRate>30.0</updateRate>
+      <gaussianNoise>0.0</gaussianNoise>
+    </plugin>
+  </gazebo>
   <link name="l_hand">
     <inertial>
       <origin


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡| [OCEANWATER-614 / Implement a force torque sensor for the lander arm ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-614) |
| :----------- | :----------- |
| Jira Ticket 🎟️   | [OCEANWATER-615 / Introduce a force torque sensor for the dist_patch joint ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-615) |
| Github :octocat:  | N/A |


## Summary of Changes
* Introduced a force torque sensor for the dist_patch joint

## Test
* Launch the simulation
```bash
roslaunch ow (atacma_y1a.launch | europa_terminator_workspace.launch)
```
* While the simulation running open another terminal and use rostopic to listen to the **ft_sensor_dist_pitch** topic
```bash
rostopic echo /ft_sensor_dist_pitch
```
You should see a stream of **WrenchStamped** messages with relatively stable values for force and torque.
* Execute any arm activity and you should see the stream of values fluctuate.

