### PR TITLE
OCEANWATER 607  Pan/Tilt Faults Halt Antennae Movement 

### DIFF
--- a/ow/launch/common.launch
+++ b/ow/launch/common.launch
@@ -92,7 +92,10 @@
     launch-prefix="bash -c 'sleep 5; $0 $@' "/-->
   <node pkg="rqt_gui" type="rqt_gui" name="rqt_gui"
     launch-prefix="bash -c 'sleep 5; $0 $@' "
-    args="&#45;&#45;perspective-file $(find ow)/config/default.perspective"/>
+    args="&#45;&#45;perspective-file $(find ow)/config/default.perspective">
+    <remap from="/ant_pan_position_controller/command" to="/_original/ant_pan_position_controller/command"/>
+    <remap from="/ant_tilt_position_controller/command" to="/_original/ant_tilt_position_controller/command"/> 
+  </node>
   <!-- == launch the mechanical power publishing node ========= -->
   <node pkg="ow_lander" name="mechanical_power_arm" type="mechanical_power_arm.py" output="screen" />
 

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -79,7 +79,7 @@ private:
   // Antennae functions
   void antennaePanFaultCb(const std_msgs::Float64& msg);
   void antennaeTiltFaultCb(const std_msgs::Float64& msg);
-  void publishAntennaeFaults(const std_msgs::Float64& msg, bool encoder, bool torque, float& m_faultValue, ros::Publisher m_publisher);
+  void publishAntennaeFaults(const std_msgs::Float64& msg, bool encoder, bool torque, float& m_faultValue, ros::Publisher& m_publisher);
 
   // Output /faults/joint_states, a modified version of /joint_states, injecting
   // simple message faults that don't need to be simulated at their source.

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -68,8 +68,18 @@ public:
 private:
   float powerTemperatureOverloadValue;
   
+
+
+
+  float faultPanValue;
+  float faultTiltValue;
+
   // renders new temperature when thermal power fault is re-triggered
   void setPowerTemperatureFaultValue(bool getTempBool);
+
+  // Antennae functions
+  void antennaePanFaultCb(const std_msgs::Float64& msg);
+  void antennaeTiltFaultCb(const std_msgs::Float64& msg);
 
   // Output /faults/joint_states, a modified version of /joint_states, injecting
   // simple message faults that don't need to be simulated at their source.
@@ -109,6 +119,12 @@ private:
   ros::Publisher m_arm_fault_status_pub;
   ros::Publisher m_power_fault_status_pub;
   ros::Publisher m_antennae_fault_status_pub;
+
+  //antenna pub and subs
+  ros::Subscriber m_fault_ant_pan_sub;
+  ros::Subscriber m_fault_ant_tilt_sub;
+  ros::Publisher m_fault_ant_pan_pub;
+  ros::Publisher m_fault_ant_tilt_pub;
 
   // Map ow_lander::joint_t enum values to indices in JointState messages
   std::vector<unsigned int> m_joint_state_indices;

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -70,9 +70,8 @@ private:
   
 
 
-
-  float faultPanValue;
-  float faultTiltValue;
+  float m_faultPanValue;
+  float m_faultTiltValue;
 
   // renders new temperature when thermal power fault is re-triggered
   void setPowerTemperatureFaultValue(bool getTempBool);
@@ -80,6 +79,7 @@ private:
   // Antennae functions
   void antennaePanFaultCb(const std_msgs::Float64& msg);
   void antennaeTiltFaultCb(const std_msgs::Float64& msg);
