### PR TITLE
OCEANWATER-617: Set appropriate sensor update rate and noise

### DIFF
--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -411,8 +411,8 @@
     <plugin name="ft_sensor" filename="libgazebo_ros_ft_sensor.so">
       <jointName>j_dist_pitch</jointName>
       <topicName>ft_sensor_dist_pitch</topicName>
-      <updateRate>30.0</updateRate>
-      <gaussianNoise>0.0</gaussianNoise>
+      <updateRate>250.0</updateRate>  <!-- max sensor update rate 2500 Hz  -->
+      <gaussianNoise>0.2</gaussianNoise> <!-- estimated based on a profile of the barret ft sensor -->
     </plugin>
   </gazebo>
   <link name="l_hand">


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡| [OCEANWATER-614 / Implement a force torque sensor for the lander arm ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-614) |
| :----------- | :----------- |
| Jira Ticket 🎟️   | [OCEANWATER-617 / Introduce sufficient noise to model a realistic sensor ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-617) |
| Github :octocat:  | N/A |


## Summary of Changes
* Set sensor update rate to 250 Hz
* set sensor gaussian noise level to 0.2
  - Noise value is based on generated noise profile of the [Barret FT sensor](https://web.barrett.com/files/Low-Profile_Force-Torque_Sensor_FT-02-2011.pdf)
  - See table listed below for comparison of real signal vs simulated  

| Real | Simulated |
| :----------: | :----------: |
|![image](https://user-images.githubusercontent.com/606033/112533125-daaec700-8d66-11eb-9eea-54a516a4fa5b.png)|![image](https://user-images.githubusercontent.com/606033/112551442-3df82380-8d7e-11eb-9854-24affb53d0bc.png)|
|![image](https://user-images.githubusercontent.com/606033/112531875-59a30000-8d65-11eb-9b7b-73c117321c59.png)|![image](https://user-images.githubusercontent.com/606033/112532039-9242d980-8d65-11eb-8923-e6b8cd18286c.png)|

## Test
This test verifies that the current implementation of ground detection which uses the F/T sensor signal still works even after some noise has been introduced. 
1. Launch the simulation
```bash
roslaunch ow (atacma_y1a.launch | europa_terminator_workspace.launch)
```
2. While the simulation running invoke guarded move with varying set of valid arguments in the same session.
```bash
rosservice call /arm/guarded_move -- True 0 0 0 0 0 0 0
rosservice call /arm/guarded_move -- False 1.7 0.3 0.5 0 0 1 0.7
rosservice call /arm/guarded_move -- False 1.7 -0.3 0.5 0 0 1 0.7
rosservice call /arm/guarded_move -- False 1.9 -0.4 0.5 0 0 1 0.7
rosservice call /arm/guarded_move -- False 1.9 0.5 0.5 0 0 1 0.7
rosservice call /arm/guarded_move -- False 1.7 0.0 0.5 1 1 1 0.7
rosservice call /arm/guarded_move -- False 1.7 0.0 0.5 0.5 -0.5 1 0.8
```
The ground is detected with no delay and premature detection

>Note: The threshold value has not been optimized but this the current value seems to be sufficient.
