### PR TITLE
Oceanwater 704 moveit commander throws an exception for arm ros actions interface under noetic

### DIFF
--- a/ow_lander/scripts/action_deliver_sample.py
+++ b/ow_lander/scripts/action_deliver_sample.py
@@ -124,7 +124,7 @@ def deliver_sample(move_arm, robot, moveit_fk, args):
 
   move_arm.set_pose_target(goal_pose)
 
-  plan_a = move_arm.plan()
+  _, plan_a, _, _ = move_arm.plan()
   
 
   if len(plan_a.joint_trajectory.points) == 0:  # If no plan found, abort
@@ -158,7 +158,7 @@ def deliver_sample(move_arm, robot, moveit_fk, args):
   goal_pose.orientation = Quaternion(q[0], q[1], q[2], q[3])
   
   move_arm.set_pose_target(goal_pose)
-  plan_b = move_arm.plan()
+  _, plan_b, _, _ = move_arm.plan()
 
   if len(plan_b.joint_trajectory.points) == 0:  # If no plan found, send the previous plan only
     return plan_a

--- a/ow_lander/scripts/action_dig_circular.py
+++ b/ow_lander/scripts/action_dig_circular.py
@@ -81,8 +81,7 @@ def go_to_XYZ_coordinate(move_arm, cs, goal_pose, x_start, y_start, z_start, app
   else:
     move_arm.set_pose_target(goal_pose)
 
-  plan = move_arm.plan()
-  print (plan)
+  _, plan, _, _ = move_arm.plan()
   
   if len(plan.joint_trajectory.points) == 0:  # If no plan found, abort
     return False
@@ -116,7 +115,7 @@ def go_to_Z_coordinate(move_arm, cs, goal_pose, x_start, y_start, z_start, appro
   else:
     move_arm.set_pose_target(goal_pose)
 
-  plan = move_arm.plan()
+  _, plan, _, _ = move_arm.plan()
   
   
   if len(plan.joint_trajectory.points) == 0:  # If no plan found, abort
@@ -154,8 +153,9 @@ def move_to_pre_trench_configuration_dig_circ(move_arm, robot, x_start, y_start)
     return False
 
   joint_goal[constants.J_SCOOP_YAW] = 0
-  
-  plan = move_arm.plan(joint_goal)
+
+  move_arm.set_joint_value_target(joint_goal)
+  _, plan, _, _ = move_arm.plan()
   return plan
 
 
@@ -191,7 +191,7 @@ def dig_circular(move_arm, move_limbs, robot, moveit_fk, args):
     
     move_arm.set_start_state(cs)
     move_arm.set_pose_target(end_pose)
-    plan_b = move_arm.plan()
+    _, plan_b, _, _ = move_arm.plan()
     if len(plan_b.joint_trajectory.points) == 0:  # If no plan found, abort
       return False
     circ_traj = cascade_plans (plan_a, plan_b)

--- a/ow_lander/scripts/action_dig_linear.py
+++ b/ow_lander/scripts/action_dig_linear.py
@@ -79,7 +79,8 @@ def move_to_pre_trench_configuration(move_arm, robot, x_start, y_start):
     return False
 
   joint_goal[constants.J_SCOOP_YAW] = 0
-  plan = move_arm.plan(joint_goal)
+  move_arm.set_joint_value_target(joint_goal)
+  _, plan, _, _ = move_arm.plan()
   return plan
 
 
@@ -120,7 +121,8 @@ def change_joint_value(move_arm, cs, start_state, joint_index, target_value):
       
       
   joint_goal[joint_index] = target_value
-  plan = move_arm.plan(joint_goal)
+  move_arm.set_joint_value_target(joint_goal)
+  _, plan, _, _ = move_arm.plan()
   return plan
 
 def go_to_Z_coordinate(move_arm, cs, goal_pose, x_start, y_start, z_start, approximate=True):
@@ -146,7 +148,7 @@ def go_to_Z_coordinate(move_arm, cs, goal_pose, x_start, y_start, z_start, appro
     move_arm.set_joint_value_target(goal_pose, True)
   else:
     move_arm.set_pose_target(goal_pose)
-  plan = move_arm.plan()
+  _, plan, _, _ = move_arm.plan()
   if len(plan.joint_trajectory.points) == 0:  # If no plan found, abort
     return False
   return plan

--- a/ow_lander/scripts/action_grind.py
+++ b/ow_lander/scripts/action_grind.py
@@ -141,7 +141,7 @@ def grind(move_grinder, robot, moveit_fk, args):
   goal_pose.orientation.z = -0.706723318474
   goal_pose.orientation.w = 0.0307192507001
   move_grinder.set_pose_target(goal_pose)
-  plan_a = move_grinder.plan()
+  _, plan_a, _, _ = move_grinder.plan()
   if len(plan_a.joint_trajectory.points) == 0: # If no plan found, abort
     return False
 

--- a/ow_lander/scripts/action_guarded_move.py
+++ b/ow_lander/scripts/action_guarded_move.py
@@ -64,7 +64,8 @@ def guarded_move_plan(move_arm, robot, moveit_fk, args):
 
   joint_goal[constants.J_SCOOP_YAW] = 0
   
-  plan_a = move_arm.plan(joint_goal)
+  move_arm.set_joint_value_target(joint_goal)
+  _, plan_a, _, _ = move_arm.plan()
   if len(plan_a.joint_trajectory.points) == 0:  # If no plan found, abort
     return False
   
@@ -77,7 +78,7 @@ def guarded_move_plan(move_arm, robot, moveit_fk, args):
 
   move_arm.set_pose_target(goal_pose)
   move_arm.set_max_velocity_scaling_factor(0.5)
-  plan_b = move_arm.plan()
+  _, plan_b, _, _ = move_arm.plan()
   if len(plan_b.joint_trajectory.points) == 0:  # If no plan found, abort
     return False
   pre_guarded_move_traj = cascade_plans (plan_a, plan_b)
@@ -96,7 +97,7 @@ def guarded_move_plan(move_arm, robot, moveit_fk, args):
   goal_pose.position.z -= direction_z*search_distance
 
   move_arm.set_pose_target(goal_pose)
-  plan_c  = move_arm.plan()
+  _, plan_c, _, _  = move_arm.plan()
   
   guarded_move_traj = cascade_plans (pre_guarded_move_traj, plan_c)
   

--- a/ow_lander/scripts/activity_deliver_sample.py
+++ b/ow_lander/scripts/activity_deliver_sample.py
@@ -61,7 +61,7 @@ def deliver_sample(move_arm, args):
 
   move_arm.set_pose_target(goal_pose)
 
-  success, plan, planning_time, error_code = move_arm.plan()
+  _, plan, _, _ = move_arm.plan()
 
   if len(plan.joint_trajectory.points) == 0:  # If no plan found, abort
     return False
@@ -96,7 +96,7 @@ def deliver_sample(move_arm, args):
 
   goal_pose.orientation = Quaternion(q[0], q[1], q[2], q[3])
   move_arm.set_pose_target(goal_pose)
-  success, plan, planning_time, error_code = move_arm.plan()
+  _, plan, _, _ = move_arm.plan()
 
   if len(plan.joint_trajectory.points) == 0:  # If no plan found, abort
     return False

--- a/ow_lander/scripts/activity_full_digging_traj.py
+++ b/ow_lander/scripts/activity_full_digging_traj.py
@@ -32,7 +32,8 @@ def go_to_Z_coordinate(move_group, x_start, y_start, z_start, approximate=True):
     move_group.set_joint_value_target(goal_pose, True)
   else:
     move_group.set_pose_target(goal_pose)
-  success, plan, planning_time, error_code = move_group.plan()
+  
+  _, plan, _, _ = move_group.plan()
   if len(plan.joint_trajectory.points) == 0:  # If no plan found, abort
     return False
   plan = move_group.go(wait=True)
@@ -48,7 +49,8 @@ def change_joint_value(move_group, joint_index, target_value):
   """
   joint_goal = move_group.get_current_joint_values()
   joint_goal[joint_index] = target_value
-  plan = move_group.plan(joint_goal)
+  move_group.set_joint_value_target(joint_goal)
+  _, plan, _, _ = move_group.plan()
   move_group.execute(plan, wait=True)
   #move_group.go(joint_goal, wait=True)
   move_group.stop()
@@ -79,7 +81,8 @@ def move_to_pre_trench_configuration(move_arm, x_start, y_start):
     return False
 
   joint_goal[constants.J_SCOOP_YAW] = 0
-  plan = move_arm.plan(joint_goal)
+  move_arm.set_joint_value_target(joint_goal)
+  _, plan, _, _ = move_arm.plan()
   #move_arm.asyncExecute(plan, wait=True)
   move_arm.execute(plan, wait=True)
   #move_arm.go(joint_goal, wait=True)

--- a/ow_lander/scripts/activity_grind.py
+++ b/ow_lander/scripts/activity_grind.py
@@ -98,7 +98,7 @@ def grind(move_grinder, args):
   goal_pose.orientation.z = -0.706723318474
   goal_pose.orientation.w = 0.0307192507001
   move_grinder.set_pose_target(goal_pose)
-  success, plan, planning_time, error_code = move_grinder.plan()
+  _, plan, _, _ = move_grinder.plan()
   if len(plan.joint_trajectory.points) == 0: # If no plan found, abort
     return False
   plan = move_grinder.go(wait=True)

--- a/ow_lander/scripts/activity_guarded_move.py
+++ b/ow_lander/scripts/activity_guarded_move.py
@@ -85,7 +85,7 @@ def pre_guarded_move(move_arm, args):
   goal_pose.position.y = targ_y
   goal_pose.position.z = targ_z
   move_arm.set_pose_target(goal_pose)
-  success, plan, planning_time, error_code = move_arm.plan()
+  _, plan, _, _ = move_arm.plan()
   if len(plan.joint_trajectory.points) == 0:  # If no plan found, abort
     return False
 

--- a/ow_lander/scripts/path_planning_commander.py
+++ b/ow_lander/scripts/path_planning_commander.py
@@ -55,7 +55,7 @@ class PathPlanningCommander(object):
     goal = self.arm_move_group.get_named_target_values("arm_stowed")
     self.arm_move_group.set_joint_value_target(goal)
 
-    success, plan, planning_time, error_code = self.arm_move_group.plan()
+    _, plan, _, _ = self.arm_move_group.plan()
     if len(plan.joint_trajectory.points) == 0:
       return False
     self.trajectory_async_executer.execute(plan.joint_trajectory, 
@@ -72,7 +72,7 @@ class PathPlanningCommander(object):
     print("Unstow arm activity started")
     goal = self.arm_move_group.get_named_target_values("arm_unstowed")
     self.arm_move_group.set_joint_value_target(goal)
-    success, plan, planning_time, error_code = self.arm_move_group.plan()
+    _, plan, _, _ = self.arm_move_group.plan()
     if len(plan.joint_trajectory.points) == 0:
       return False
     self.trajectory_async_executer.execute(plan.joint_trajectory,

--- a/ow_lander/scripts/stow_action_server.py
+++ b/ow_lander/scripts/stow_action_server.py
@@ -24,7 +24,7 @@ from trajectory_async_execution import TrajectoryAsyncExecuter
 
 
 
-class UnstowActionServer(object):
+class StowActionServer(object):
     
     def __init__(self,name):
         self._action_name = name
@@ -55,10 +55,11 @@ class UnstowActionServer(object):
         
     def _update_motion(self):
 
-        print("Unstow arm activity started")
+        print("Stow arm activity started")
         goal = self._interface.move_arm.get_current_pose().pose
         goal = self._interface.move_arm.get_named_target_values("arm_stowed")
-        plan = self._interface.move_arm.plan(goal)
+        self._interface.move_arm.set_joint_value_target(goal)
+        _, plan, _, _ = self._interface.move_arm.plan()
         if len(plan.joint_trajectory.points) < 1: 
             return 
         else:
@@ -107,7 +108,7 @@ class UnstowActionServer(object):
 
 if __name__ == '__main__':
     rospy.init_node('Stow')
-    server = UnstowActionServer(rospy.get_name())
+    server = StowActionServer(rospy.get_name())
     rospy.spin()
         
   

--- a/ow_lander/scripts/stow_action_server.py
+++ b/ow_lander/scripts/stow_action_server.py
@@ -56,7 +56,6 @@ class StowActionServer(object):
     def _update_motion(self):
 
         print("Stow arm activity started")
-        goal = self._interface.move_arm.get_current_pose().pose
         goal = self._interface.move_arm.get_named_target_values("arm_stowed")
         self._interface.move_arm.set_joint_value_target(goal)
         _, plan, _, _ = self._interface.move_arm.plan()

--- a/ow_lander/scripts/unstow_action_server.py
+++ b/ow_lander/scripts/unstow_action_server.py
@@ -56,7 +56,6 @@ class UnstowActionServer(object):
     def _update_motion(self):
 
         print("Unstow arm activity started")
-        goal = self._interface.move_arm.get_current_pose().pose
         goal = self._interface.move_arm.get_named_target_values("arm_unstowed")
         self._interface.move_arm.set_joint_value_target(goal)
         _, plan, _, _ = self._interface.move_arm.plan()

--- a/ow_lander/scripts/unstow_action_server.py
+++ b/ow_lander/scripts/unstow_action_server.py
@@ -58,7 +58,8 @@ class UnstowActionServer(object):
         print("Unstow arm activity started")
         goal = self._interface.move_arm.get_current_pose().pose
         goal = self._interface.move_arm.get_named_target_values("arm_unstowed")
-        success, plan, planning_time, error_code = self._interface.move_arm.plan(goal)
+        self._interface.move_arm.set_joint_value_target(goal)
+        _, plan, _, _ = self._interface.move_arm.plan()
         if len(plan.joint_trajectory.points) < 1: 
             return 
         else:


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡| [OCEANWATER-577 / Support for ROS Noetic](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-577) |
| :----------- | :----------- |
| Jira Ticket 🎟️   | [OCEANWATER-704 / MoveIt Commander throws an exception for arm ros actions interface under Noetic](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-704) |
| Github :octocat:  | N/A |


## Summary of Changes
* The goal for all MoveIt MoveGroup planning requests is explicitly set in a separate call
* All plan requests expects a tuple of 4 as an answer to the return request    

## Test
> Note: You need to be on Ubuntu 20.04 with ROS Noetic installed to test this
* Run through tests [2](https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/OW-TEST008+-+release-8-0#OWTEST008release80-2.Samplecollection:planningandexecution) and [9](https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/OW-TEST008+-+release-8-0#OWTEST008release80-9.ROSActions) of [OceanWATERS release 8 tests](https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/OW-TEST008+-+release-8-0) 
