### PR TITLE
Oceanwater 660 rename faults vars

### DIFF
--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -44,11 +44,8 @@ public:
   enum Nominal { None=0 };
   
   enum class ComponentFaults : uint {
-    // general
     Hardware = 1, 
-    //pt
     JointLimit = 2,
-    //arm 
     TrajectoryGeneration = 2,
     Collision = 3, 
     Estop = 4, 
@@ -59,110 +56,111 @@ public:
     };
 
   //system
-	static constexpr std::bitset<10> isSystem{		0b00'0000'0001 };
-	static constexpr std::bitset<10> isArmGoalError{		0b00'0000'0010 };
-	static constexpr std::bitset<10> isArmExecutionError{		0b00'0000'0100 };
-	static constexpr std::bitset<10> isTaskGoalError{	0b00'000'1000 };
-	static constexpr std::bitset<10> isCamGoalError{	0b00'0001'0000 };
-	static constexpr std::bitset<10> isCamExecutionError{	0b00'0010'0000 };
-	static constexpr std::bitset<10> isPanTiltGoalError{		0b00'0100'0000 };
+	static constexpr std::bitset<10> isSystem{		            0b00'0000'0001 };
+	static constexpr std::bitset<10> isArmGoalError{          0b00'0000'0010 };
+	static constexpr std::bitset<10> isArmExecutionError{     0b00'0000'0100 };
+	static constexpr std::bitset<10> isTaskGoalError{	        0b00'0000'1000 };
+	static constexpr std::bitset<10> isCamGoalError{	        0b00'0001'0000 };
+	static constexpr std::bitset<10> isCamExecutionError{	    0b00'0010'0000 };
+	static constexpr std::bitset<10> isPanTiltGoalError{	  	0b00'0100'0000 };
 	static constexpr std::bitset<10> isPanTiltExecutionError{	0b00'1000'0000 };
 	static constexpr std::bitset<10> isLanderExecutionError{	0b01'0000'0000 };
-	static constexpr std::bitset<10> isPowerSystemFault{	0b10'0000'0000 };
+	static constexpr std::bitset<10> isPowerSystemFault{    	0b10'0000'0000 };
   
   //power
   static constexpr std::bitset<3> islowVoltageError{ 0b001 };
-	static constexpr std::bitset<3> isCapLossError{	0b010 };
-	static constexpr std::bitset<3> isThermalError{	0b100 };
+	static constexpr std::bitset<3> isCapLossError{  	 0b010 };
+	static constexpr std::bitset<3> isThermalError{	   0b100 };
 
 private:
   
-  std_msgs::Float64 m_realPanMsg;
-  std_msgs::Float64 m_realTiltMsg;
-  float m_faultPanValue;
-  float m_faultTiltValue;
+  ////////// functions
+  //Arm functions
+  // Output /faults/joint_states, a modified version of /joint_states, injecting
+  // simple message faults that don't need to be simulated at their source.
+  void jointStateCb(const sensor_msgs::JointStateConstPtr& msg);
+  // Output /faults/joint_states, a modified version of /joint_states, injecting
+  // simple message faults that don't need to be simulated at their source.
+  void distPitchFtSensorCb(const geometry_msgs::WrenchStamped& msg);
+  // Find an item in an std::vector or other find-able data structure, and
+  // return its index. Return -1 if not found.
+  template<typename group_t, typename item_t>
+  int findPositionInGroup(const group_t& group, const item_t& item);
+  // Get index from m_joint_index_map. If found, modify out_index and return
+  // true. Otherwise, return false.
+  bool findJointIndex(const unsigned int joint, unsigned int& out_index);
 
   // power functions
-  float originalSOC;
   float getRandomFloatFromRange(float min_val, float max_val);
   void publishPowerSystemFault(bool fault);
   void powerSOCListener(const std_msgs::Float64& msg);
