### PR TITLE
HOTFIX: Address the slow movement of arm after recent moveit update

### DIFF
--- a/ow_lander/config/joint_limits.yaml
+++ b/ow_lander/config/joint_limits.yaml
@@ -47,3 +47,6 @@ joint_limits:
     max_velocity: 0.15
     has_acceleration_limits: false
     max_acceleration: 0
+
+default_acceleration_scaling_factor: 1.0
+default_velocity_scaling_factor: 1.0

--- a/ow_lander/scripts/action_guarded_move.py
+++ b/ow_lander/scripts/action_guarded_move.py
@@ -76,7 +76,6 @@ def guarded_move_plan(move_arm, robot, moveit_fk, args):
   goal_pose.position.z = targ_z
 
   move_arm.set_pose_target(goal_pose)
-  move_arm.set_max_velocity_scaling_factor(0.5)
   plan_b = move_arm.plan()
   if len(plan_b.joint_trajectory.points) == 0:  # If no plan found, abort
     return False


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡| [OCEANWATER-577 / Support for ROS Noetic](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-577) |
| :----------- | :----------- |
| Jira Ticket 🎟️   | [OCEANWATER-705 / Arm moves very slow under ROS Melodic and Noetic](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-705) |
| Jira Ticket 🎟️   | [OCEANWATER-715 / Fix Velocity Limit issue with Moveit](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-715) |
| Github :octocat:  | #136, #147  |

## Summary of Changes
**Problem Statement:** After some recent updates made to ROS Moveit (Melodic/Noetic), the lander arm started to move very slow. This issue is caused by recent changes made to **MoveIt** (since v1.0.8) that changed the initial values of `default_velocity_scaling_factor` and `default_acceleration_scaling_factor` from 1.0 to 0.1. This made OceanWATERS arm movement to be extremely slow.
  
**Solution:** Set `default_acceleration_scaling_factor` and `default_velocity_scaling_factor` to match previous default values before the update:
```yaml
default_acceleration_scaling_factor: 1.0
default_velocity_scaling_factor: 1.0
``` 
This fix should work against the current MoveIt version under ROS Melodic and previous versions too!

## Test
* Launch the simulation
```bash
roslaunch ow atacama_y1a.launch
```
* Run [OceanWATERS Test Procedures](https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/OW-TEST008+-+release-8-0) 2 and 9.
```bash
rosservice call /arm/stow ...
rosservice call /arm/unstow ...
rosservice call /arm/grind ...
rosservice call /arm/dig_linear ...
rosservice call /arm/dig_circular ...
rosservice call /arm/guarded_move ...
python stow_action_client.py
# ...
```
* Arm should execute the operation normally as before