### PR TITLE
Oceanwater 706 update camera fault

### DIFF
--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -123,6 +123,7 @@ private:
   //checking rqt faults
   void checkArmFaults();
   void checkAntFaults();
+  void checkCamFaults();
 
   ///////publishers and subsscribers
   // arm faults
@@ -162,6 +163,7 @@ private:
   //general component faults
   bool m_arm_fault;
   bool m_ant_fault;
+  bool m_cam_fault = false;
   bool m_soc_fault = false;
   bool m_temperature_fault = false;
 

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -269,8 +269,7 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
   if (m_cam_fault){
     m_system_faults_bitset |= isCamExecutionError;
     setComponentFaultsMessage(camera_faults_msg, hardwareFault);
-  }
-  else {
+  } else {
     m_system_faults_bitset &= ~isCamExecutionError;
   }
 

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -97,18 +97,10 @@ void FaultInjector::setComponentFaultsMessage(fault_msg& msg, ComponentFaults va
 }
 
 void FaultInjector::cameraTriggerCb(const std_msgs::Empty& msg){
-  ow_faults::CamFaults camera_faults_msg;
-
-  if (m_faults.camera_left_trigger_failure) {// if fault
-    setComponentFaultsMessage(camera_faults_msg, ComponentFaults::Hardware);
-    m_system_faults_bitset |= isCamExecutionError;
-  } else { //no fault
+  if (!m_cam_fault) {// if no fault
     std_msgs::Empty msg;
     m_camera_trigger_remapped_pub.publish(msg);
-    m_system_faults_bitset &= ~isCamExecutionError;
   }
-  // publishSystemFaultsMessage();
-  m_camera_fault_msg_pub.publish(camera_faults_msg);
 }
 
 void FaultInjector::publishAntennaeFaults(const std_msgs::Float64& msg, bool encoder, bool torque, float& m_faultValue, ros::Publisher& m_publisher){
@@ -192,6 +184,7 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
   ow_faults::SystemFaults system_faults_msg;
   ow_faults::ArmFaults arm_faults_msg;
   ow_faults::PTFaults pt_faults_msg;
+  ow_faults::CamFaults camera_faults_msg;
 
   ComponentFaults hardwareFault =  ComponentFaults::Hardware;
 
@@ -200,6 +193,7 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
 
   checkArmFaults();
   checkAntFaults();
+  checkCamFaults();
 
   //pant tilt faults
   if (m_faults.ant_pan_encoder_failure && findJointIndex(J_ANT_PAN, index)) {
@@ -272,14 +266,20 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
     m_system_faults_bitset &= ~isArmExecutionError;
   }
 
-  if (!m_faults.camera_left_trigger_failure) {// if fault
+  if (m_cam_fault){
+    m_system_faults_bitset |= isCamExecutionError;
+    setComponentFaultsMessage(camera_faults_msg, hardwareFault);
+  }
+  else {
     m_system_faults_bitset &= ~isCamExecutionError;
   }
+
   m_joint_state_pub.publish(output);
   publishSystemFaultsMessage();
 
   m_arm_fault_msg_pub.publish(arm_faults_msg);
   m_antenna_fault_msg_pub.publish(pt_faults_msg);
+  m_camera_fault_msg_pub.publish(camera_faults_msg);
 }
 
 void FaultInjector::publishSystemFaultsMessage(){
@@ -329,6 +329,10 @@ void FaultInjector::checkArmFaults(){
 void FaultInjector::checkAntFaults(){
   m_ant_fault = (m_faults.ant_pan_encoder_failure || m_faults.ant_pan_effort_failure ||
                 m_faults.ant_tilt_encoder_failure || m_faults.ant_tilt_effort_failure);
+}
+
+void FaultInjector::checkCamFaults(){
+  m_cam_fault = m_faults.camera_left_trigger_failure ;
 }
 
 template<typename group_t, typename item_t>


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡| [OCEANWATER-706](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-706) |
| :----------- | :----------- |
| Jira Ticket 🎟️   | [OCEANWATER-551](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-551)) |
| Github :octocat:  | # |


## Summary of Changes
*  updating where cam faults get published such that when selected in rqt, messages are published. 

## Test
*  see tests from #129 
