### PR TITLE
stopping all arm actions

### DIFF
--- a/ow_lander/scripts/deliver_action_server.py
+++ b/ow_lander/scripts/deliver_action_server.py
@@ -86,7 +86,7 @@ class DeliverActionServer(object):
 
            self._update_feedback()
            
-        success = self.trajectory_async_executer.success() & self.trajectory_async_executer.wait()        
+        success = self.trajectory_async_executer.success() and self.trajectory_async_executer.wait()        
         
         if success:
             self._result.final.x = self._fdbk.current.x

--- a/ow_lander/scripts/deliver_action_server.py
+++ b/ow_lander/scripts/deliver_action_server.py
@@ -73,7 +73,7 @@ class DeliverActionServer(object):
         self.trajectory_async_executer.execute(self.deliver_sample_traj.joint_trajectory,
                                            done_cb=None,
                                            active_cb=None,
-                                           feedback_cb=None)
+                                           feedback_cb=self.trajectory_async_executer.stop_arm_if_fault)
 
         # Record start time
         start_time = rospy.get_time()
@@ -86,15 +86,16 @@ class DeliverActionServer(object):
 
            self._update_feedback()
            
-        success = self.trajectory_async_executer.wait()
+        success = self.trajectory_async_executer.success() & self.trajectory_async_executer.wait()        
         
-            
         if success:
             self._result.final.x = self._fdbk.current.x
             self._result.final.y = self._fdbk.current.y 
             self._result.final.z = self._fdbk.current.z 
             rospy.loginfo('%s: Succeeded' % self._action_name)
             self._server.set_succeeded(self._result)
+        else:
+            rospy.loginfo('%s: Failed' % self._action_name)
     
 if __name__ == '__main__':
     rospy.init_node('Deliver')

--- a/ow_lander/scripts/dig_circular_action_server.py
+++ b/ow_lander/scripts/dig_circular_action_server.py
@@ -100,7 +100,7 @@ class DigCircularActionServer(object):
         self.trajectory_async_executer.execute(self.current_traj.joint_trajectory,
                                            done_cb=None,
                                            active_cb=None,
-                                           feedback_cb=None)
+                                           feedback_cb=self.trajectory_async_executer.stop_arm_if_fault)
 
         # Record start time
         start_time = rospy.get_time()
@@ -112,7 +112,7 @@ class DigCircularActionServer(object):
 
            self._update_feedback()
            
-        success = self.trajectory_async_executer.wait()
+        success = self.trajectory_async_executer.success() & self.trajectory_async_executer.wait()        
         
             
         if success:
@@ -121,7 +121,9 @@ class DigCircularActionServer(object):
             self._result.final.z = self._fdbk.current.z 
             rospy.loginfo('%s: Succeeded' % self._action_name)
             self._server.set_succeeded(self._result)
-    
+        else:
+            rospy.loginfo('%s: Failed' % self._action_name)
+
 if __name__ == '__main__':
     rospy.init_node('DigCircular')
     server = DigCircularActionServer(rospy.get_name())

--- a/ow_lander/scripts/dig_circular_action_server.py
+++ b/ow_lander/scripts/dig_circular_action_server.py
@@ -112,7 +112,7 @@ class DigCircularActionServer(object):
 
            self._update_feedback()
            
-        success = self.trajectory_async_executer.success() & self.trajectory_async_executer.wait()        
+        success = self.trajectory_async_executer.success() and self.trajectory_async_executer.wait()        
         
             
         if success:

--- a/ow_lander/scripts/dig_linear_action_server.py
+++ b/ow_lander/scripts/dig_linear_action_server.py
@@ -81,7 +81,7 @@ class DigLinearActionServer(object):
         self.trajectory_async_executer.execute(self.current_traj.joint_trajectory,
                                            done_cb=None,
                                            active_cb=None,
-                                           feedback_cb=None)
+                                           feedback_cb=self.trajectory_async_executer.stop_arm_if_fault)
 
         # Record start time
         start_time = rospy.get_time()
@@ -94,8 +94,7 @@ class DigLinearActionServer(object):
 
            self._update_feedback()
            
-        success = self.trajectory_async_executer.wait()
-        
+        success = self.trajectory_async_executer.success() & self.trajectory_async_executer.wait()        
             
         if success:
             self._result.final.x = self._fdbk.current.x
