### PR TITLE
 switching back controllers in grind in the event of fault

### DIFF
--- a/ow_lander/scripts/grind_action_server.py
+++ b/ow_lander/scripts/grind_action_server.py
@@ -120,6 +120,10 @@ class GrindActionServer(object):
         else:
             rospy.loginfo('%s: Failed' % self._action_name)
             self._server.set_aborted(self._result)
+            switch_success = self.switch_controllers('arm_controller','grinder_controller')
+            if not switch_success:
+                return False, "Failed Switching Controllers"
+            rospy.loginfo('%s: Succeeded' % self._action_name)
 
     
 if __name__ == '__main__':


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️   | [Oceanwater-XXX](url) |
| ----------- | ----------- |
| EPIC ⚡| [Oceanwater-XXX](url) |
| Github :octocat:  | # |


## Summary of Changes
* Change back controller in the event of fault. 

## Test
* Test 6.4 . Re-do test 6.4 to see if it works. 