### PR TITLE
remove rviz visualization of planned path

### DIFF
--- a/ow_lander/config/moveit.rviz
+++ b/ow_lander/config/moveit.rviz
@@ -183,7 +183,7 @@ Visualization Manager:
         Robot Alpha: 0.5
         Robot Color: 150; 50; 150
         Show Robot Collision: false
-        Show Robot Visual: true
+        Show Robot Visual: false
         Show Trail: false
         State Display Time: 0.05 s
         Trail Step Size: 1


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡| [OCEANWATER-XXX](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-XXX) |
) |
| :----------- | :----------- |
| Jira Ticket 🎟️   | [OCEANWATER-XXX](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-XXX)) |
| Github :octocat:  | # |


## Summary of Changes
* Removes Rviz Visualization of the plans. (Turns out it was not the fake controller but Rviz was showing the planned path.)

## Test
* Run any Ros action to see no displayed rviz trjactory before movement of Gazebo
