### PR TITLE
Oceanwater 630 rename ft faults

### DIFF
--- a/ow_faults/README.md
+++ b/ow_faults/README.md
@@ -53,7 +53,7 @@ Then set faults on the `faults` node from anywhere in your script:
 
 ```
 client = dynamic_reconfigure.client.Client('/faults')
-params = { 'ant_pan_encoder_failure' : 'True', 'ant_tilt_torque_sensor_failure' : 'True' }
+params = { 'ant_pan_encoder_failure' : 'True', 'ant_tilt_effort_failure' : 'True' }
 config = client.update_configuration(params)
 ```
 

--- a/ow_faults/cfg/Faults.cfg
+++ b/ow_faults/cfg/Faults.cfg
@@ -12,29 +12,29 @@ joint_state_enum = gen.enum([gen.const("nominal",  int_t, 0, "Joint is functioni
                             "An enum to set joint state")
 # ANTENNA FAULTS
 gen.add("ant_pan_encoder_failure",       bool_t,   0, "Antenna pan encoder failure",       False)
-gen.add("ant_pan_effort_failure", bool_t,   0, "Antenna pan torque sensor failure", False)
+gen.add("ant_pan_effort_failure", bool_t,   0, "Antenna pan effort failure", False)
 
 gen.add("ant_tilt_encoder_failure",       bool_t,   0, "Antenna tilt encoder failure",       False)
-gen.add("ant_tilt_effort_failure", bool_t,   0, "Antenna tilt torque sensor failure", False)
+gen.add("ant_tilt_effort_failure", bool_t,   0, "Antenna tilt effort failure", False)
 
 # ARM FAULTS
 gen.add("shou_yaw_encoder_failure",       bool_t,   0, "Shoulder yaw encoder failure",       False)
-gen.add("shou_yaw_effort_failure", bool_t,   0, "Shoulder yaw torque sensor failure", False)
+gen.add("shou_yaw_effort_failure", bool_t,   0, "Shoulder yaw effort failure", False)
 
 gen.add("shou_pitch_encoder_failure",       bool_t,   0, "Shoulder pitch encoder failure",       False)
-gen.add("shou_pitch_effort_failure", bool_t,   0, "Shoulder pitch torque sensor failure", False)
+gen.add("shou_pitch_effort_failure", bool_t,   0, "Shoulder pitch effort failure", False)
 
 gen.add("prox_pitch_encoder_failure",       bool_t,   0, "Proximal pitch encoder failure",       False)
-gen.add("prox_pitch_effort_failure", bool_t,   0, "Proximal pitch torque sensor failure", False)
+gen.add("prox_pitch_effort_failure", bool_t,   0, "Proximal pitch effort failure", False)
 
 gen.add("dist_pitch_encoder_failure",       bool_t,   0, "Distal pitch encoder failure",       False)
-gen.add("dist_pitch_effort_failure", bool_t,   0, "Distal pitch torque sensor failure", False)
+gen.add("dist_pitch_effort_failure", bool_t,   0, "Distal pitch effort failure", False)
 
 gen.add("hand_yaw_encoder_failure",       bool_t,   0, "Hand yaw encoder failure",       False)
-gen.add("hand_yaw_effort_failure", bool_t,   0, "Hand yaw torque sensor failure", False)
+gen.add("hand_yaw_effort_failure", bool_t,   0, "Hand yaw effort failure", False)
 
 gen.add("scoop_yaw_encoder_failure",       bool_t,   0, "Scoop yaw encoder failure",       False)
-gen.add("scoop_yaw_effort_failure", bool_t,   0, "Scoop yaw torque sensor failure", False)
+gen.add("scoop_yaw_effort_failure", bool_t,   0, "Scoop yaw effort failure", False)
 
 # POWER FAULTS
 gen.add("low_state_of_charge_power_failure", bool_t,   0, "Low state of charge power failure", False)

--- a/ow_faults/cfg/Faults.cfg
+++ b/ow_faults/cfg/Faults.cfg
@@ -12,29 +12,29 @@ joint_state_enum = gen.enum([gen.const("nominal",  int_t, 0, "Joint is functioni
                             "An enum to set joint state")
 # ANTENNA FAULTS
 gen.add("ant_pan_encoder_failure",       bool_t,   0, "Antenna pan encoder failure",       False)
-gen.add("ant_pan_torque_sensor_failure", bool_t,   0, "Antenna pan torque sensor failure", False)
+gen.add("ant_pan_effort_failure", bool_t,   0, "Antenna pan torque sensor failure", False)
 
 gen.add("ant_tilt_encoder_failure",       bool_t,   0, "Antenna tilt encoder failure",       False)
-gen.add("ant_tilt_torque_sensor_failure", bool_t,   0, "Antenna tilt torque sensor failure", False)
+gen.add("ant_tilt_effort_failure", bool_t,   0, "Antenna tilt torque sensor failure", False)
 
 # ARM FAULTS
 gen.add("shou_yaw_encoder_failure",       bool_t,   0, "Shoulder yaw encoder failure",       False)
-gen.add("shou_yaw_torque_sensor_failure", bool_t,   0, "Shoulder yaw torque sensor failure", False)
+gen.add("shou_yaw_effort_failure", bool_t,   0, "Shoulder yaw torque sensor failure", False)
 
 gen.add("shou_pitch_encoder_failure",       bool_t,   0, "Shoulder pitch encoder failure",       False)
-gen.add("shou_pitch_torque_sensor_failure", bool_t,   0, "Shoulder pitch torque sensor failure", False)
+gen.add("shou_pitch_effort_failure", bool_t,   0, "Shoulder pitch torque sensor failure", False)
 
 gen.add("prox_pitch_encoder_failure",       bool_t,   0, "Proximal pitch encoder failure",       False)
-gen.add("prox_pitch_torque_sensor_failure", bool_t,   0, "Proximal pitch torque sensor failure", False)
+gen.add("prox_pitch_effort_failure", bool_t,   0, "Proximal pitch torque sensor failure", False)
 
 gen.add("dist_pitch_encoder_failure",       bool_t,   0, "Distal pitch encoder failure",       False)
-gen.add("dist_pitch_torque_sensor_failure", bool_t,   0, "Distal pitch torque sensor failure", False)
+gen.add("dist_pitch_effort_failure", bool_t,   0, "Distal pitch torque sensor failure", False)
 
 gen.add("hand_yaw_encoder_failure",       bool_t,   0, "Hand yaw encoder failure",       False)
-gen.add("hand_yaw_torque_sensor_failure", bool_t,   0, "Hand yaw torque sensor failure", False)
+gen.add("hand_yaw_effort_failure", bool_t,   0, "Hand yaw torque sensor failure", False)
 
 gen.add("scoop_yaw_encoder_failure",       bool_t,   0, "Scoop yaw encoder failure",       False)
-gen.add("scoop_yaw_torque_sensor_failure", bool_t,   0, "Scoop yaw torque sensor failure", False)
+gen.add("scoop_yaw_effort_failure", bool_t,   0, "Scoop yaw torque sensor failure", False)
 
 # POWER FAULTS
 gen.add("low_state_of_charge_power_failure", bool_t,   0, "Low state of charge power failure", False)

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -86,14 +86,14 @@ void FaultInjector::publishAntennaeFaults(const std_msgs::Float64& msg, bool enc
 void FaultInjector::antennaePanFaultCb(const std_msgs::Float64& msg){
   publishAntennaeFaults(msg, 
                         m_faults.ant_pan_encoder_failure, 
-                        m_faults.ant_pan_torque_sensor_failure, 
+                        m_faults.ant_pan_effort_failure, 
                         m_faultPanValue, m_fault_ant_pan_pub );
 }
 
 void FaultInjector::antennaeTiltFaultCb(const std_msgs::Float64& msg){
   publishAntennaeFaults(msg, 
                         m_faults.ant_tilt_encoder_failure, 
-                        m_faults.ant_tilt_torque_sensor_failure, 
+                        m_faults.ant_tilt_effort_failure, 
                         m_faultTiltValue, m_fault_ant_tilt_pub );
 }
 
@@ -140,13 +140,13 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
   if (m_faults.ant_pan_encoder_failure && findJointIndex(J_ANT_PAN, index)) {
     output.position[index] = FAULT_ZERO_TELEMETRY;
   }
-  if (m_faults.ant_pan_torque_sensor_failure && findJointIndex(J_ANT_PAN, index)) {
+  if (m_faults.ant_pan_effort_failure && findJointIndex(J_ANT_PAN, index)) {
     output.effort[index]  = FAULT_ZERO_TELEMETRY;
   }
   if (m_faults.ant_tilt_encoder_failure && findJointIndex(J_ANT_TILT, index)) {
     output.position[index]  = FAULT_ZERO_TELEMETRY;
   }
-  if (m_faults.ant_tilt_torque_sensor_failure && findJointIndex(J_ANT_TILT, index)) {
+  if (m_faults.ant_tilt_effort_failure && findJointIndex(J_ANT_TILT, index)) {
     output.effort[index]  = FAULT_ZERO_TELEMETRY;
   }
 
@@ -159,42 +159,42 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
   if (m_faults.shou_yaw_encoder_failure && findJointIndex(J_SHOU_YAW, index)) {
     output.position[index]  = FAULT_ZERO_TELEMETRY;
   }
-  if (m_faults.shou_yaw_torque_sensor_failure && findJointIndex(J_SHOU_YAW, index)) {
+  if (m_faults.shou_yaw_effort_failure && findJointIndex(J_SHOU_YAW, index)) {
     output.effort[index]  = FAULT_ZERO_TELEMETRY;
   }
 
   if (m_faults.shou_pitch_encoder_failure && findJointIndex(J_SHOU_PITCH, index)) {
     output.position[index]  = FAULT_ZERO_TELEMETRY;
   }
-  if (m_faults.shou_pitch_torque_sensor_failure && findJointIndex(J_SHOU_PITCH, index)) {
+  if (m_faults.shou_pitch_effort_failure && findJointIndex(J_SHOU_PITCH, index)) {
     output.effort[index]  = FAULT_ZERO_TELEMETRY;
   }
 
   if (m_faults.prox_pitch_encoder_failure && findJointIndex(J_PROX_PITCH, index)) {
     output.position[index]  = FAULT_ZERO_TELEMETRY;
   }
-  if (m_faults.prox_pitch_torque_sensor_failure && findJointIndex(J_PROX_PITCH, index)) {
+  if (m_faults.prox_pitch_effort_failure && findJointIndex(J_PROX_PITCH, index)) {
     output.effort[index]  = FAULT_ZERO_TELEMETRY;
   }
 
   if (m_faults.dist_pitch_encoder_failure && findJointIndex(J_DIST_PITCH, index)) {
     output.position[index]  = FAULT_ZERO_TELEMETRY;
   }
-  if (m_faults.dist_pitch_torque_sensor_failure && findJointIndex(J_DIST_PITCH, index)) {
+  if (m_faults.dist_pitch_effort_failure && findJointIndex(J_DIST_PITCH, index)) {
     output.effort[index]  = FAULT_ZERO_TELEMETRY;
   }
 
   if (m_faults.hand_yaw_encoder_failure && findJointIndex(J_HAND_YAW, index)) {
     output.position[index]  = FAULT_ZERO_TELEMETRY;
   }
-  if (m_faults.hand_yaw_torque_sensor_failure && findJointIndex(J_HAND_YAW, index)) {
+  if (m_faults.hand_yaw_effort_failure && findJointIndex(J_HAND_YAW, index)) {
     output.effort[index]  = FAULT_ZERO_TELEMETRY;
   }
 
   if (m_faults.scoop_yaw_encoder_failure && findJointIndex(J_SCOOP_YAW, index)) {
     output.position[index]  = FAULT_ZERO_TELEMETRY;
   }
-  if (m_faults.scoop_yaw_torque_sensor_failure && findJointIndex(J_SCOOP_YAW, index)) {
+  if (m_faults.scoop_yaw_effort_failure && findJointIndex(J_SCOOP_YAW, index)) {
     output.effort[index]  = FAULT_ZERO_TELEMETRY;
   }
 
@@ -240,17 +240,17 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
 }
 
 void FaultInjector::checkArmFaults(){
-  m_armFault = (m_faults.shou_yaw_encoder_failure || m_faults.shou_yaw_torque_sensor_failure ||             
-                m_faults.shou_pitch_encoder_failure || m_faults.shou_pitch_torque_sensor_failure ||
-                m_faults.prox_pitch_encoder_failure || m_faults.prox_pitch_torque_sensor_failure || 
-                m_faults.dist_pitch_encoder_failure || m_faults.dist_pitch_torque_sensor_failure ||
-                m_faults.hand_yaw_encoder_failure || m_faults.hand_yaw_torque_sensor_failure ||
-                m_faults.scoop_yaw_encoder_failure || m_faults.scoop_yaw_torque_sensor_failure);
+  m_armFault = (m_faults.shou_yaw_encoder_failure || m_faults.shou_yaw_effort_failure ||             
+                m_faults.shou_pitch_encoder_failure || m_faults.shou_pitch_effort_failure ||
+                m_faults.prox_pitch_encoder_failure || m_faults.prox_pitch_effort_failure || 
+                m_faults.dist_pitch_encoder_failure || m_faults.dist_pitch_effort_failure ||
+                m_faults.hand_yaw_encoder_failure || m_faults.hand_yaw_effort_failure ||
+                m_faults.scoop_yaw_encoder_failure || m_faults.scoop_yaw_effort_failure);
 }
 
 void FaultInjector::checkAntFaults(){
-  m_antFault = (m_faults.ant_pan_encoder_failure || m_faults.ant_pan_torque_sensor_failure || 
-                m_faults.ant_tilt_encoder_failure || m_faults.ant_tilt_torque_sensor_failure);
+  m_antFault = (m_faults.ant_pan_encoder_failure || m_faults.ant_pan_effort_failure || 
+                m_faults.ant_tilt_encoder_failure || m_faults.ant_tilt_effort_failure);
 }
 
 template<typename group_t, typename item_t>


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️   | [Oceanwater-624](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-630) |
| ----------- | ----------- |
| EPIC ⚡| [Oceanwater-551](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-551) |
| Github :octocat:  | https://github.com/nasa/ow_autonomy/pull/30 |

*** requires ow_autonomy to be updated to the linked PR

## Summary of Changes
*renaming force torque to effort

## Test
* roslaunch any
* ropstopic echo system_faults_status
* select any faults from rqt
* see output still in rostopic.

