### PR TITLE
HOTFIX: Disable velocity limits on all joints

### DIFF
--- a/ow_lander/config/joint_limits.yaml
+++ b/ow_lander/config/joint_limits.yaml
@@ -3,47 +3,47 @@
 # Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
 joint_limits:
   j_ant_pan:
-    has_velocity_limits: true
+    has_velocity_limits: false
     max_velocity: 0.4
     has_acceleration_limits: false
     max_acceleration: 0
   j_ant_tilt:
-    has_velocity_limits: true
+    has_velocity_limits: false
     max_velocity: 0.4
     has_acceleration_limits: false
     max_acceleration: 0
   j_dist_pitch:
-    has_velocity_limits: true
+    has_velocity_limits: false
     max_velocity: 0.2
     has_acceleration_limits: false
     max_acceleration: 0
   j_grinder:
-    has_velocity_limits: true
+    has_velocity_limits: false
     max_velocity: 0.1
     has_acceleration_limits: false
     max_acceleration: 0
   j_hand_yaw:
-    has_velocity_limits: true
+    has_velocity_limits: false
     max_velocity: 0.2
     has_acceleration_limits: false
     max_acceleration: 0
   j_prox_pitch:
-    has_velocity_limits: true
+    has_velocity_limits: false
     max_velocity: 0.2
     has_acceleration_limits: false
     max_acceleration: 0
   j_scoop_yaw:
-    has_velocity_limits: true
+    has_velocity_limits: false
     max_velocity: 0.2
     has_acceleration_limits: false
     max_acceleration: 0
   j_shou_pitch:
-    has_velocity_limits: true
+    has_velocity_limits: false
     max_velocity: 0.2
     has_acceleration_limits: false
     max_acceleration: 0
   j_shou_yaw:
-    has_velocity_limits: true
+    has_velocity_limits: false
     max_velocity: 0.15
     has_acceleration_limits: false
     max_acceleration: 0


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡| [OCEANWATER-577 / Support for ROS Noetic](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-577) |
| :----------- | :----------- |
| Jira Ticket 🎟️   | [OCEANWATER-705 / Arm moves very slow under ROS Melodic and Noetic](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-705)) |
| Github :octocat:  | #136  |


## Summary of Changes
**Problem Statement:** After some recent updates made to ROS Moveit (Melodic/Noetic), the lander arm started to move very slow. This issue was probably caused by a feature in MoveIt that OceanWATERS was making use of but it wasn't functional. The feature in question basically gives users the ability to limit the speed at which joints can move. 
  
**Solution:** Disable velocity limits on all joints

## Test
* Launch the simulation
```bash
roslaunch ow atacama_y1a.launch
```
* Run any arm operation
```bash
rosservice call /arm/stow
# or
rosservice call /arm/unstow
# or
python stow_action_client.py
# ...
```
* Arm should execute the operation normally as before