### PR TITLE
Oceanwater 738 full automation of lander release test case 2

### DIFF
--- a/ow_sim_tests/test/arm_check.py
+++ b/ow_sim_tests/test/arm_check.py
@@ -41,10 +41,10 @@ class ArmCheck(unittest.TestCase):
     @returns: the normalized value of the angle
     """
     from math import pi
-    angle =  angle % (2*pi)
+    angle = angle % (2*pi)
     angle = (angle + 2*pi) % (2*pi)
     if angle > pi:
-        angle -= 2*pi
+      angle -= 2*pi
     return angle
 
   def _all_close(self, goal, actual, tolerance=0.02):
@@ -61,7 +61,7 @@ class ArmCheck(unittest.TestCase):
     return True
 
   def _test_activity(self,
-    service_name, service_type, joints_goal, test_duration, service_args = None):
+                     service_name, service_type, joints_goal, test_duration, service_args=None):
     """
     A helper method that does validates a any arm operation
     @param service_name: Name of the ros service to be invoked
@@ -83,102 +83,110 @@ class ArmCheck(unittest.TestCase):
 
     elapsed = 0
     while not rospy.is_shutdown() and \
-        elapsed < test_duration and \
-        not goal_state_achieved:
+            elapsed < test_duration and \
+            not goal_state_achieved:
 
       joints_state = self._arm_move_group.get_current_joint_values()
-      normalized_joints_state = [ self._normalize_angle(e) for e in joints_state ]
-      goal_state_achieved = self._all_close(joints_goal, normalized_joints_state)
+      normalized_joints_state = [
+          self._normalize_angle(e) for e in joints_state]
+      goal_state_achieved = self._all_close(
+          joints_goal, normalized_joints_state)
       rospy.sleep(0.2)
       elapsed = rospy.get_time() - test_start_time
 
-    rospy.loginfo("{} service reported: {}".format(service_name, goal_state_achieved))
-    self.assertTrue(elapsed < test_duration, "arm operation timed-out! condition: {} < {}".format(elapsed, test_duration))
+    rospy.loginfo("activity {} took {} seconds and reported success? {}".format(
+        service_name, elapsed, goal_state_achieved))
+    self.assertTrue(elapsed < test_duration,
+                    "arm operation timed-out! condition: {} < {}".format(elapsed, test_duration))
     self.assertTrue(goal_state_achieved, "expected joint states don't match!")
 
   def test_01_unstow(self):
-    joints_target = self._arm_move_group.get_named_target_values("arm_unstowed")
+    joints_target = self._arm_move_group.get_named_target_values(
+        "arm_unstowed")
     joints_goal = self._map_named_joint_target_to_list(joints_target)
     self._test_activity(
-      service_name = '/arm/unstow',
-      service_type = Unstow,
-      joints_goal = joints_goal,
-      test_duration = 30)
+        service_name='/arm/unstow',
+        service_type=Unstow,
+        joints_goal=joints_goal,
+        test_duration=30)
 
   def test_02_guarded_move(self):
     self._test_activity(
-      service_name = '/arm/guarded_move',
-      service_type = GuardedMove,
-      joints_goal = [-0.02, 0.68, -1.39, 0.75, -0.01, -0.053],
-      test_duration = 45,
-      service_args = [True, 0, 0, 0, 0, 0, 0, 0])
+        service_name='/arm/guarded_move',
+        service_type=GuardedMove,
+        joints_goal=[-0.02, 0.68, -1.39, 0.75, -0.01, -0.053],
+        test_duration=45,
+        service_args=[True, 0, 0, 0, 0, 0, 0, 0])
 
   def test_03_unstow(self):