@@ -103,6 +102,8 @@ class DigLinearActionServer(object):
             self._result.final.z = self._fdbk.current.z 
             rospy.loginfo('%s: Succeeded' % self._action_name)
             self._server.set_succeeded(self._result)
+        else:
+            rospy.loginfo('%s: Failed' % self._action_name)
     
 if __name__ == '__main__':
     rospy.init_node('DigLinear')

--- a/ow_lander/scripts/dig_linear_action_server.py
+++ b/ow_lander/scripts/dig_linear_action_server.py
@@ -94,7 +94,7 @@ class DigLinearActionServer(object):
 
            self._update_feedback()
            
-        success = self.trajectory_async_executer.success() & self.trajectory_async_executer.wait()        
+        success = self.trajectory_async_executer.success() and self.trajectory_async_executer.wait()        
             
         if success:
             self._result.final.x = self._fdbk.current.x

--- a/ow_lander/scripts/grind_action_server.py
+++ b/ow_lander/scripts/grind_action_server.py
@@ -95,7 +95,7 @@ class GrindActionServer(object):
         self.trajectory_async_executer.execute(self.current_traj.joint_trajectory,
                                            done_cb=None,
                                            active_cb=None,
-                                           feedback_cb=None)
+                                           feedback_cb=self.trajectory_async_executer.stop_arm_if_fault)
 
         # Record start time
         start_time = rospy.get_time()
@@ -106,8 +106,7 @@ class GrindActionServer(object):
         while ((now_from_start(start_time) < self._timeout)):
            self._update_feedback()
            
-        success = self.trajectory_async_executer.wait()
-        
+        success = self.trajectory_async_executer.success() & self.trajectory_async_executer.wait()        
             
         if success:
             self._result.final.x = self._fdbk.current.x
@@ -118,6 +117,8 @@ class GrindActionServer(object):
                 return False, "Failed Switching Controllers"
             rospy.loginfo('%s: Succeeded' % self._action_name)
             self._server.set_succeeded(self._result)
+        else:
+            rospy.loginfo('%s: Failed' % self._action_name)
     
 if __name__ == '__main__':
     rospy.init_node('Grind')

--- a/ow_lander/scripts/grind_action_server.py
+++ b/ow_lander/scripts/grind_action_server.py
@@ -106,7 +106,7 @@ class GrindActionServer(object):
         while ((now_from_start(start_time) < self._timeout)):
            self._update_feedback()
            
-        success = self.trajectory_async_executer.success() & self.trajectory_async_executer.wait()        
+        success = self.trajectory_async_executer.success() and self.trajectory_async_executer.wait()        
             
         if success:
             self._result.final.x = self._fdbk.current.x

--- a/ow_lander/scripts/guarded_move_action_server.py
+++ b/ow_lander/scripts/guarded_move_action_server.py
@@ -112,7 +112,7 @@ class GuardedMoveActionServer(object):
 
            self._update_feedback()
            
-        success = self.trajectory_async_executer.success() & self.trajectory_async_executer.wait()
+        success = self.trajectory_async_executer.success() and self.trajectory_async_executer.wait()
             
         if success:
             self._result.final.x = self.ground_detector.ground_position.x

--- a/ow_lander/scripts/guarded_move_action_server.py
+++ b/ow_lander/scripts/guarded_move_action_server.py
@@ -42,7 +42,6 @@ class GuardedMoveActionServer(object):
         self.pos = Point()
         self.guarded_move_pub = rospy.Publisher(
         '/guarded_move_result', GuardedMoveFinalResult, queue_size=10)