-  void powerTempListener(const std_msgs::Float64& msg);
+  void powerTemperatureListener(const std_msgs::Float64& msg);
 
   // Antennae functions
   void antennaePanFaultCb(const std_msgs::Float64& msg);
   void antennaeTiltFaultCb(const std_msgs::Float64& msg);
   void publishAntennaeFaults(const std_msgs::Float64& msg, bool encoder, bool torque, float& m_faultValue, ros::Publisher& m_publisher);
 
-  // Output /faults/joint_states, a modified version of /joint_states, injecting
-  // simple message faults that don't need to be simulated at their source.
-  void jointStateCb(const sensor_msgs::JointStateConstPtr& msg);
-  
-  // Output /faults/joint_states, a modified version of /joint_states, injecting
-  // simple message faults that don't need to be simulated at their source.
-  void distPitchFtSensorCb(const geometry_msgs::WrenchStamped& msg);
-
-  //Setting the correct values for faults messages via function overloading
+  //Setting message values
   template<typename fault_msg>
   void setFaultsMessageHeader(fault_msg& msg);
-
   template<typename bitsetFaultsMsg, typename bitmask>
   void setBitsetFaultsMessage(bitsetFaultsMsg& msg, bitmask systemFaultsBitmask);
-
   template<typename fault_msg>
   void setComponentFaultsMessage(fault_msg& msg, ComponentFaults value);
-
-  //checking faults
+ 
+  //checking rqt faults
   void checkArmFaults();
   void checkAntFaults();
 
-  // Find an item in an std::vector or other find-able data structure, and
-  // return its index. Return -1 if not found.
-  template<typename group_t, typename item_t>
-  int findPositionInGroup(const group_t& group, const item_t& item);
-
-  // Get index from m_joint_index_map. If found, modify out_index and return
-  // true. Otherwise, return false.
-  bool findJointIndex(const unsigned int joint, unsigned int& out_index);
-
-  ow_faults::FaultsConfig m_faults;
-
-
-  //component faults
-  bool m_armFault;
-  bool m_antFault;
-
-  //system
-  std::bitset<10> systemFaultsBitset;
-
+  ///////publishers and subsscribers
   // arm faults
   ros::Subscriber m_joint_state_sub;
   ros::Publisher m_joint_state_pub;
 
   //power
   ros::Subscriber m_power_soc_sub;
-  ros::Subscriber m_power_temp_sub;
+  ros::Subscriber m_power_temperature_sub;
   ros::Publisher m_power_fault_trigger_pub;
 
   // ft sensor
   ros::Subscriber m_dist_pitch_ft_sensor_sub;
   ros::Publisher m_dist_pitch_ft_sensor_pub;
 
-  // publishers for sending ros messages for component failures
-  ros::Publisher m_fault_status_pub;
-  ros::Publisher m_arm_fault_status_pub;
-  ros::Publisher m_power_fault_status_pub;
-  ros::Publisher m_antennae_fault_status_pub;
-
-  //antenna pub and subs
+  //antenna 
   ros::Subscriber m_fault_ant_pan_sub;
   ros::Subscriber m_fault_ant_tilt_sub;
-  ros::Publisher m_fault_ant_pan_pub;
-  ros::Publisher m_fault_ant_tilt_pub;
+  ros::Publisher m_fault_ant_pan_remapped_pub;
+  ros::Publisher m_fault_ant_tilt_remapped_pub;
+
+  // jpl message publishers
+  ros::Publisher m_system_fault_jpl_msg_pub;
+  ros::Publisher m_arm_fault_jpl_msg_pub;
+  ros::Publisher m_power_fault_jpl_msg_pub;
+  ros::Publisher m_antennae_fault_jpl_msg_pub;
+
+  ////////// vars
+  //system
+  std::bitset<10> systemFaultsBitset;
+
+  //general component faults
+  bool m_armFault;
+  bool m_antFault;
+
+  //arm joint faults
+  ow_faults::FaultsConfig m_faults;
+
+  //power vars
+  float m_originalSOC;
+
+  // antenna vars
+  std_msgs::Float64 m_realPanMsg;
+  std_msgs::Float64 m_realTiltMsg;
+  float m_faultPanValue;
+  float m_faultTiltValue;
 
   // Map ow_lander::joint_t enum values to indices in JointState messages
   std::vector<unsigned int> m_joint_state_indices;