-    joints_target = self._arm_move_group.get_named_target_values("arm_unstowed")
+    joints_target = self._arm_move_group.get_named_target_values(
+        "arm_unstowed")
     joints_goal = self._map_named_joint_target_to_list(joints_target)
     self._test_activity(
-      service_name = '/arm/unstow',
-      service_type = Unstow,
-      joints_goal = joints_goal,
-      test_duration = 30)
+        service_name='/arm/unstow',
+        service_type=Unstow,
+        joints_goal=joints_goal,
+        test_duration=30)
 
   def test_04_grind(self):
     self._test_activity(
-      service_name = '/arm/grind',
-      service_type = Grind,
-      joints_goal = [-0.12, 1.91, -2.33, 0.40, -2.10, 0.37],
-      test_duration = 90,
-      service_args = [True, 0, 0, 0, 0, False, 0])
+        service_name='/arm/grind',
+        service_type=Grind,
+        joints_goal=[-0.12, 1.91, -2.33, 0.40, -2.10, 0.37],
+        test_duration=90,
+        service_args=[True, 0, 0, 0, 0, False, 0])
 
   def test_05_dig_circular(self):
     self._test_activity(
-      service_name = '/arm/dig_circular',
-      service_type = DigCircular,
-      joints_goal = [-0.03, 0.96, -1.64, 1.66, 0.0, 1.57],
-      test_duration = 100,
-      service_args = [True, 0, 0, 0, False, 0])
+        service_name='/arm/dig_circular',
+        service_type=DigCircular,
+        joints_goal=[-0.03, 0.96, -1.64, 1.66, 0.0, 1.57],
+        test_duration=100,
+        service_args=[True, 0, 0, 0, False, 0])
 
   def test_06_grind(self):
     self._test_activity(
-      service_name = '/arm/grind',
-      service_type = Grind,
-      joints_goal = [-0.13, 2.14, -2.46, 0.30, -2.10, 1.56],
-      test_duration = 100,
-      service_args = [False, 1.55, 0, 0.15, 0.85, True, -0.155])
+        service_name='/arm/grind',
+        service_type=Grind,
+        joints_goal=[-0.13, 2.14, -2.46, 0.30, -2.10, 1.56],
+        test_duration=100,
+        service_args=[False, 1.55, 0, 0.15, 0.85, True, -0.155])
 
   def test_07_dig_linear(self):
     self._test_activity(
-      service_name = '/arm/dig_linear',
-      service_type = DigLinear,
-      joints_goal = [-0.04, 0.55, -1.17, 1.57, 0.0,1.57],
-      test_duration = 120,
-      service_args = [True, 0, 0, 0, 0, 0])
+        service_name='/arm/dig_linear',
+        service_type=DigLinear,
+        joints_goal=[-0.04, 0.55, -1.17, 1.57, 0.0, 1.57],
+        test_duration=120,
+        service_args=[True, 0, 0, 0, 0, 0])
 
   def test_08_deliver_sample(self):
     self._test_activity(
-      service_name = '/arm/deliver_sample',
-      service_type = DeliverSample,
-      joints_goal = [0.98, 1.78, 0.96,1.98, 2.55,1.58],
-      test_duration = 70,
-      service_args = [True, 0, 0, 0])
+        service_name='/arm/deliver_sample',
+        service_type=DeliverSample,
+        joints_goal=[0.98, 1.78, 0.96, 1.98, 2.55, 1.58],
+        test_duration=70,
+        service_args=[True, 0, 0, 0])
 
   def test_09_unstow(self):
-    joints_target = self._arm_move_group.get_named_target_values("arm_unstowed")
+    joints_target = self._arm_move_group.get_named_target_values(
+        "arm_unstowed")
     joints_goal = self._map_named_joint_target_to_list(joints_target)
     self._test_activity(
-      service_name = '/arm/unstow',
-      service_type = Unstow,
-      joints_goal = joints_goal,
-      test_duration = 30)
+        service_name='/arm/unstow',
+        service_type=Unstow,
+        joints_goal=joints_goal,
+        test_duration=30)
 
   def test_10_stow(self):
     joints_target = self._arm_move_group.get_named_target_values("arm_stowed")
     joints_goal = self._map_named_joint_target_to_list(joints_target)
     self._test_activity(
-      service_name = '/arm/stow',
-      service_type = Stow,
-      joints_goal = joints_goal,
-      test_duration = 25)
+        service_name='/arm/stow',
+        service_type=Stow,
+        joints_goal=joints_goal,
+        test_duration=25)
+
 
 if __name__ == '__main__':
   import rostest