-        self.arm_fault = False
 
     def handle_guarded_move_done(self, state, result):
         """

--- a/ow_lander/scripts/mechanical_power_arm.py
+++ b/ow_lander/scripts/mechanical_power_arm.py
@@ -44,9 +44,7 @@ class MechanicalPower:
     num_joints = len(ros_data.name)
     power = 0
     for x in range(0,num_joints-1):
-        #power = power + abs(ros_data.velocity[x]*ros_data.effort[x])
-        power = 0
-
+        power = power + abs(ros_data.velocity[x]*ros_data.effort[x])
         # Publish total power
     power_avg =  self._moving_average(power)
         

--- a/ow_lander/scripts/path_planning_commander.py
+++ b/ow_lander/scripts/path_planning_commander.py
@@ -167,6 +167,7 @@ class PathPlanningCommander(object):
     """
     :type feedback: FollowJointTrajectoryFeedback
     """
+    self.stop_arm_if_fault_feedback_cb(feedback)
 
     if self.ground_detector.detect():
       self.trajectory_async_executer.stop()

--- a/ow_lander/scripts/path_planning_commander.py
+++ b/ow_lander/scripts/path_planning_commander.py
@@ -59,7 +59,7 @@ class PathPlanningCommander(object):
     if len(plan.joint_trajectory.points) == 0:
       return False
     self.trajectory_async_executer.execute(plan.joint_trajectory, 
-                                          feedback_cb=self.stop_arm_if_fault_feedback_cb)
+                                          feedback_cb=None)
     self.trajectory_async_executer.wait()
     return self.return_message("Stow arm")
 
@@ -76,7 +76,7 @@ class PathPlanningCommander(object):
     if len(plan.joint_trajectory.points) == 0:
       return False
     self.trajectory_async_executer.execute(plan.joint_trajectory,
-                                          feedback_cb=self.stop_arm_if_fault_feedback_cb)
+                                          feedback_cb=None)
     self.trajectory_async_executer.wait()
     return self.return_message("Unstow arm")
 
@@ -167,7 +167,6 @@ class PathPlanningCommander(object):
     """
     :type feedback: FollowJointTrajectoryFeedback
     """
-    self.stop_arm_if_fault_feedback_cb(feedback)
 
     if self.ground_detector.detect():
       self.trajectory_async_executer.stop()
@@ -227,12 +226,6 @@ class PathPlanningCommander(object):
     print("path_planning_commander has started!")
 
     rospy.spin()
-
-  def stop_arm_if_fault_feedback_cb(self, feedback):
-    """
-    stops arm if arm fault exists during feedback callback
-    """
-    if self.arm_fault: self.trajectory_async_executer.stop()
 
   def return_message(self, action_name, success=True):
     if not self.arm_fault:

--- a/ow_lander/scripts/stow_action_server.py
+++ b/ow_lander/scripts/stow_action_server.py
@@ -72,7 +72,7 @@ class UnstowActionServer(object):
         self.trajectory_async_executer.execute(plan.joint_trajectory,
                                            done_cb=None,
                                            active_cb=None,
-                                           feedback_cb=None)
+                                           feedback_cb=self.trajectory_async_executer.stop_arm_if_fault)
 
         # Record start time
         start_time = rospy.get_time()
@@ -84,8 +84,7 @@ class UnstowActionServer(object):
 
            self._update_feedback()
            
-        success = self.trajectory_async_executer.wait()
-        
+        success = self.trajectory_async_executer.success() & self.trajectory_async_executer.wait()        
             
         if success:
             self._result.final.x = self._fdbk.current.x
@@ -93,7 +92,9 @@ class UnstowActionServer(object):
             self._result.final.z = self._fdbk.current.z 
             rospy.loginfo('%s: Succeeded' % self._action_name)
             self._server.set_succeeded(self._result)
-    
+        else:
+            rospy.loginfo('%s: Failed' % self._action_name)
+
 if __name__ == '__main__':
     rospy.init_node('Stow')
     server = UnstowActionServer(rospy.get_name())

--- a/ow_lander/scripts/stow_action_server.py
+++ b/ow_lander/scripts/stow_action_server.py
@@ -84,7 +84,7 @@ class UnstowActionServer(object):
 
            self._update_feedback()
            
-        success = self.trajectory_async_executer.success() & self.trajectory_async_executer.wait()        
+        success = self.trajectory_async_executer.success() and self.trajectory_async_executer.wait()        
             
         if success:
             self._result.final.x = self._fdbk.current.x

--- a/ow_lander/scripts/trajectory_async_execution.py
+++ b/ow_lander/scripts/trajectory_async_execution.py
@@ -42,7 +42,6 @@ class TrajectoryAsyncExecuter:
       self.arm_fault = (data.value & ARM_EXECUTION_ERROR == ARM_EXECUTION_ERROR)
         
   def success(self):
-    print("success ", not self.arm_fault)
     return (not self.arm_fault)
 
   def connect(self, controller):

--- a/ow_lander/scripts/trajectory_async_execution.py
+++ b/ow_lander/scripts/trajectory_async_execution.py
@@ -7,7 +7,9 @@
 import rospy
 import actionlib
 from control_msgs.msg import FollowJointTrajectoryAction, FollowJointTrajectoryGoal
+from ow_faults.msg import SystemFaults
 
+ARM_EXECUTION_ERROR = 4
 
 class TrajectoryAsyncExecuter:
   """