-
   std::mt19937 m_random_generator; // Utilize a Mersenne Twister pesduo random generation
 };
 

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -31,8 +31,8 @@ FaultInjector::FaultInjector(ros::NodeHandle node_handle)
   //power fault publishers and subs
     // will return to checking state of charge once that returns
   m_power_soc_sub = node_handle.subscribe("/power_system_node/state_of_charge", 1000, &FaultInjector::powerSOCListener, this); 
-  m_power_temp_sub = node_handle.subscribe("/power_system_node/battery_temperature", 1000, &FaultInjector::powerTempListener, this); 
-  m_power_fault_trigger_pub = node_handle.advertise<ow_faults::SystemFaults>("/faults/power_faults", 10);
+  m_power_temperature_sub = node_handle.subscribe("/power_system_node/battery_temperature", 1000, &FaultInjector::powerTemperatureListener, this); 
+  m_power_fault_trigger_pub = node_handle.advertise<ow_faults::SystemFaults>("/faults/trigger/power_faults", 10);
 
   //antenna fault publishers and subs
   m_fault_ant_pan_sub = node_handle.subscribe("/_original/ant_pan_position_controller/command", 
@@ -43,14 +43,14 @@ FaultInjector::FaultInjector(ros::NodeHandle node_handle)
                                               3, 
                                               &FaultInjector::antennaeTiltFaultCb, 
                                               this);
-  m_fault_ant_pan_pub = node_handle.advertise<std_msgs::Float64>("/ant_pan_position_controller/command", 10);
-  m_fault_ant_tilt_pub = node_handle.advertise<std_msgs::Float64>("/ant_tilt_position_controller/command", 10);
+  m_fault_ant_pan_remapped_pub = node_handle.advertise<std_msgs::Float64>("/ant_pan_position_controller/command", 10);
+  m_fault_ant_tilt_remapped_pub = node_handle.advertise<std_msgs::Float64>("/ant_tilt_position_controller/command", 10);
 
   // topic for system fault messages, see Faults.msg, Arm.msg, Power.msg, PTFaults.msg
-  m_fault_status_pub = node_handle.advertise<ow_faults::SystemFaults>("/system_faults_status", 10); 
-  m_arm_fault_status_pub = node_handle.advertise<ow_faults::ArmFaults>("/arm_faults_status", 10); 
-  m_power_fault_status_pub = node_handle.advertise<ow_faults::PowerFaults>("/power_faults_status", 10); 
-  m_antennae_fault_status_pub = node_handle.advertise<ow_faults::PTFaults>("/pt_faults_status", 10);
+  m_system_fault_jpl_msg_pub = node_handle.advertise<ow_faults::SystemFaults>("/faults/jpl/system_faults_status", 10); 
+  m_arm_fault_jpl_msg_pub = node_handle.advertise<ow_faults::ArmFaults>("/faults/jpl/arm_faults_status", 10); 
+  m_power_fault_jpl_msg_pub = node_handle.advertise<ow_faults::PowerFaults>("/faults/jpl/power_faults_status", 10); 
+  m_antennae_fault_jpl_msg_pub = node_handle.advertise<ow_faults::PTFaults>("/faults/jpl/pt_faults_status", 10);
 
   srand (static_cast <unsigned> (time(0)));
 }