--- a/ow_sim_tests/test/arm_check.py
+++ b/ow_sim_tests/test/arm_check.py
@@ -88,8 +88,6 @@ class ArmCheck(unittest.TestCase):
 
       joints_state = self._arm_move_group.get_current_joint_values()
       normalized_joints_state = [ self._normalize_angle(e) for e in joints_state ]
-      rospy.loginfo("goal: " + ",".join([str(j) for j in joints_goal]))
-      rospy.loginfo("state: " + ",".join([str(j) for j in normalized_joints_state]))
       goal_state_achieved = self._all_close(joints_goal, normalized_joints_state)
       rospy.sleep(0.2)
       elapsed = rospy.get_time() - test_start_time

--- a/ow_sim_tests/test/arm_check.py
+++ b/ow_sim_tests/test/arm_check.py
@@ -137,7 +137,7 @@ class ArmCheck(unittest.TestCase):
         service_type=Grind,
         joints_goal=[-0.12, 1.91, -2.33, 0.40, -2.10, 0.37],
         test_duration=270,
-        tolerance=0.05,
+        tolerance=0.06,
         service_args=[True, 0, 0, 0, 0, False, 0])
 
   def test_05_dig_circular(self):

--- a/ow_sim_tests/test/arm_check.py
+++ b/ow_sim_tests/test/arm_check.py
@@ -8,14 +8,16 @@ import sys
 import rospy
 import roslib
 import unittest
-import time
 from ow_lander.srv import *
 import moveit_commander
+import numpy as np
 
 PKG = 'ow_sim_tests'
 roslib.load_manifest(PKG)
 
 # a class that monitors minimum reported frame rate by a gazebo simulation
+
+
 class ArmCheck(unittest.TestCase):
 
   def __init__(self, *args, **kwargs):
@@ -47,27 +49,16 @@ class ArmCheck(unittest.TestCase):
       angle -= 2*pi
     return angle
 
-  def _all_close(self, goal, actual, tolerance=0.02):
-    """
-    Convenience method for testing if a list of values are within a tolerance of their counterparts in another list
-    @param goal: A list of floats
-    @param actual: A list of floats
-    @param tolerance: A float
-    @returns: True if all values satify the condition, otherwise False.
-    """
-    for index in range(len(goal)):
-      if abs(actual[index] - goal[index]) > tolerance:
-        return False
-    return True
-
-  def _test_activity(self,
-                     service_name, service_type, joints_goal, test_duration, service_args=None):
+  def _test_activity(self, service_name, service_type,
+                     joints_goal, test_duration,
+                     tolerance=0.02, service_args=None):
     """
     A helper method that does validates a any arm operation
     @param service_name: Name of the ros service to be invoked
     @param service_type: Type of the service
     @param joints_goal: Expected joints values when the activity is completed
     @param test_duration: How long the operation needs to complete
+    @param tolerance: [optional] How much tolerance is allowed against the specified joints_goal
     @param service_args: [optional] Args to be passed to the service when invoked
     """
 
@@ -78,8 +69,8 @@ class ArmCheck(unittest.TestCase):
     success = arm_activity() if service_args is None else arm_activity(*service_args)
     self.assertTrue(success, "submitted request to " + service_name)
     goal_state_achieved = False
-
-    rospy.loginfo("testing service: " + service_name)
+    joints_goal_array = np.array(joints_goal)
+    joints_abs_diff_array = np.full(joints_goal_array.shape, np.inf)
 
     elapsed = 0
     while not rospy.is_shutdown() and \
@@ -87,17 +78,28 @@ class ArmCheck(unittest.TestCase):
             not goal_state_achieved:
 
       joints_state = self._arm_move_group.get_current_joint_values()
