### PR TITLE
OCEANWATER-613_Add_Temperature_as_a_ROS_Topic

### DIFF
--- a/ow_power_system/README.md
+++ b/ow_power_system/README.md
@@ -6,11 +6,16 @@ ow_power_system
 ===============
 It creates a node called power_system_node, which listens for power consumption
 in a topic called power_draw, publishes the estimated state of charge (SOC)
-in a topic called state_of_charge, publishes the estimated remaining useful life (RUL) in seconds in a topic called remaining_useful_life, and publishes the estimated battery temperature in a topic called battery_temperature.
+in a topic called state_of_charge, publishes the estimated remaining useful life (RUL) in seconds in a topic called
+remaining_useful_life, and publishes the estimated battery temperature in degrees Celsius in a topic called 
+battery_temperature.
 
-Currently, the state_of_charge topic is not published. The RUL value is computed via the GSAP prognostics library based on power input values from a precomputed constant or variable load csv. The value is published every second.
+The RUL, SOC, and battery temperature values are computed via the GSAP prognostics library based on power input
+values from a precomputed constant or variable load csv. The values are published every second.
 
-The RUL is expected to fluctuate (rather than decrease monotonically) due to uncertainties in the Monte Carlo predictor method, with the predicted value becoming more accurate closer to EOD (end of discharge).
+The predicted RUL and SOC values are expected to fluctuate slightly (rather than decrease monotonically) due to 
+uncertainties in the Monte Carlo predictor method, with the predicted value becoming more accurate closer to EOD 
+(end of discharge). The battery temperature is expected to hover around a constant value of approximately 20 deg. C.
 
 Once the publisher hits the end of the csv, it will repeat the dissipation sequence from the top.
 
@@ -23,7 +28,7 @@ This node can be launched using the format:
 </node>
 ```
 
-There are three options for the power draw: either constant load or variable load, with the specs listed below.
+There are two options for the power draw: either constant load or variable load, with the specs listed below.
   
 **SPECS:**  
 data_const_load.csv  

--- a/ow_power_system/src/power_system_node.cpp
+++ b/ow_power_system/src/power_system_node.cpp
@@ -80,11 +80,12 @@ int main(int argc, char* argv[]) {
   
   ros::Rate rate(power_update_rate);
   //individual soc_msg to be published by SOC_pub
-  std_msgs::Float64 soc_msg;
-  soc_msg.data = 0.0;
   std_msgs::Int16 rul_msg;
   rul_msg.data = 0;  // immediately set to a good default
+  std_msgs::Float64 soc_msg;
+  soc_msg.data = 0.0;
   std_msgs::Float64 tempbat_msg;
+  tempbat_msg.data = 0.0;
   ROS_INFO ("Power system node running");
 
   while (ros::ok()) {
@@ -124,26 +125,23 @@ int main(int argc, char* argv[]) {
         std::sort(samplesSOC.begin(), samplesSOC.end());
         double soc_median = samplesSOC.at(samplesSOC.size() / 2);
         soc_msg.data = soc_median;
-      }
 
-      // Temperature Code
-      //std::vector<UData> systemStates = eod_event.getSystemState()[0]; // Get the system (battery) state at t=0 (now)
-      // This is in format [stateId][sampleId].
-      // Here you will have to choose the sampleId the corresponds to your chosen percentile (e.g., Median) - and load it into a vector<double> where each element is a different state (in same order as above). 
-      // For Example:
-      //std::vector<double> medianSystemState(systemStates.size());
-      //for (int i = 0; i < medianSystemState.size(); i++) 
-        //medianSystemState[i] = systemStates[i][MEDIAN]; // Where MEDIAN corresponds to the sampleID of the median EOL prediction
-        
-      // Next, You will pass it into the model outputEqn to get the outputs:
-      //auto output = model.outputEqn(medianSystemState);
-      //double temperature = output[1];
-      //tempbat_msg.data = temperature;
+        // Temperature Code
+        auto stateSamples = eod_event.getSystemState()[0];
+        std::vector<double> state;
+        for (auto sample : stateSamples) {
+          state.push_back(sample[0]);
+        }
+        auto& model = ((ModelBasedPrognoser *) prognoser.get())->getModel();
+        auto z = model.outputEqn(now_s.count(), (PrognosticsModel::state_type) state);
+        double temperature = z[1];
+        tempbat_msg.data = temperature;
+      }
       
       //publish current SOC & RUL
       SOC_pub.publish(soc_msg);
       RUL_pub.publish(rul_msg);
-      //TempBat_pub.publish(tempbat_msg);
+      TempBat_pub.publish(tempbat_msg);
       ros::spinOnce();
       rate.sleep();
     }

--- a/ow_power_system/src/power_system_node.cpp
+++ b/ow_power_system/src/power_system_node.cpp
@@ -86,6 +86,7 @@ int main(int argc, char* argv[]) {
   soc_msg.data = 0.0;
   std_msgs::Float64 tempbat_msg;
   tempbat_msg.data = 0.0;
+  int temp_index = 1; // Set to 1 for now (constant vector). This will change to median SOC or RUL index or fixed percentile
   ROS_INFO ("Power system node running");
 
   while (ros::ok()) {
@@ -134,7 +135,7 @@ int main(int argc, char* argv[]) {
         }
         auto& model = dynamic_cast<ModelBasedPrognoser*>(prognoser.get())->getModel();
         auto z = model.outputEqn(now_s.count(), (PrognosticsModel::state_type) state);
-        double temperature = z[1];
+        double temperature = z[temp_index];
         tempbat_msg.data = temperature;
       }
       


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️   | [Oceanwater-613](https://babelfish.arc.nasa.gov/jira/secure/RapidBoard.jspa?rapidView=168&projectKey=OCEANWATER&view=detail&selectedIssue=OCEANWATER-613) |
| DoD: One of the output parameters of the GSAP prognostics factory is temperature. It needs to be converted to a ROS topic that can be subscribed to by users for fault injection. |
| EPIC ⚡| [Oceanwater-84](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-84) |
| Github :octocat:  | # |


## Summary of Changes
* Identified and helped fix a GSAP issue that previously made temperature inaccessible
* Identified and helped fix a GSAP bug that caused an under-prediction of temperature values 
* Added Temperature calculation and extraction from state matrix
* Created rostopic to publish value to power system node
* Updated README to reflect recent changes to power system node functionality

## Test
* Pull updates to OW-1.0 tagged branch of GSAP
* Recompile GSAP (1. navigate to build folder 2. cmake .. 3. make)
* rebuild the ow_power_system
* Launch OW
* Subscribe to power_system_node/battery_temperature rostopic
* Verify the temperature hovers around a constant value of approximately 20 deg. C.
