### PR TITLE
Oceanwater 698 cam trigger fault

### DIFF
--- a/ow/launch/common.launch
+++ b/ow/launch/common.launch
@@ -92,6 +92,7 @@
     args="&#45;&#45;perspective-file $(find ow)/config/default.perspective">
     <remap from="/ant_pan_position_controller/command" to="/_original/ant_pan_position_controller/command"/>
     <remap from="/ant_tilt_position_controller/command" to="/_original/ant_tilt_position_controller/command"/> 
+    <remap from="/StereoCamera/left/image_trigger" to="/_original/StereoCamera/left/image_trigger"/> 
   </node>
 
   <!-- == start bag_recorder_node =========== -->

--- a/ow_faults/CMakeLists.txt
+++ b/ow_faults/CMakeLists.txt
@@ -55,6 +55,7 @@ add_message_files(
   ArmFaults.msg
   PowerFaults.msg
   PTFaults.msg
+  CamFaults.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/ow_faults/cfg/Faults.cfg
+++ b/ow_faults/cfg/Faults.cfg
@@ -11,30 +11,37 @@ joint_state_enum = gen.enum([gen.const("nominal",  int_t, 0, "Joint is functioni
                              gen.const("friction", int_t, 3, "Joint is consuming extra power")],
                             "An enum to set joint state")
 # ANTENNA FAULTS
-gen.add("ant_pan_encoder_failure",       bool_t,   0, "Antenna pan encoder failure",       False)
-gen.add("ant_pan_effort_failure", bool_t,   0, "Antenna pan effort failure", False)
+ant_faults = gen.add_group("ant_faults")
+ant_faults.add("ant_pan_encoder_failure",       bool_t,   0, "Antenna pan encoder failure",       False)
+ant_faults.add("ant_pan_effort_failure", bool_t,   0, "Antenna pan effort failure", False)
 
-gen.add("ant_tilt_encoder_failure",       bool_t,   0, "Antenna tilt encoder failure",       False)
-gen.add("ant_tilt_effort_failure", bool_t,   0, "Antenna tilt effort failure", False)
+ant_faults.add("ant_tilt_encoder_failure",       bool_t,   0, "Antenna tilt encoder failure",       False)
+ant_faults.add("ant_tilt_effort_failure", bool_t,   0, "Antenna tilt effort failure", False)
+
+# CAM FAULTS
+cam_faults = gen.add_group("cam_faults")
+
+cam_faults.add("camera_left_trigger_failure",       bool_t,   0, "Camera Left Trigger failure",       False)
 
 # ARM FAULTS
-gen.add("shou_yaw_encoder_failure",       bool_t,   0, "Shoulder yaw encoder failure",       False)
-gen.add("shou_yaw_effort_failure", bool_t,   0, "Shoulder yaw effort failure", False)
+arm_faults = gen.add_group("arm_faults")
+arm_faults.add("shou_yaw_encoder_failure",       bool_t,   0, "Shoulder yaw encoder failure",       False)
+arm_faults.add("shou_yaw_effort_failure", bool_t,   0, "Shoulder yaw effort failure", False)
 
-gen.add("shou_pitch_encoder_failure",       bool_t,   0, "Shoulder pitch encoder failure",       False)
-gen.add("shou_pitch_effort_failure", bool_t,   0, "Shoulder pitch effort failure", False)
+arm_faults.add("shou_pitch_encoder_failure",       bool_t,   0, "Shoulder pitch encoder failure",       False)
+arm_faults.add("shou_pitch_effort_failure", bool_t,   0, "Shoulder pitch effort failure", False)
 
-gen.add("prox_pitch_encoder_failure",       bool_t,   0, "Proximal pitch encoder failure",       False)
-gen.add("prox_pitch_effort_failure", bool_t,   0, "Proximal pitch effort failure", False)
+arm_faults.add("prox_pitch_encoder_failure",       bool_t,   0, "Proximal pitch encoder failure",       False)
+arm_faults.add("prox_pitch_effort_failure", bool_t,   0, "Proximal pitch effort failure", False)
 
-gen.add("dist_pitch_encoder_failure",       bool_t,   0, "Distal pitch encoder failure",       False)
-gen.add("dist_pitch_effort_failure", bool_t,   0, "Distal pitch effort failure", False)
+arm_faults.add("dist_pitch_encoder_failure",       bool_t,   0, "Distal pitch encoder failure",       False)
+arm_faults.add("dist_pitch_effort_failure", bool_t,   0, "Distal pitch effort failure", False)
 
-gen.add("hand_yaw_encoder_failure",       bool_t,   0, "Hand yaw encoder failure",       False)
-gen.add("hand_yaw_effort_failure", bool_t,   0, "Hand yaw effort failure", False)
+arm_faults.add("hand_yaw_encoder_failure",       bool_t,   0, "Hand yaw encoder failure",       False)
+arm_faults.add("hand_yaw_effort_failure", bool_t,   0, "Hand yaw effort failure", False)
 
-gen.add("scoop_yaw_encoder_failure",       bool_t,   0, "Scoop yaw encoder failure",       False)
-gen.add("scoop_yaw_effort_failure", bool_t,   0, "Scoop yaw effort failure", False)
+arm_faults.add("scoop_yaw_encoder_failure",       bool_t,   0, "Scoop yaw encoder failure",       False)
+arm_faults.add("scoop_yaw_effort_failure", bool_t,   0, "Scoop yaw effort failure", False)
 
 # FT Sensor Faults
 ft_sensor_faults = gen.add_group("ft_sensor_faults")

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -80,6 +80,8 @@ public:
 private:
   
   ////////// functions
+  void publishSystemFaultsMessage();
+
   //Arm functions
   // Output /faults/joint_states, a modified version of /joint_states, injecting
   // simple message faults that don't need to be simulated at their source.
@@ -155,7 +157,7 @@ private:
 
   ////////// vars
   //system
-  std::bitset<10> m_system_faults_bitset;
+  std::bitset<10> m_system_faults_bitset{};
 
   //general component faults
   bool m_arm_fault;

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -11,11 +11,13 @@
 #include <ros/ros.h>
 #include <cstdint>
 #include <std_msgs/Float64.h>
+#include <std_msgs/Empty.h>
 #include <ow_faults/FaultsConfig.h>
 #include "ow_faults/SystemFaults.h"
 #include "ow_faults/ArmFaults.h"
 #include "ow_faults/PowerFaults.h"
 #include "ow_faults/PTFaults.h"
+#include "ow_faults/CamFaults.h"
 #include <ow_lander/lander_joints.h>
 #include <sensor_msgs/JointState.h>
 #include <geometry_msgs/WrenchStamped.h>
@@ -93,6 +95,9 @@ private:
   // true. Otherwise, return false.
   bool findJointIndex(const unsigned int joint, unsigned int& out_index);
 
+  //camera function
+  void cameraTriggerCb(const std_msgs::Empty& msg);
+
   // power functions
   float getRandomFloatFromRange(float min_val, float max_val);
   void publishPowerSystemFault();
@@ -131,6 +136,10 @@ private:
   ros::Subscriber m_dist_pitch_ft_sensor_sub;
   ros::Publisher m_dist_pitch_ft_sensor_pub;
 
+  // camera
+  ros::Subscriber m_camera_trigger_sub;
+  ros::Publisher m_camera_trigger_remapped_pub;
+
   //antenna 
   ros::Subscriber m_fault_ant_pan_sub;
   ros::Subscriber m_fault_ant_tilt_sub;
@@ -138,10 +147,11 @@ private:
   ros::Publisher m_fault_ant_tilt_remapped_pub;
 
   // jpl message publishers
-  ros::Publisher m_system_fault_jpl_msg_pub;
-  ros::Publisher m_arm_fault_jpl_msg_pub;
-  ros::Publisher m_power_fault_jpl_msg_pub;
   ros::Publisher m_antennae_fault_jpl_msg_pub;
+  ros::Publisher m_arm_fault_jpl_msg_pub;
+  ros::Publisher m_camera_fault_jpl_msg_pub;
+  ros::Publisher m_power_fault_jpl_msg_pub;
+  ros::Publisher m_system_fault_jpl_msg_pub;
 
   ////////// vars
   //system

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -107,8 +107,8 @@ private:
   void powerTemperatureListener(const std_msgs::Float64& msg);
 
   // Antennae functions
-  void antennaePanFaultCb(const std_msgs::Float64& msg);
-  void antennaeTiltFaultCb(const std_msgs::Float64& msg);
+  void antennaPanFaultCb(const std_msgs::Float64& msg);
+  void antennaTiltFaultCb(const std_msgs::Float64& msg);
   void publishAntennaeFaults(const std_msgs::Float64& msg, bool encoder, 
                              bool torque, float& m_faultValue, ros::Publisher& m_publisher);
 
@@ -149,7 +149,7 @@ private:
   ros::Publisher m_fault_ant_tilt_remapped_pub;
 
   // jpl message publishers
-  ros::Publisher m_antennae_fault_jpl_msg_pub;
+  ros::Publisher m_antenna_fault_jpl_msg_pub;
   ros::Publisher m_arm_fault_jpl_msg_pub;
   ros::Publisher m_camera_fault_jpl_msg_pub;
   ros::Publisher m_power_fault_jpl_msg_pub;

--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -149,11 +149,11 @@ private:
   ros::Publisher m_fault_ant_tilt_remapped_pub;
 
   // jpl message publishers
-  ros::Publisher m_antenna_fault_jpl_msg_pub;
-  ros::Publisher m_arm_fault_jpl_msg_pub;
-  ros::Publisher m_camera_fault_jpl_msg_pub;
-  ros::Publisher m_power_fault_jpl_msg_pub;
-  ros::Publisher m_system_fault_jpl_msg_pub;
+  ros::Publisher m_antenna_fault_msg_pub;
+  ros::Publisher m_arm_fault_msg_pub;
+  ros::Publisher m_camera_fault_msg_pub;
+  ros::Publisher m_power_fault_msg_pub;
+  ros::Publisher m_system_fault_msg_pub;
 
   ////////// vars
   //system

--- a/ow_faults/msg/CamFaults.msg
+++ b/ow_faults/msg/CamFaults.msg
@@ -1,0 +1,6 @@
+#Cam fault status
+# int32 None = 0
+# int32 Hardware = 1
+# int32 BadParameters = 2
+Header header
+int32 value

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -30,9 +30,10 @@ FaultInjector::FaultInjector(ros::NodeHandle& node_handle)
     10, &FaultInjector::distPitchFtSensorCb, this);
   m_dist_pitch_ft_sensor_pub = node_handle.advertise<geometry_msgs::WrenchStamped>(ft_sensor_dist_pitch_str, 10);
 
-  m_camera_trigger_sub = node_handle.subscribe("/_original/StereoCamera/left/image_trigger",
+  auto image_trigger_str = "/StereoCamera/left/image_trigger";
+  m_camera_trigger_sub = node_handle.subscribe(string("/_original") + image_trigger_str,
     10, &FaultInjector::cameraTriggerCb, this);
-  m_camera_trigger_remapped_pub = node_handle.advertise<std_msgs::Empty>("/StereoCamera/left/image_trigger", 10);
+  m_camera_trigger_remapped_pub = node_handle.advertise<std_msgs::Empty>(image_trigger_str, 10);
 
   m_fault_ant_pan_remapped_pub = node_handle.advertise<std_msgs::Float64>("/ant_pan_position_controller/command", 10);
   m_fault_ant_tilt_remapped_pub = node_handle.advertise<std_msgs::Float64>("/ant_tilt_position_controller/command", 10);

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -39,11 +39,11 @@ FaultInjector::FaultInjector(ros::NodeHandle& node_handle)
   m_fault_ant_tilt_remapped_pub = node_handle.advertise<std_msgs::Float64>("/ant_tilt_position_controller/command", 10);
 
   // topics for JPL msgs: system fault messages, see Faults.msg, Arm.msg, Power.msg, PTFaults.msg
-  m_antenna_fault_jpl_msg_pub = node_handle.advertise<ow_faults::PTFaults>("/faults/pt_faults_status", 10);
-  m_arm_fault_jpl_msg_pub = node_handle.advertise<ow_faults::ArmFaults>("/faults/arm_faults_status", 10);
-  m_camera_fault_jpl_msg_pub = node_handle.advertise<ow_faults::CamFaults>("/faults/cam_faults_status", 10);
-  m_power_fault_jpl_msg_pub = node_handle.advertise<ow_faults::PowerFaults>("/faults/power_faults_status", 10);
-  m_system_fault_jpl_msg_pub = node_handle.advertise<ow_faults::SystemFaults>("/faults/system_faults_status", 10);
+  m_antenna_fault_msg_pub = node_handle.advertise<ow_faults::PTFaults>("/faults/pt_faults_status", 10);
+  m_arm_fault_msg_pub = node_handle.advertise<ow_faults::ArmFaults>("/faults/arm_faults_status", 10);
+  m_camera_fault_msg_pub = node_handle.advertise<ow_faults::CamFaults>("/faults/cam_faults_status", 10);
+  m_power_fault_msg_pub = node_handle.advertise<ow_faults::PowerFaults>("/faults/power_faults_status", 10);
+  m_system_fault_msg_pub = node_handle.advertise<ow_faults::SystemFaults>("/faults/system_faults_status", 10);
 
   //power fault publishers and subs
   m_power_soc_sub = node_handle.subscribe("/power_system_node/state_of_charge",
@@ -108,7 +108,7 @@ void FaultInjector::cameraTriggerCb(const std_msgs::Empty& msg){
     m_system_faults_bitset &= ~isCamExecutionError;
   }
   // publishSystemFaultsMessage();
-  m_camera_fault_jpl_msg_pub.publish(camera_faults_msg);
+  m_camera_fault_msg_pub.publish(camera_faults_msg);
 }
 
 void FaultInjector::publishAntennaeFaults(const std_msgs::Float64& msg, bool encoder, bool torque, float& m_faultValue, ros::Publisher& m_publisher){
@@ -153,7 +153,7 @@ void FaultInjector::publishPowerSystemFault(){
     m_system_faults_bitset &= ~isPowerSystemFault;
   }
   publishSystemFaultsMessage();
-  m_power_fault_jpl_msg_pub.publish(power_faults_msg);
+  m_power_fault_msg_pub.publish(power_faults_msg);
 }
 
 void FaultInjector::powerTemperatureListener(const std_msgs::Float64& msg)
@@ -278,14 +278,14 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
   m_joint_state_pub.publish(output);
   publishSystemFaultsMessage();
 
-  m_arm_fault_jpl_msg_pub.publish(arm_faults_msg);
-  m_antenna_fault_jpl_msg_pub.publish(pt_faults_msg);
+  m_arm_fault_msg_pub.publish(arm_faults_msg);
+  m_antenna_fault_msg_pub.publish(pt_faults_msg);
 }
 
 void FaultInjector::publishSystemFaultsMessage(){
   ow_faults::SystemFaults system_faults_msg;
   setBitsetFaultsMessage(system_faults_msg, m_system_faults_bitset);
-  m_system_fault_jpl_msg_pub.publish(system_faults_msg);
+  m_system_fault_msg_pub.publish(system_faults_msg);
 }
 
 void FaultInjector::distPitchFtSensorCb(const geometry_msgs::WrenchStamped& msg)

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -38,7 +38,7 @@ FaultInjector::FaultInjector(ros::NodeHandle& node_handle)
   m_fault_ant_tilt_remapped_pub = node_handle.advertise<std_msgs::Float64>("/ant_tilt_position_controller/command", 10);
 
   // topics for JPL msgs: system fault messages, see Faults.msg, Arm.msg, Power.msg, PTFaults.msg
-  m_antennae_fault_jpl_msg_pub = node_handle.advertise<ow_faults::PTFaults>("/faults/pt_faults_status", 10);
+  m_antenna_fault_jpl_msg_pub = node_handle.advertise<ow_faults::PTFaults>("/faults/pt_faults_status", 10);
   m_arm_fault_jpl_msg_pub = node_handle.advertise<ow_faults::ArmFaults>("/faults/arm_faults_status", 10);
   m_camera_fault_jpl_msg_pub = node_handle.advertise<ow_faults::CamFaults>("/faults/cam_faults_status", 10);
   m_power_fault_jpl_msg_pub = node_handle.advertise<ow_faults::PowerFaults>("/faults/power_faults_status", 10);
@@ -57,11 +57,11 @@ FaultInjector::FaultInjector(ros::NodeHandle& node_handle)
   //antenna fault publishers and subs
   m_fault_ant_pan_sub = node_handle.subscribe("/_original/ant_pan_position_controller/command",
                                               3,
-                                              &FaultInjector::antennaePanFaultCb,
+                                              &FaultInjector::antennaPanFaultCb,
                                               this);
   m_fault_ant_tilt_sub = node_handle.subscribe("/_original/ant_tilt_position_controller/command",
                                               3,
-                                              &FaultInjector::antennaeTiltFaultCb,
+                                              &FaultInjector::antennaTiltFaultCb,
                                               this);
 
   srand (static_cast <unsigned> (time(0)));
@@ -122,14 +122,14 @@ void FaultInjector::publishAntennaeFaults(const std_msgs::Float64& msg, bool enc
 
 // Note for torque sensor failure, we are finding whether or not the hardware faults for antenna are being triggered.
 // Given that, this is separate from the torque sensor implemented by Ussama.
-void FaultInjector::antennaePanFaultCb(const std_msgs::Float64& msg){
+void FaultInjector::antennaPanFaultCb(const std_msgs::Float64& msg){
   publishAntennaeFaults(msg,
                         m_faults.ant_pan_encoder_failure,
                         m_faults.ant_pan_effort_failure,
                         m_fault_pan_value, m_fault_ant_pan_remapped_pub );
 }
 
-void FaultInjector::antennaeTiltFaultCb(const std_msgs::Float64& msg){
+void FaultInjector::antennaTiltFaultCb(const std_msgs::Float64& msg){
   publishAntennaeFaults(msg,
                         m_faults.ant_tilt_encoder_failure,
                         m_faults.ant_tilt_effort_failure,
@@ -278,7 +278,7 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
   publishSystemFaultsMessage();
 
   m_arm_fault_jpl_msg_pub.publish(arm_faults_msg);
-  m_antennae_fault_jpl_msg_pub.publish(pt_faults_msg);
+  m_antenna_fault_jpl_msg_pub.publish(pt_faults_msg);
 }
 
 void FaultInjector::publishSystemFaultsMessage(){


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡| [OCEANWATER-698](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-698) |
| :----------- | :----------- |
| Jira Ticket 🎟️   | [OCEANWATER-551](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-551) |
| Github :octocat:  | # |


## Summary of Changes
* New JPL msg CamFaults.msg
* new rqt option for camera trigger fault
* new topic for jpl messages
* * /faults/camera_fault_status
* new function to handle all publishing to system faults status
* remapped /StereoCamera/left/image_trigger with prefix /_original
* On camera trigger fault, camera trigger does not fire and publishes error to cam faults status and system faults status.


## Test
`roslaunch ow atacama_y1a.launch 
`

TEST REMAPPING
* `rostopic info /_original/StereoCamera/left/image_trigger`
** observe that it is subbed by the Faults node
* `rostopic info /StereoCamera/left/image_trigger`
** observe it is published by Faults node

TEST CAMERA FAULT
* in RQT->control and Viz, check on StereoCamera/left/image_trigger
** you should see a black screen in Image View
* in new terminal, set cam fault on
** `rosrun dynamic_reconfigure dynparam set /faults camera_left_trigger_failure true`
* in RQT move antenna 
** set /ant_tilt_position_controller value to 0.5
** here you should see no change in Image view, black image
* back in terminal, set cam fault off
** `rosrun dynamic_reconfigure dynparam set /faults camera_left_trigger_failure false`
* go back to Image View
** image should be updated with view of rocks

TEST CAMS JPL MESSAGE
note: bc the fault is camera trigger, messages do not publish unless the cam trigger is set to on. This simulates fault notifications when the user is trying to take an image. 
* in RQT->control and Viz, check on StereoCamera/left/image_trigger
* in new terminal, run
** `rostopic echo /faults/cam_faults_status`
** should see value =  0
* in new terminal, set cam fault on
** `rosrun dynamic_reconfigure dynparam set /faults camera_left_trigger_failure true`
* back to rostopic terminal, value should be 1 now
* back in rosrun terminal, set cam fault off
** `rosrun dynamic_reconfigure dynparam set /faults camera_left_trigger_failure false`
* back to rostopic terminal, no more publishing to topic.

TEST CAMS FAULTS IN SYSTEM FAULTS
note: bc the fault is camera trigger, messages do not publish unless the cam trigger is set to on. This simulates fault notifications when the user is trying to take an image. 
* in RQT->control and Viz, check on StereoCamera/left/image_trigger
* in new terminal, run
** `rostopic echo /faults/system_faults_status`
** should see value =  0
* in new terminal, set cam fault on
** `rosrun dynamic_reconfigure dynparam set /faults camera_left_trigger_failure true`
* back to rostopic terminal, value should be 32 now
* back in rosrun terminal, set cam fault off
** `rosrun dynamic_reconfigure dynparam set /faults camera_left_trigger_failure false`
* back to rostopic terminal, value should be 0 now