-      normalized_joints_state = [
-          self._normalize_angle(e) for e in joints_state]
-      goal_state_achieved = self._all_close(
-          joints_goal, normalized_joints_state)
+      norm_joints_state_array = np.array(
+          [self._normalize_angle(e) for e in joints_state])
+      rospy.loginfo("expected joints state: {}".format(
+          np.round(joints_goal_array, 2)))
+      rospy.loginfo("current joints state: {}".format(
+          np.round(norm_joints_state_array, 2)))
+      joints_abs_diff_array = np.abs(
+          joints_goal_array - norm_joints_state_array)
+      rospy.loginfo("diff joints state: {}".format(
+          np.round(joints_abs_diff_array, 2)))
+      goal_state_achieved = all(joints_abs_diff_array < tolerance)
       rospy.sleep(0.2)
       elapsed = rospy.get_time() - test_start_time
 
-    rospy.loginfo("activity {} took {} seconds and reported success? {}".format(
-        service_name, elapsed, goal_state_achieved))
+    rospy.loginfo("operation {} took {}s, time-limit={}s".format(
+        service_name, round(elapsed), test_duration))
+    rospy.loginfo("maximum difference between expected/current: {}".format(
+        np.max(joints_abs_diff_array)))
+
     self.assertTrue(elapsed < test_duration,
-                    "arm operation timed-out! condition: {} < {}".format(elapsed, test_duration))
+                    "arm operation timed-out! condition: {} < {}".format(
+                        elapsed, test_duration))
     self.assertTrue(goal_state_achieved, "expected joint states don't match!")
 
   def test_01_unstow(self):
@@ -116,6 +118,7 @@ class ArmCheck(unittest.TestCase):
         service_type=GuardedMove,
         joints_goal=[-0.02, 0.68, -1.39, 0.75, -0.01, -0.053],
         test_duration=45,
+        tolerance=0.05,
         service_args=[True, 0, 0, 0, 0, 0, 0, 0])
 
   def test_03_unstow(self):
@@ -134,6 +137,7 @@ class ArmCheck(unittest.TestCase):
         service_type=Grind,
         joints_goal=[-0.12, 1.91, -2.33, 0.40, -2.10, 0.37],
         test_duration=90,
+        tolerance=0.05,
         service_args=[True, 0, 0, 0, 0, False, 0])
 
   def test_05_dig_circular(self):
@@ -142,6 +146,7 @@ class ArmCheck(unittest.TestCase):
         service_type=DigCircular,
         joints_goal=[-0.03, 0.96, -1.64, 1.66, 0.0, 1.57],
         test_duration=100,
+        tolerance=0.05,
         service_args=[True, 0, 0, 0, False, 0])
 
   def test_06_grind(self):
@@ -150,6 +155,7 @@ class ArmCheck(unittest.TestCase):
         service_type=Grind,
         joints_goal=[-0.13, 2.14, -2.46, 0.30, -2.10, 1.56],
         test_duration=100,
+        tolerance=0.05,
         service_args=[False, 1.55, 0, 0.15, 0.85, True, -0.155])
 
   def test_07_dig_linear(self):
@@ -158,6 +164,7 @@ class ArmCheck(unittest.TestCase):
         service_type=DigLinear,
         joints_goal=[-0.04, 0.55, -1.17, 1.57, 0.0, 1.57],
         test_duration=120,
+        tolerance=0.05,
         service_args=[True, 0, 0, 0, 0, 0])
 
   def test_08_deliver_sample(self):

--- a/ow_sim_tests/test/arm_check.py
+++ b/ow_sim_tests/test/arm_check.py
@@ -117,7 +117,7 @@ class ArmCheck(unittest.TestCase):
         service_name='/arm/guarded_move',
         service_type=GuardedMove,
         joints_goal=[-0.02, 0.68, -1.39, 0.75, -0.01, -0.053],
-        test_duration=45,
+        test_duration=60,
         tolerance=0.05,
         service_args=[True, 0, 0, 0, 0, 0, 0, 0])
 
@@ -136,7 +136,7 @@ class ArmCheck(unittest.TestCase):
         service_name='/arm/grind',
         service_type=Grind,
         joints_goal=[-0.12, 1.91, -2.33, 0.40, -2.10, 0.37],