+  void publishAntennaeFaults(const std_msgs::Float64& msg, bool encoder, bool torque, float& m_faultValue, ros::Publisher m_publisher);
 
   // Output /faults/joint_states, a modified version of /joint_states, injecting
   // simple message faults that don't need to be simulated at their source.

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -87,16 +87,11 @@ void FaultInjector::setFaultsMessage(ow_faults::PTFaults& msg, ComponentFaults v
 void FaultInjector::publishAntennaeFaults(const std_msgs::Float64& msg, bool encoder, bool torque, float& m_faultValue, ros::Publisher m_publisher){
   std_msgs::Float64 out_msg;
 
-  if (encoder || torque) {
-    if (isnan(m_faultValue)){
-      m_faultValue = msg.data;
-    }
-    out_msg.data = m_faultValue;
-    m_publisher.publish(out_msg);
-  } else {
-    m_publisher.publish(msg);
+  if (!(encoder || torque)) {
     m_faultValue = msg.data;
   }
+  out_msg.data = m_faultValue;
+  m_publisher.publish(out_msg);
 }
 
 void FaultInjector::antennaePanFaultCb(const std_msgs::Float64& msg){

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -22,6 +22,12 @@ FaultInjector::FaultInjector(ros::NodeHandle node_handle)
   m_fault_power_state_of_charge_pub = node_handle.advertise<std_msgs::Float64>("temporary/power_fault/state_of_charge", 10);
   m_fault_power_temp_pub = node_handle.advertise<std_msgs::Float64>("temporary/power_fault/temp_increase", 10);
 
+  //antenna fault publishers and subs
+  m_fault_ant_pan_sub = node_handle.subscribe("/_original/ant_pan_position_controller/command", 3, &FaultInjector::antennaePanFaultCb, this);
+  m_fault_ant_tilt_sub = node_handle.subscribe("/_original/ant_tilt_position_controller/command", 3, &FaultInjector::antennaeTiltFaultCb, this);
+  m_fault_ant_pan_pub = node_handle.advertise<std_msgs::Float64>("/ant_pan_position_controller/command", 10);
+  m_fault_ant_tilt_pub = node_handle.advertise<std_msgs::Float64>("/ant_tilt_position_controller/command", 10);
+
   // topic for system fault messages, see Faults.msg
   m_fault_status_pub = node_handle.advertise<ow_faults::SystemFaults>("/system_faults_status", 10); 
   // topic for arm fault status, see ArmFaults.msg
@@ -73,6 +79,41 @@ void FaultInjector::setFaultsMessage(ow_faults::PTFaults& msg, ComponentFaults v
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = "world";
   msg.value = static_cast<uint>(value); //should be HARDWARE for now
+}
+
+void FaultInjector::antennaePanFaultCb(const std_msgs::Float64& msg){
+  std_msgs::Float64 pan_msg;
+  ROS_INFO("THIS IS THE OG %f", msg.data);
+  if (m_faults.ant_pan_encoder_failure || m_faults.ant_pan_torque_sensor_failure) {
+    if (isnan(faultPanValue)){
+      faultPanValue = msg.data;
+      ROS_INFO("set fault value to OG %f", msg.data);
+    }
+    pan_msg.data = faultPanValue;
+    ROS_INFO("publishing %f", faultPanValue);
+    m_fault_ant_pan_pub.publish(pan_msg);
+  } else {
+    //turning off fault, should revert to most recent msg val
+    ROS_INFO("publishing %f", msg.data);
+    m_fault_ant_pan_pub.publish(msg);
+    faultPanValue = msg.data;
+  }
+
+}
+
+void FaultInjector::antennaeTiltFaultCb(const std_msgs::Float64& msg){
+  std_msgs::Float64 tilt_msg;
+
+  if (m_faults.ant_tilt_encoder_failure || m_faults.ant_tilt_torque_sensor_failure) {
+    if (isnan(faultTiltValue)){
+      faultTiltValue = msg.data;
+    }
+    tilt_msg.data = faultTiltValue;
+    m_fault_ant_tilt_pub.publish(tilt_msg);
+  } else {
+    m_fault_ant_tilt_pub.publish(msg);
+    faultTiltValue = NAN;
+  }
 }
 
 void FaultInjector::setPowerTemperatureFaultValue(bool getTempBool){

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -85,7 +85,7 @@ void FaultInjector::setFaultsMessage(ow_faults::PTFaults& msg, ComponentFaults v
 }
 
 void FaultInjector::publishAntennaeFaults(const std_msgs::Float64& msg, bool encoder, bool torque, float& m_faultValue, ros::Publisher m_publisher){
-std_msgs::Float64 out_msg;
+  std_msgs::Float64 out_msg;
 
   if (encoder || torque) {
     if (isnan(m_faultValue)){

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -23,18 +23,21 @@ FaultInjector::FaultInjector(ros::NodeHandle node_handle)
   m_fault_power_temp_pub = node_handle.advertise<std_msgs::Float64>("temporary/power_fault/temp_increase", 10);
 
   //antenna fault publishers and subs
-  m_fault_ant_pan_sub = node_handle.subscribe("/_original/ant_pan_position_controller/command", 3, &FaultInjector::antennaePanFaultCb, this);
-  m_fault_ant_tilt_sub = node_handle.subscribe("/_original/ant_tilt_position_controller/command", 3, &FaultInjector::antennaeTiltFaultCb, this);
+  m_fault_ant_pan_sub = node_handle.subscribe("/_original/ant_pan_position_controller/command", 
+                                              3, 
+                                              &FaultInjector::antennaePanFaultCb, 
+                                              this);
+  m_fault_ant_tilt_sub = node_handle.subscribe("/_original/ant_tilt_position_controller/command", 
+                                              3, 
+                                              &FaultInjector::antennaeTiltFaultCb, 
+                                              this);
   m_fault_ant_pan_pub = node_handle.advertise<std_msgs::Float64>("/ant_pan_position_controller/command", 10);
   m_fault_ant_tilt_pub = node_handle.advertise<std_msgs::Float64>("/ant_tilt_position_controller/command", 10);
 
-  // topic for system fault messages, see Faults.msg
+  // topic for system fault messages, see Faults.msg, Amrms.msg, Power.msg, PTFaults.msg
   m_fault_status_pub = node_handle.advertise<ow_faults::SystemFaults>("/system_faults_status", 10); 
-  // topic for arm fault status, see ArmFaults.msg
   m_arm_fault_status_pub = node_handle.advertise<ow_faults::ArmFaults>("/arm_faults_status", 10); 
-  // topic for power fault status, see PowerFaults.msg
   m_power_fault_status_pub = node_handle.advertise<ow_faults::PowerFaults>("/power_faults_status", 10); 
-  // topic for power fault status, see PTFaults.msg
   m_antennae_fault_status_pub = node_handle.advertise<ow_faults::PTFaults>("/pt_faults_status", 10);
 
   srand (static_cast <unsigned> (time(0)));
@@ -97,11 +100,17 @@ std_msgs::Float64 out_msg;
 }
 
 void FaultInjector::antennaePanFaultCb(const std_msgs::Float64& msg){
-  publishAntennaeFaults(msg, m_faults.ant_pan_encoder_failure, m_faults.ant_pan_torque_sensor_failure, m_faultPanValue, m_fault_ant_pan_pub );
+  publishAntennaeFaults(msg, 
+                        m_faults.ant_pan_encoder_failure, 
+                        m_faults.ant_pan_torque_sensor_failure, 
+                        m_faultPanValue, m_fault_ant_pan_pub );
 }
 
 void FaultInjector::antennaeTiltFaultCb(const std_msgs::Float64& msg){
-  publishAntennaeFaults(msg, m_faults.ant_tilt_encoder_failure, m_faults.ant_tilt_torque_sensor_failure, m_faultTiltValue, m_fault_ant_tilt_pub );
+  publishAntennaeFaults(msg, 
+                        m_faults.ant_tilt_encoder_failure, 
+                        m_faults.ant_tilt_torque_sensor_failure, 
+                        m_faultTiltValue, m_fault_ant_tilt_pub );
 }
 
 void FaultInjector::setPowerTemperatureFaultValue(bool getTempBool){

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -83,27 +83,21 @@ void FaultInjector::setFaultsMessage(ow_faults::PTFaults& msg, ComponentFaults v
 
 void FaultInjector::antennaePanFaultCb(const std_msgs::Float64& msg){
   std_msgs::Float64 pan_msg;
-  ROS_INFO("THIS IS THE OG %f", msg.data);
   if (m_faults.ant_pan_encoder_failure || m_faults.ant_pan_torque_sensor_failure) {
     if (isnan(faultPanValue)){
       faultPanValue = msg.data;
-      ROS_INFO("set fault value to OG %f", msg.data);
     }
     pan_msg.data = faultPanValue;
-    ROS_INFO("publishing %f", faultPanValue);
     m_fault_ant_pan_pub.publish(pan_msg);
   } else {
     //turning off fault, should revert to most recent msg val
-    ROS_INFO("publishing %f", msg.data);
     m_fault_ant_pan_pub.publish(msg);
     faultPanValue = msg.data;
   }
-
 }
 
 void FaultInjector::antennaeTiltFaultCb(const std_msgs::Float64& msg){
   std_msgs::Float64 tilt_msg;
-
   if (m_faults.ant_tilt_encoder_failure || m_faults.ant_tilt_torque_sensor_failure) {
     if (isnan(faultTiltValue)){
       faultTiltValue = msg.data;
@@ -112,7 +106,7 @@ void FaultInjector::antennaeTiltFaultCb(const std_msgs::Float64& msg){
     m_fault_ant_tilt_pub.publish(tilt_msg);
   } else {
     m_fault_ant_tilt_pub.publish(msg);
-    faultTiltValue = NAN;
+    faultTiltValue = msg.data;
   }
 }
 

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -34,7 +34,7 @@ FaultInjector::FaultInjector(ros::NodeHandle node_handle)
   m_fault_ant_pan_pub = node_handle.advertise<std_msgs::Float64>("/ant_pan_position_controller/command", 10);
   m_fault_ant_tilt_pub = node_handle.advertise<std_msgs::Float64>("/ant_tilt_position_controller/command", 10);
 
-  // topic for system fault messages, see Faults.msg, Amrms.msg, Power.msg, PTFaults.msg
+  // topic for system fault messages, see Faults.msg, Arm.msg, Power.msg, PTFaults.msg
   m_fault_status_pub = node_handle.advertise<ow_faults::SystemFaults>("/system_faults_status", 10); 
   m_arm_fault_status_pub = node_handle.advertise<ow_faults::ArmFaults>("/arm_faults_status", 10); 
   m_power_fault_status_pub = node_handle.advertise<ow_faults::PowerFaults>("/power_faults_status", 10); 
@@ -84,7 +84,7 @@ void FaultInjector::setFaultsMessage(ow_faults::PTFaults& msg, ComponentFaults v
   msg.value = static_cast<uint>(value); //should be HARDWARE for now
 }
 
-void FaultInjector::publishAntennaeFaults(const std_msgs::Float64& msg, bool encoder, bool torque, float& m_faultValue, ros::Publisher m_publisher){
+void FaultInjector::publishAntennaeFaults(const std_msgs::Float64& msg, bool encoder, bool torque, float& m_faultValue, ros::Publisher& m_publisher){
   std_msgs::Float64 out_msg;
 
   if (!(encoder || torque)) {
@@ -94,6 +94,8 @@ void FaultInjector::publishAntennaeFaults(const std_msgs::Float64& msg, bool enc
   m_publisher.publish(out_msg);
 }
 
+// Note for torque sensor failure, we are finding whether or not the hardware faults for antenna are being triggered. 
+// Given that, this is separate from the torque sensor implemented by Ussama.
 void FaultInjector::antennaePanFaultCb(const std_msgs::Float64& msg){
   publishAntennaeFaults(msg, 
                         m_faults.ant_pan_encoder_failure, 


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️   | [Oceanwater-607](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-607) |
| ----------- | ----------- |
| EPIC ⚡| [Oceanwater-551](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-551) |
| Github :octocat:  | ow_autonomy [PR](https://github.com/nasa/ow_autonomy/pull/29)  |

IMPORTANT! To run this, you will need to also pull the ow_autonomy [pr](https://github.com/nasa/ow_autonomy/pull/29) of the same name. 

## Summary of Changes
* antennae faults now cause antennae movement to be halted depending on pan or tilt
* remapping pan and tilt topics from rviz and autonomy nodes
* set original topics to /_original
* 'NEW' topics:
** /ant_pan_position_controller/command
** /ant_tilt_position_controller/command

## Test
TEST REMAPPING
* roslaunch any launch file
** to see autonomy remapping, you will need to also roslaunch an autonomy file
* go to rqt -> plugins -> node graph   (select view all)
or 
* roslaunch any launch file
** to see autonomy remapping, you will need to also roslaunch an autonomy file
* rostopic info either to see faults is now the sole publisher
* ** /ant_pan_position_controller/command
** /ant_tilt_position_controller/command
* rostopic info either to see faults now is a subscriber to this
** /_original/ant_pan_position_controller/command
** /_original/ant_tilt_position_controller/command


 TEST RVIZ
* roslaunch any launch file
* in a new terminal `rostopic echo /ant_pan_position_controller/command` or `rostopic echo /ant_tilt_position_controller/command`
* go to rqt and from Control and Viz tab update value to any value for 'command' for either pan or tilt
* go to rqt dynamic reconfigure and select either pan or tilt fault (respective to the topic you're observing)
** click and unclick the fault in rqt to see the output from the 'echo' update.

 TEST AUTONOMY
* roslaunch any launch file
* in a new terminal `rostopic echo /ant_pan_position_controller/command` or `rostopic echo /ant_tilt_position_controller/command`
* roslaunch any autonomy , I recommend demo since it includes antenna movement.
* go to rqt dynamic reconfigure and select either pan or tilt FAULT (respective to the topic you're observing)
** click and unclick the fault in rqt to see the output from the 'echo' update.