@@ -99,14 +99,14 @@ void FaultInjector::antennaePanFaultCb(const std_msgs::Float64& msg){
   publishAntennaeFaults(msg, 
                         m_faults.ant_pan_encoder_failure, 
                         m_faults.ant_pan_effort_failure, 
-                        m_faultPanValue, m_fault_ant_pan_pub );
+                        m_faultPanValue, m_fault_ant_pan_remapped_pub );
 }
 
 void FaultInjector::antennaeTiltFaultCb(const std_msgs::Float64& msg){
   publishAntennaeFaults(msg, 
                         m_faults.ant_tilt_encoder_failure, 
                         m_faults.ant_tilt_effort_failure, 
-                        m_faultTiltValue, m_fault_ant_tilt_pub );
+                        m_faultTiltValue, m_fault_ant_tilt_remapped_pub );
 }
 
 float FaultInjector::getRandomFloatFromRange( float min_val, float max_val){
@@ -132,12 +132,12 @@ void FaultInjector::publishPowerSystemFault(bool fault){
   }
   //publish
   setBitsetFaultsMessage(system_faults_msg, systemFaultsBitmask);
-  m_fault_status_pub.publish(system_faults_msg);
-  m_power_fault_status_pub.publish(power_faults_msg);
+  m_system_fault_jpl_msg_pub.publish(system_faults_msg);
+  m_power_fault_jpl_msg_pub.publish(power_faults_msg);
 
 }
 