-        test_duration=90,
+        test_duration=270,
         tolerance=0.05,
         service_args=[True, 0, 0, 0, 0, False, 0])
 
@@ -145,7 +145,7 @@ class ArmCheck(unittest.TestCase):
         service_name='/arm/dig_circular',
         service_type=DigCircular,
         joints_goal=[-0.03, 0.96, -1.64, 1.66, 0.0, 1.57],
-        test_duration=100,
+        test_duration=160,
         tolerance=0.05,
         service_args=[True, 0, 0, 0, False, 0])
 
@@ -154,7 +154,7 @@ class ArmCheck(unittest.TestCase):
         service_name='/arm/grind',
         service_type=Grind,
         joints_goal=[-0.13, 2.14, -2.46, 0.30, -2.10, 1.56],
-        test_duration=100,
+        test_duration=160,
         tolerance=0.05,
         service_args=[False, 1.55, 0, 0.15, 0.85, True, -0.155])
 
@@ -163,7 +163,7 @@ class ArmCheck(unittest.TestCase):
         service_name='/arm/dig_linear',
         service_type=DigLinear,
         joints_goal=[-0.04, 0.55, -1.17, 1.57, 0.0, 1.57],
-        test_duration=120,
+        test_duration=180,
         tolerance=0.05,
         service_args=[True, 0, 0, 0, 0, 0])
 
@@ -172,7 +172,7 @@ class ArmCheck(unittest.TestCase):
         service_name='/arm/deliver_sample',
         service_type=DeliverSample,
         joints_goal=[0.98, 1.78, 0.96, 1.98, 2.55, 1.58],
-        test_duration=70,
+        test_duration=90,
         service_args=[True, 0, 0, 0])
 
   def test_09_unstow(self):
@@ -192,7 +192,7 @@ class ArmCheck(unittest.TestCase):
         service_name='/arm/stow',
         service_type=Stow,
         joints_goal=joints_goal,
-        test_duration=25)
+        test_duration=30)
 
 
 if __name__ == '__main__':

--- a/ow_sim_tests/test/arm_check.py
+++ b/ow_sim_tests/test/arm_check.py
@@ -47,7 +47,7 @@ class ArmCheck(unittest.TestCase):
         angle -= 2*pi
     return angle
 
-  def _all_close(self, goal, actual, tolerance=0.01):
+  def _all_close(self, goal, actual, tolerance=0.02):
     """
     Convenience method for testing if a list of values are within a tolerance of their counterparts in another list
     @param goal: A list of floats

--- a/ow_sim_tests/test/arm_check.py
+++ b/ow_sim_tests/test/arm_check.py
@@ -58,7 +58,9 @@ class ArmCheck(unittest.TestCase):
     @param service_type: Type of the service
     @param joints_goal: Expected joints values when the activity is completed
     @param test_duration: How long the operation needs to complete
-    @param tolerance: [optional] How much tolerance is allowed against the specified joints_goal
+    @param tolerance: [optional] How much tolerance is allowed against the
+      specified joints_goal. The tolerance can be passed as an array of same size
+      as joints_goal.
     @param service_args: [optional] Args to be passed to the service when invoked
     """
 
@@ -92,8 +94,8 @@ class ArmCheck(unittest.TestCase):
       rospy.sleep(0.2)
       elapsed = rospy.get_time() - test_start_time
 
-    rospy.loginfo("operation {} took {}s, time-limit={}s".format(
-        service_name, round(elapsed), test_duration))
+    rospy.loginfo("operation {} took {}s, time-limit is {}s".format(
+        service_name, int(round(elapsed)), test_duration))
     rospy.loginfo("maximum difference between expected/current: {}".format(
         np.max(joints_abs_diff_array)))
 
