### PR TITLE
fixing velocity limits in both joint_limit.yamls and lander.xarco file

### DIFF
--- a/ow_lander/config/joint_limits.yaml
+++ b/ow_lander/config/joint_limits.yaml
@@ -4,46 +4,46 @@
 joint_limits:
   j_ant_pan:
     has_velocity_limits: true
-    max_velocity: 0.4
+    max_velocity: 3.0
     has_acceleration_limits: false
     max_acceleration: 0
   j_ant_tilt:
     has_velocity_limits: true
-    max_velocity: 0.4
+    max_velocity: 3.0
     has_acceleration_limits: false
     max_acceleration: 0
   j_dist_pitch:
     has_velocity_limits: true
-    max_velocity: 0.2
+    max_velocity: 3.0
     has_acceleration_limits: false
     max_acceleration: 0
   j_grinder:
     has_velocity_limits: true
-    max_velocity: 0.1
+    max_velocity: 3.0
     has_acceleration_limits: false
     max_acceleration: 0
   j_hand_yaw:
     has_velocity_limits: true
-    max_velocity: 0.2
+    max_velocity: 3.0
     has_acceleration_limits: false
     max_acceleration: 0
   j_prox_pitch:
     has_velocity_limits: true
-    max_velocity: 0.2
+    max_velocity: 3.0
     has_acceleration_limits: false
     max_acceleration: 0
   j_scoop_yaw:
     has_velocity_limits: true
-    max_velocity: 0.2
+    max_velocity: 3.0
     has_acceleration_limits: false
     max_acceleration: 0
   j_shou_pitch:
     has_velocity_limits: true
-    max_velocity: 0.2
+    max_velocity: 3.0
     has_acceleration_limits: false
     max_acceleration: 0
   j_shou_yaw:
     has_velocity_limits: true
-    max_velocity: 0.15
+    max_velocity: 3.0
     has_acceleration_limits: false
     max_acceleration: 0

--- a/ow_lander/scripts/action_grind.py
+++ b/ow_lander/scripts/action_grind.py
@@ -90,7 +90,6 @@ def plan_cartesian_path(move_group, wpose, length, alpha, parallel, z_start, cs)
                                waypoints,   # waypoints to follow
                                0.01,        # end effector follow step (meters)
                                0.0)         # jump threshold
-
   return plan, fraction
 
 

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -165,7 +165,7 @@
     <axis
       xyz="0 0 -1" />
     <dynamics damping="50.0" friction="2.6"/>
-    <limit effort="70.9" velocity="0.15" lower="-1.8" upper="1.8"/>
+    <limit effort="70.9" velocity="1.0" lower="-1.8" upper="1.8"/>
   </joint>
   <transmission name="shou_yaw_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -241,7 +241,7 @@
     <axis
       xyz="0 0 -1" />
     <dynamics damping="50.0" friction="4.6"/>
-    <limit effort="101.0" velocity="0.2" lower="0.05" upper="2.2"/>
+    <limit effort="101.0" velocity="1.0" lower="0.05" upper="2.2"/>
   </joint>
   <transmission name="shou_pitch_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -317,7 +317,7 @@
     <axis
       xyz="0 0 -1" />
     <dynamics damping="50.0" friction="2.7"/>
-    <limit effort="73.0" velocity="0.2"/>
+    <limit effort="73.0" velocity="1.0"/>
   </joint>
   <transmission name="prox_pitch_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -393,7 +393,7 @@
     <axis
       xyz="0 0 1" />
     <dynamics damping="50.0" friction="0.3"/>
-    <limit effort="25.7" velocity="0.2" />
+    <limit effort="25.7" velocity="1.0" />
   </joint>
   <transmission name="dist_pitch_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -493,7 +493,7 @@
     <axis
       xyz="0 0 -1" />
     <dynamics damping="50.0" friction="0.3"/>
-    <limit effort="25.7" velocity="0.2" />
+    <limit effort="25.7" velocity="1.0" />
   </joint>
   <transmission name="hand_yaw_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -598,7 +598,7 @@
     <axis
       xyz="0 0 -1" />
     <dynamics damping="50.0" friction="0.5"/>
-    <limit effort="20.0" velocity="0.2" />
+    <limit effort="20.0" velocity="1.0" />
   </joint>
   <transmission name="scoop_yaw_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -712,7 +712,7 @@
     <child link="l_grinder" />
     <axis xyz="-1 0 0" />
     <dynamics damping="1" />
-    <limit lower="-3.14" upper="3.14" effort="1.0" velocity="0.1" />
+    <limit lower="-3.14" upper="3.14" effort="1.0" velocity="1.0" />
   </joint>
   <transmission name="grinder_yaw_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -789,7 +789,7 @@
     <axis
       xyz="0 0 -1" />
     <dynamics damping="50.0" />
-    <limit effort="80.0" velocity="0.2" />
+    <limit effort="80.0" velocity="1.0" />
   </joint>
   <transmission name="ant_pan_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -865,7 +865,7 @@
     <axis
       xyz="0 0 -1" />
     <dynamics damping="50.0" />
-    <limit effort="100.0" velocity="0.2" />
+    <limit effort="100.0" velocity="1.0" />
   </joint>
   <transmission name="ant_tilt_transmission">
     <type>transmission_interface/SimpleTransmission</type>


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡| [OCEANWATER-XXX](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-XXX) |
) |
| :----------- | :----------- |
| Jira Ticket 🎟️   | [OCEANWATER-XXX](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-XXX)) |
| Github :octocat:  | # |


## Summary of Changes
*  Updated velocity limits for all joints in both joint_limits.yaml and lander.xacro file 
* After carefully checking all the possible changes, it seems that re-timing of the trajectory is not necessary  as in branch 711. 

## Test
* Please check all the arm movements in both actions and services. 
* Test 2 and Test 9 of our Release 8.