@@ -19,6 +21,29 @@ class TrajectoryAsyncExecuter:
     self._connected = False
     self._goal_time_tolerance = rospy.Time(0.1)
     self._client = None
+    self.arm_fault = False
+
+    # rospy.init_node('trajectoryAsyncExecuter')
+     # subscribe to system_fault_status for any arm faults
+    rospy.Subscriber("/system_faults_status", SystemFaults, self.faultCheckCallback)
+
+    # rospy.spin()
+  
+  def stop_arm_if_fault(self, feedback):
+        """
+        stops arm if arm fault exists during feedback callback
+        """
+        if self.arm_fault: self.stop()
+
+  def faultCheckCallback(self, data):
+      """
+      If system fault occurs, and it is an arm failure, an arm failure flag is set for the whole class
+      """
+      self.arm_fault = (data.value & ARM_EXECUTION_ERROR == ARM_EXECUTION_ERROR)
+        
+  def success(self):
+    print("success ", not self.arm_fault)
+    return (not self.arm_fault)
 
   def connect(self, controller):
     """

--- a/ow_lander/scripts/unstow_action_server.py
+++ b/ow_lander/scripts/unstow_action_server.py
@@ -87,8 +87,7 @@ class UnstowActionServer(object):
            self._update_feedback()
            
         success = self.trajectory_async_executer.success() & self.trajectory_async_executer.wait()        
-        rospy.loginfo(' Success is ')
-        rospy.loginfo(success)
+
         if success:
             self._result.final.x = self._fdbk.current.x
             self._result.final.y = self._fdbk.current.y 

--- a/ow_lander/scripts/unstow_action_server.py
+++ b/ow_lander/scripts/unstow_action_server.py
@@ -74,7 +74,7 @@ class UnstowActionServer(object):
         self.trajectory_async_executer.execute(plan.joint_trajectory,
                                            done_cb=None,
                                            active_cb=None,
-                                           feedback_cb=None)
+                                           feedback_cb=self.trajectory_async_executer.stop_arm_if_fault)
 
         # Record start time
         start_time = rospy.get_time()
@@ -86,16 +86,18 @@ class UnstowActionServer(object):
 
            self._update_feedback()
            
-        success = self.trajectory_async_executer.wait()
-        
-            
+        success = self.trajectory_async_executer.success() & self.trajectory_async_executer.wait()        
+        rospy.loginfo(' Success is ')
+        rospy.loginfo(success)
         if success:
             self._result.final.x = self._fdbk.current.x
             self._result.final.y = self._fdbk.current.y 
             self._result.final.z = self._fdbk.current.z 
             rospy.loginfo('%s: Succeeded' % self._action_name)
             self._server.set_succeeded(self._result)
-    
+        else:
+            rospy.loginfo('%s: Failed' % self._action_name)
+
 if __name__ == '__main__':
     rospy.init_node('Unstow')
     server = UnstowActionServer(rospy.get_name())

--- a/ow_lander/scripts/unstow_action_server.py
+++ b/ow_lander/scripts/unstow_action_server.py
@@ -86,7 +86,7 @@ class UnstowActionServer(object):
 
            self._update_feedback()
            
-        success = self.trajectory_async_executer.success() & self.trajectory_async_executer.wait()        
+        success = self.trajectory_async_executer.success() and self.trajectory_async_executer.wait()        
 
         if success:
             self._result.final.x = self._fdbk.current.x


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️   | [Oceanwater-553](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-553) |
| ----------- | ----------- |
| EPIC ⚡| [Oceanwater-551](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-551) |
| Github :octocat:  | #66 (parent) |


## Summary of Changes
* goal: updating arm actions s.t. a faults trigger will halt arm movement
* updating trajectory async executor to keep track of arm fault boolean 
* updating arm actions to listen to faults
  * stow
  * unstow
  * Move guarded
  * grind
  * dig circular
  * dig linear
  * deliver sample


## Test
* `roslaunch ow europa_terminator_workspace.launch`
* in new terminal, try any of the following actions
python unstow_action_client.py
python stow_action_client.py
python guarded_move_action_client.py
python grind_action_client.py
python dig_linear_action_client.py
python dig_circular_action_client.py
python deliver_action_client.py
* in middle of movement, turn faults on
* `rosrun dynamic_reconfigure dynparam set /faults prox_pitch_encoder_failure True`
* observe gazebo, and see arm stop movement