@@ -135,9 +137,9 @@ class ArmCheck(unittest.TestCase):
     self._test_activity(
         service_name='/arm/grind',
         service_type=Grind,
-        joints_goal=[-0.12, 1.91, -2.33, 0.40, -2.10, 0.37],
+        joints_goal=[-0.12, 1.91, -2.33, 0.40, -2.10, 0.32],
         test_duration=270,
-        tolerance=0.06,
+        tolerance=[0.05, 0.05, 0.05, 0.05, 0.05, 0.15],
         service_args=[True, 0, 0, 0, 0, False, 0])
 
   def test_05_dig_circular(self):
@@ -155,7 +157,7 @@ class ArmCheck(unittest.TestCase):
         service_type=Grind,
         joints_goal=[-0.13, 2.14, -2.46, 0.30, -2.10, 1.56],
         test_duration=160,
-        tolerance=0.05,
+        tolerance=[0.05, 0.05, 0.05, 0.05, 0.05, 0.15],
         service_args=[False, 1.55, 0, 0.15, 0.85, True, -0.155])
 
   def test_07_dig_linear(self):

--- a/ow_sim_tests/test/arm_check.py
+++ b/ow_sim_tests/test/arm_check.py
@@ -79,6 +79,8 @@ class ArmCheck(unittest.TestCase):
     self.assertTrue(success, "submitted request to " + service_name)
     goal_state_achieved = False
 
+    rospy.loginfo("testing service: " + service_name)
+
     elapsed = 0
     while not rospy.is_shutdown() and \
         elapsed < test_duration and \
@@ -86,38 +88,99 @@ class ArmCheck(unittest.TestCase):
 
       joints_state = self._arm_move_group.get_current_joint_values()
       normalized_joints_state = [ self._normalize_angle(e) for e in joints_state ]
+      rospy.loginfo("goal: " + ",".join([str(j) for j in joints_goal]))
+      rospy.loginfo("state: " + ",".join([str(j) for j in normalized_joints_state]))
       goal_state_achieved = self._all_close(joints_goal, normalized_joints_state)
       rospy.sleep(0.2)
       elapsed = rospy.get_time() - test_start_time
 
+    rospy.loginfo("{} service reported: {}".format(service_name, goal_state_achieved))
     self.assertTrue(elapsed < test_duration, "arm operation timed-out! condition: {} < {}".format(elapsed, test_duration))
     self.assertTrue(goal_state_achieved, "expected joint states don't match!")
 
-  def test_1_unstow(self):
+  def test_01_unstow(self):
     joints_target = self._arm_move_group.get_named_target_values("arm_unstowed")
     joints_goal = self._map_named_joint_target_to_list(joints_target)
     self._test_activity(
       service_name = '/arm/unstow',
       service_type = Unstow,
       joints_goal = joints_goal,
-      test_duration = rospy.get_param("/arm_check/unstow_duration"))
+      test_duration = 30)
 
