### PR TITLE
remove RRT planning output from terminal

### DIFF
--- a/ow_lander/launch/move_group.launch
+++ b/ow_lander/launch/move_group.launch
@@ -55,8 +55,9 @@
     <arg name="moveit_controller_manager" value="fake" if="$(arg fake_execution)"/>
   </include>
 
-  <!-- Start the actual move_group node/action server -->
-  <node name="move_group" launch-prefix="$(arg launch_prefix)" pkg="moveit_ros_move_group" type="move_group" respawn="false" output="screen" args="$(arg command_args)">
+  <!-- Start the actual move_group node/action server-->
+  <!-- Add output="screen" to see RRT planning details -->
+  <node name="move_group" launch-prefix="$(arg launch_prefix)" pkg="moveit_ros_move_group" type="move_group" respawn="false" args="$(arg command_args)">
     <!-- Set the display variable, in case OpenGL code is used internally -->
     <env name="DISPLAY" value="$(optenv DISPLAY :0)" />
 


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡| [OCEANWATER-XXX](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-XXX) |
) |
| :----------- | :----------- |
| Jira Ticket 🎟️   | [OCEANWATER-XXX](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-XXX)) |
| Github :octocat:  | # |


## Summary of Changes
* Removes planning (RRT) output from the terminal. 

## Test
* Test all the actions and main terminal window should not display any planning output 
