### PR TITLE
Decouple dependency of PowerNode on joint_states topic +

### DIFF
--- a/ow_power_system/include/power_system_node.h
+++ b/ow_power_system/include/power_system_node.h
@@ -16,7 +16,11 @@ public:
   void Run();
 
 private:
+  bool loadSystemConfig();
   std::vector<std::map<MessageId, Datum<double>>> loadPowerProfile(const std::string& filename);
+  bool loadFaultPowerProfiles();
+  bool initPrognoser();
+  bool initTopics();
   void jointStatesCb(const sensor_msgs::JointStateConstPtr& msg);
   double generateTemperatureEstimate();
   double generateVoltageEstimate();
@@ -70,6 +74,12 @@ private:
   bool m_thermal_power_failure_activated = false;
   std::vector<std::map<PCOE::MessageId, PCOE::Datum<double>>> m_thermal_power_failure_sequence;
   size_t m_thermal_power_failure_sequence_index = 0;
+
+  double m_power_node_processing_rate = 0.5;   // [Hz] hard code processing rate for now 
+  bool m_processing_power_batch = false;        // flag that indicates that the prognoser is handling current batch
+  bool m_trigger_processing_new_power_batch = false;
+  double m_unprocessed_mechanical_power = 0.0;
+  double m_mechanical_power_to_be_processed = 0.0;
 };
 
 #endif


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡| [OCEANWATER-84 / Power System Modelling](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-84) |
| :----------- | :----------- |
| Jira Ticket 🎟️  | [OCEANWATER-652 / Remove the strong dependency of PowerSystemNode on joint_states topic ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-652) |
| Jira Ticket 🎟️  | [OCEANWATER-673 / When power faults are injected the publish rate of power value is increased ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-673) |
| Github :octocat:  | N/A |


## Summary of Changes
* Decouple the processing of power values from the joint_states callback. This was critical for the following factors:
  - Prognoser takes too much time to process data and thus is not able to keep up
  - This entails that not all power values were actually being processed
  - Also, this change is required for the future when integrated power consumption from other devices (such as the compute board, the antenna, cameras and lander lights, ..)
* Rather than invoking the prognoser on the mean mechanical power value use the accumulated raw power values consumed over a processing cycle
* Set a fixed processing rate for the power (hard coded to 0.5 for now)  

## Test
1) Launch the simulation
```bash
roslaunch ow atacama_y1a.launch
```

2) In another terminal with oceanwaters workspace sourced, monitor the different power system output
```bash
rostopic echo /power_system_node/state_of_charge
rostopic echo /power_system_node/remaining_useful_life
rostopic echo /power_system_node/battery_temperature
```

3) Also monitor the publish rate of the previous topics
```bash
rostopic hz /power_system_node/state_of_charge
rostopic hz /power_system_node/remaining_useful_life
rostopic hz /power_system_node/battery_temperature
```
the update rate should on the order of  ~0.5 hz

4) Enable one or two at most of the different power faults from RQT Dynamic Reconfigure
* low_state_of_charge_power_failure
* instantaneous_capacity_loss_power_failure
* thermal_power_failure

5) Check that the update rate of power node topics stays about the same and doesn't exceed 0.5