-  def test_2_stow(self):
+  def test_02_guarded_move(self):
+    self._test_activity(
+      service_name = '/arm/guarded_move',
+      service_type = GuardedMove,
+      joints_goal = [-0.02, 0.68, -1.39, 0.75, -0.01, -0.053],
+      test_duration = 45,
+      service_args = [True, 0, 0, 0, 0, 0, 0, 0])
+
+  def test_03_unstow(self):
+    joints_target = self._arm_move_group.get_named_target_values("arm_unstowed")
+    joints_goal = self._map_named_joint_target_to_list(joints_target)
+    self._test_activity(
+      service_name = '/arm/unstow',
+      service_type = Unstow,
+      joints_goal = joints_goal,
+      test_duration = 30)
+
+  def test_04_grind(self):
+    self._test_activity(
+      service_name = '/arm/grind',
+      service_type = Grind,
+      joints_goal = [-0.12, 1.91, -2.33, 0.40, -2.10, 0.37],
+      test_duration = 90,
+      service_args = [True, 0, 0, 0, 0, False, 0])
+
+  def test_05_dig_circular(self):
+    self._test_activity(
+      service_name = '/arm/dig_circular',
+      service_type = DigCircular,
+      joints_goal = [-0.03, 0.96, -1.64, 1.66, 0.0, 1.57],
+      test_duration = 100,
+      service_args = [True, 0, 0, 0, False, 0])
+
+  def test_06_grind(self):
+    self._test_activity(
+      service_name = '/arm/grind',
+      service_type = Grind,
+      joints_goal = [-0.13, 2.14, -2.46, 0.30, -2.10, 1.56],
+      test_duration = 100,
+      service_args = [False, 1.55, 0, 0.15, 0.85, True, -0.155])
+
+  def test_07_dig_linear(self):
+    self._test_activity(
+      service_name = '/arm/dig_linear',
+      service_type = DigLinear,
+      joints_goal = [-0.04, 0.55, -1.17, 1.57, 0.0,1.57],
+      test_duration = 120,
+      service_args = [True, 0, 0, 0, 0, 0])
+
+  def test_08_deliver_sample(self):
+    self._test_activity(
+      service_name = '/arm/deliver_sample',
+      service_type = DeliverSample,
+      joints_goal = [0.98, 1.78, 0.96,1.98, 2.55,1.58],
+      test_duration = 70,
+      service_args = [True, 0, 0, 0])
+
+  def test_09_unstow(self):
+    joints_target = self._arm_move_group.get_named_target_values("arm_unstowed")
+    joints_goal = self._map_named_joint_target_to_list(joints_target)
+    self._test_activity(
+      service_name = '/arm/unstow',
+      service_type = Unstow,
+      joints_goal = joints_goal,
+      test_duration = 30)
+
+  def test_10_stow(self):
     joints_target = self._arm_move_group.get_named_target_values("arm_stowed")
     joints_goal = self._map_named_joint_target_to_list(joints_target)
     self._test_activity(
       service_name = '/arm/stow',
       service_type = Stow,
       joints_goal = joints_goal,
-      test_duration = rospy.get_param("/arm_check/stow_duration"))
-
-  def test_3_deliver_sample(self):
-    self._test_activity(
-      service_name = '/arm/deliver_sample',
-      service_type = DeliverSample,
-      joints_goal = [0.98, 1.78, 0.96,1.98, 2.55,1.58],
-      test_duration = rospy.get_param("/arm_check/deliver_sample_duration"),
-      service_args = [True, 0, 0, 0])
+      test_duration = 25)
 
 if __name__ == '__main__':
   import rostest

--- a/ow_sim_tests/test/arm_check.test
+++ b/ow_sim_tests/test/arm_check.test
@@ -5,10 +5,6 @@
 
     <include file="$(find ow_sim_tests)/launch/europa_terminator_workspace.launch" />
 
-    <test test-name="arm_check" pkg="ow_sim_tests" type="arm_check.py" time-limit="150.0">
-        <param name="unstow_duration" value="30.0" />
-        <param name="stow_duration" value="25.0" />
-        <param name="deliver_sample_duration" value="70.0" />
-    </test>
+    <test test-name="arm_check" pkg="ow_sim_tests" type="arm_check.py" time-limit="700.0" />
 
 </launch>


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡| [OCEANWATER-684 / Automated Build & Testing ](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-684) |
| :----------- | :----------- |
| Jira Ticket 🎟️   | [OCEANWATER-738 / full automation of lander arm release test case 2](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-738) |
| Github :octocat:  | #149 |


## Summary of Changes
* Fully automated test case 2 of [OceanWATERS release tests](https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/OW-TEST008+-+release-8-0?searchId=O143IYLN6)

## Test
* To test arm operation run the following command:
```bash
rostest ow_sim_tests arm_check.test
```
This should run successfully and print a summary of 10 tests. If there are no issues in the simulation/lander operation, then all tests should show as succeeded. If there is any issue in the behavior of the three arm activities performed then respective test should fail.  Currently, we only validate the end goal of operation and execution time!

Expected output:
![image](https://user-images.githubusercontent.com/606033/124632383-229abb00-de39-11eb-8b7a-9fa74ce91a46.png)

Validate that the test automation is performing exactly what test case 2 is supposed to do. The **joints_goal** value were measured first and then were added to the test script (So it assumes what we have in mainline is correct).