### PR TITLE
Update to include perma url

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,8 @@
 ## Linked Issues:
-| EPIC ⚡| [OCEANWATER-XXX](url) |
+| EPIC ⚡| [OCEANWATER-XXX](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-XXX) |
+) |
 | :----------- | :----------- |
-| Jira Ticket 🎟️   | [OCEANWATER-XXX](url) |
+| Jira Ticket 🎟️   | [OCEANWATER-XXX](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-XXX)) |
 | Github :octocat:  | # |
 
 


### PR DESCRIPTION
all links to jira follow the same URL structure except the ticket number. Users will only need to update XXX with respective ticket numbers instead of copying the entire URL each time.

## Linked Issues:
| EPIC ⚡| [OCEANWATER-XXX](url) |
| :----------- | :----------- |
| Jira Ticket 🎟️   | [OCEANWATER-XXX](url) |
| Github :octocat:  | # |


## Summary of Changes
* 

## Test
* 