-void FaultInjector::powerTempListener(const std_msgs::Float64& msg)
+void FaultInjector::powerTemperatureListener(const std_msgs::Float64& msg)
 {
   bool fault = false;
   if(m_faults.thermal_power_failure && msg.data > 50){
@@ -151,17 +151,17 @@ void FaultInjector::powerSOCListener(const std_msgs::Float64& msg)
 {
   bool fault = false;
   float newSOC = msg.data;
-  if (isnan(originalSOC)){
-    originalSOC = newSOC;
+  if (isnan(m_originalSOC)){
+    m_originalSOC = newSOC;
   }
   if ((m_faults.low_state_of_charge_power_failure && newSOC <= 10)  ||  
         (m_faults.instantaneous_capacity_loss_power_failure && 
-        !isnan(originalSOC) && 
-        ((abs(originalSOC - newSOC) / originalSOC) >= .05 ))) {
+        !isnan(m_originalSOC) && 
+        ((abs(m_originalSOC - newSOC) / m_originalSOC) >= .05 ))) {
     fault = true;
   }
   publishPowerSystemFault(fault);
-  originalSOC = newSOC;
+  m_originalSOC = newSOC;
 }
 
 void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
@@ -274,10 +274,10 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
   setBitsetFaultsMessage(system_faults_msg, systemFaultsBitmask);
   systemFaultsBitset = systemFaultsBitmask;
   m_joint_state_pub.publish(output);
-  m_fault_status_pub.publish(system_faults_msg);
+  m_system_fault_jpl_msg_pub.publish(system_faults_msg);
 
-  m_arm_fault_status_pub.publish(arm_faults_msg);
-  m_antennae_fault_status_pub.publish(pt_faults_msg);
+  m_arm_fault_jpl_msg_pub.publish(arm_faults_msg);
+  m_antennae_fault_jpl_msg_pub.publish(pt_faults_msg);
 
   setBitsetFaultsMessage(power_faults_trigger_msg, powerFaultsBitmask);
   m_power_fault_trigger_pub.publish(power_faults_trigger_msg);

--- a/ow_lander/scripts/path_planning_commander.py
+++ b/ow_lander/scripts/path_planning_commander.py
@@ -201,7 +201,7 @@ class PathPlanningCommander(object):
     rospy.init_node('path_planning_commander', anonymous=True)
 
     # subscribe to system_fault_status for any arm faults
-    rospy.Subscriber("/system_faults_status", SystemFaults, self.callback)
+    rospy.Subscriber("/faults/jpl/system_faults_status", SystemFaults, self.callback)
 
     self.stop_srv = rospy.Service(
         'arm/stop', Stop, self.handle_stop)

--- a/ow_power_system/include/power_system_node.h
+++ b/ow_power_system/include/power_system_node.h
@@ -17,9 +17,7 @@ public:
   int THERMAL_FAULT = 4;
 
 private:
-  bool m_lowVoltageFault = false;
-  bool m_capLossFault = false;
-  bool m_thermalFault = false;
+  
   
   void powerCallback(const std_msgs::Float64::ConstPtr& msg);
   void powerFaultsCallback(const ow_faults::SystemFaults::ConstPtr& msg);
@@ -36,6 +34,9 @@ private:
 
   std::chrono::time_point<std::chrono::system_clock> m_init_time;
 
+  bool m_lowVoltageFault = false;
+  bool m_capLossFault = false;
+  bool m_thermalFault = false;
   // declare set constants .. hardcoded for now.
   // TODO: read from config file
   static constexpr double m_initial_power = 0.0;        // This is probably always zero

--- a/ow_power_system/include/power_system_node.h
+++ b/ow_power_system/include/power_system_node.h
@@ -21,7 +21,7 @@ private:
   
   void powerCallback(const std_msgs::Float64::ConstPtr& msg);
   void powerFaultsCallback(const ow_faults::SystemFaults::ConstPtr& msg);
-  double checkForFaults(double originalValue);
+  double adjustMechPowerForFaults(double originalValue);
 
   ros::NodeHandle m_nh;                          // Node Handle Initialization
   ros::Publisher m_state_of_charge_pub;          // State of Charge Publisher

--- a/ow_power_system/src/power_system_node.cpp
+++ b/ow_power_system/src/power_system_node.cpp
@@ -153,7 +153,7 @@ void PowerSystemNode::Run()
 
   // Finally subscribe to mechanical power topic (Watts)
   m_mechanical_power_sub = m_nh.subscribe("/mechanical_power/average", 1, &PowerSystemNode::powerCallback, this);
-  m_power_fault_sub = m_nh.subscribe("/faults/power_faults", 1, &PowerSystemNode::powerFaultsCallback, this);
+  m_power_fault_sub = m_nh.subscribe("/faults/trigger/power_faults", 1, &PowerSystemNode::powerFaultsCallback, this);
 
   ROS_INFO("Power system node running");
   ros::spin();

--- a/ow_power_system/src/power_system_node.cpp
+++ b/ow_power_system/src/power_system_node.cpp
@@ -16,7 +16,7 @@ using namespace std::chrono;
 void PowerSystemNode::powerCallback(const std_msgs::Float64::ConstPtr& msg)
 {
   // Set mechanical power value to rostopic subscription
-  double mechanical_power = checkForFaults(msg->data);  // [W]
+  double mechanical_power = adjustMechPowerForFaults(msg->data);  // [W]
   
   // Temperature estimate based on pseudorandom noise and fixed range
   double temperature_estimate =
@@ -101,7 +101,7 @@ void PowerSystemNode::powerCallback(const std_msgs::Float64::ConstPtr& msg)
   m_battery_temperature_pub.publish(battery_temperature_msg);
 }
 
-double PowerSystemNode::checkForFaults(double originalValue)
+double PowerSystemNode::adjustMechPowerForFaults(double originalValue)
 {
   //will likely need to modify after Chetan's feedback
   // assuming that we can only have one power fault triggered at a time.


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️   | [Oceanwater-660](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-660) |
| ----------- | ----------- |
| EPIC ⚡| [Oceanwater-551](urlhttps://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-551) |
| Github :octocat:  | (pre) #98, (sister-in autonomy) https://github.com/nasa/ow_autonomy/pull/35  |

NOTE: Must also pull from OW autonomy PR (linked above)

## Summary of Changes
* renaming and reorganizing names for clarity
* anything remapped stays as is
* `/faults/jpl/` prefix for jpl message topics
* `/faults/trigger` prefix for topics that trigger other node's to take action (ie. power)

## Test
* test build
