### PR TITLE
Oceanwater 707 scoop collider improvement

### DIFF
--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -504,6 +504,7 @@
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
+
   <link name="l_scoop">
     <inertial>
       <origin
@@ -533,13 +534,49 @@
           rgba="0.898039215686275 0.917647058823529 0.929411764705882 1" />
       </material>
     </visual>
+    <!-- scoop bottom -->
     <collision>
-      <origin
-        xyz="0 0 0"
-        rpy="0 0 0" />
+      <origin 
+        xyz="0.030115 0 0.076505"
+        rpy="0 -0.0349040838 0" />
       <geometry>
-        <mesh
-          filename="package://ow_lander/meshes/l_scoop.STL" />
+          <box size="0.1273 0.0818 0.002"/>
+      </geometry>
+    </collision>
+    <!-- scoop backing (flat) -->
+    <collision>
+      <origin 
+        xyz="-0.032195 0 0.036854"
+        rpy="0 -1.60570041059 0" />
+      <geometry>
+          <box size="0.0749 0.0818 0.002"/>
+      </geometry>
+    </collision>
+    <!-- scoop left sidewall -->
+    <collision>
+      <origin 
+        xyz="0.025676 -0.0409 0.038875"
+        rpy="1.5708 -0.0349040838 0" />
+      <geometry>
+          <box size="0.1158 0.0749 0.002"/>
+      </geometry>
+    </collision>
+    <!-- scoop right sidewall -->
+    <collision>
+      <origin 
+        xyz="0.025676 0.0409 0.038875"
+        rpy="1.5708 -0.0349040838 0" />
+      <geometry>
+          <box size="0.1158 0.0749 0.002"/>
+      </geometry>
+    </collision>
+    <!-- scoop top -->
+    <collision>
+      <origin 
+        xyz="0.000264 0 0.000512"
+        rpy="0 -0.0349040838 0" />
+      <geometry>
+          <box size="0.06234 0.0818 0.002"/>
       </geometry>
     </collision>
   </link>

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -579,6 +579,24 @@
           <box size="0.06234 0.0818 0.002"/>
       </geometry>
     </collision>
+    <!-- scoop wide tip -->
+    <collision>
+      <origin 
+        xyz="0.090908 0 0.079513"
+        rpy="0 -0.254542712 0" />
+      <geometry>
+          <box size="0.008122 0.0818 0.002"/>
+      </geometry>
+    </collision>
+    <!-- scoop wide tip -->
+    <collision>
+      <origin 
+        xyz="0.092572 0 0.079946"
+        rpy="0 -0.254542712 0" />
+      <geometry>
+          <box size="0.01156 0.04346 0.001"/>
+      </geometry>
+    </collision>
   </link>
   <gazebo reference="l_scoop">
     <visual>


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡| [OCEANWATER-680 / Sample Acquisition](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-680) |
| :----------- | :----------- |
| Jira Ticket 🎟️   | [OCEANWATER-707 / Rigid bodies are prone to fall through the scoop](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-707) |
| Github :octocat:  | NA |

## Summary of Changes
* Removed the l_scoop.stl as the mesh collider for the scoop and replaced it with a series of box colliders that approximate the scoop's shape.

## Scoop Collision Model
![Screenshot from 2021-06-16 13-51-41](https://user-images.githubusercontent.com/17039973/122283657-034be600-ceaa-11eb-8fb6-f245b30d229c.png)
Image is from Blender, which was used to design the new collision model. Note that in this image planes are being used, but since plane collisions in Gazebo only work as infinite planes, the final collision model was built with thin walled boxes placed in the same poses.

## Video Demonstrating Material Delivery
https://user-images.githubusercontent.com/17039973/122287481-38f2ce00-ceae-11eb-925e-cc97ad999f52.mp4

## Test
This is split into two tests. The first one verifies that the new collision model does not interfere with the rest of lander operations, in particular digging commands and move guarded. The second verifies that the new collision model can hold material.
### Test 1 - Nominal Operations
1. Launch atacama_y1a 
     `roslaunch ow atacama_y1a.launch`
2. Run the ReferenceMission1 autonomy plan 
    `roslaunch ow_autonomy autonomy_node plan:=ReferenceMission1.plx`
3. While the plan runs verify the following:
     a. The scoop collides with the ground during the move guarded step.
     b. The scoop modifies the terrain as it digs through it during the digging steps.
4. Ensure the plan completes without unexpected collisions or other problematic behavior.
### Test 2 - Material Containment
1. Launch atacama_y1a 
     `roslaunch ow atacama_y1a.launch`
2. Perform a circular dig 
     `rosservice call /arm/dig_circular True 0 0 0 False 0`
    This will not modify the terrain, but that is okay since we are only maneuvering the scoop into a position where it can receive material dropped into it.
3. Spawn a rigid body into the scoop using the following command
     `rosrun gazebo_ros spawn_model -sdf -database ball_bearing -reference_frame lander -x 2.1 -y -0.02 -z 0.35 -model test_sphere`
    You should see a very small black sphere spawned in the gazebo world and fall into the scoop. Feel free to run this test multiple times, but once is enough. If you do run it multiple times, you will have to change "test_sphere" string each time otherwise you will get an error. Feel free to play around with tossing different models besides "ball_bearing" into the scoop. [The database of available models can be found here](http://models.gazebosim.org/).