### PR TITLE
OCEANWATER 721 Detect Ant Faults

### DIFF
--- a/ow_faults/include/ow_faults/FaultInjector.h
+++ b/ow_faults/include/ow_faults/FaultInjector.h
@@ -67,7 +67,7 @@ private:
   //camera function
   void cameraTriggerRepublishCb(const std_msgs::Empty& msg);
 
-  // Antennae functions
+  // // Antennae functions
   void antennaPanFaultCb(const std_msgs::Float64& msg);
   void antennaTiltFaultCb(const std_msgs::Float64& msg);
   void publishAntennaeFaults(const std_msgs::Float64& msg, bool encoder, 
@@ -95,11 +95,10 @@ private:
   //antenna 
   ros::Subscriber m_fault_ant_pan_sub;
   ros::Subscriber m_fault_ant_tilt_sub;
-  ros::Publisher m_fault_ant_pan_remapped_pub;
-  ros::Publisher m_fault_ant_tilt_remapped_pub;
+  ros::Publisher m_ant_pan_remapped_pub;
+  ros::Publisher m_ant_tilt_remapped_pub;
 
   // jpl message publishers
-  // ros::Publisher m_antenna_fault_msg_pub;
   // ros::Publisher m_arm_fault_msg_pub;
 
   ////////// vars

--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -21,7 +21,7 @@
 #include <ow_lander/lander_joints.h>
 #include <sensor_msgs/JointState.h>
 #include <geometry_msgs/WrenchStamped.h>
-
+#include <control_msgs/JointControllerState.h>
 
 // This class injects simple message faults that don't need to be simulated
 // at their source. Modified topics are prefixed with "/faults". This could be
@@ -75,6 +75,13 @@ public:
   
 private:
 
+  // Antennae functions
+  void antennaPanCommandCb(const std_msgs::Float64& msg);
+  void antennaPanStateCb(const control_msgs::JointControllerState& msg);
+  void antennaTiltCommandCb(const std_msgs::Float64& msg);
+  void antennaTiltStateCb(const control_msgs::JointControllerState& msg);
+  void antPublishFaultMessages(float command, float m_set_point ){
+
   // //camera function
   void cameraTriggerOriginalCb(const std_msgs::Empty& msg);
   void cameraTriggerCb(const std_msgs::Empty& msg);
@@ -95,34 +102,41 @@ private:
   template<typename fault_msg>
   void setComponentFaultsMessage(fault_msg& msg, ComponentFaults value);
  
-  // // camera
+  // antenna
+  ros::Subscriber m_ant_pan_command_sub;
+  ros::Subscriber m_ant_pan_state_sub;
+
+  // camera
   ros::Timer m_camera_trigger_timer;
   ros::Subscriber m_camera_original_trigger_sub;
   ros::Subscriber m_camera_trigger_sub;
 
-  // //power
+  // power
   ros::Subscriber m_power_soc_sub;
   ros::Subscriber m_power_temperature_sub;
   ros::Publisher m_power_fault_trigger_pub;
 
-  // // jpl message publishers
+  // jpl message publishers
+  ros::Publisher m_antenna_fault_msg_pub;
   ros::Publisher m_camera_fault_msg_pub;
   ros::Publisher m_power_fault_msg_pub;
   ros::Publisher m_system_fault_msg_pub;
 
 
-  // ////////// vars
-  // //system
+  // vars
+  // system
   std::bitset<10> m_system_faults_bitset{};
 
-  // //general component faults
+  // general component faults
+  float m_ant_pan_set_point;
+  float m_ant_tilt_set_point;
   bool m_cam_trigger_on = false;
   bool m_soc_fault = false;
   bool m_temperature_fault = false;
   ros::Time m_cam_trigger_time;
   ros::Time m_cam_og_trigger_time;
 
-  // //power vars
+  // power vars
   float m_last_SOC = std::numeric_limits<float>::quiet_NaN();
 
 };

--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -80,7 +80,7 @@ private:
   void antennaPanStateCb(const control_msgs::JointControllerState& msg);
   void antennaTiltCommandCb(const std_msgs::Float64& msg);
   void antennaTiltStateCb(const control_msgs::JointControllerState& msg);
-  void antPublishFaultMessages(float command, float m_set_point ){
+  void antPublishFaultMessages(float command, float m_set_point );
 
   // //camera function
   void cameraTriggerOriginalCb(const std_msgs::Empty& msg);
@@ -105,6 +105,8 @@ private:
   // antenna
   ros::Subscriber m_ant_pan_command_sub;
   ros::Subscriber m_ant_pan_state_sub;
+  ros::Subscriber m_ant_tilt_command_sub;
+  ros::Subscriber m_ant_tilt_state_sub;
 
   // camera
   ros::Timer m_camera_trigger_timer;

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -153,6 +153,7 @@ void FaultDetector::antennaPanStateCb(const control_msgs::JointControllerState& 
 void FaultDetector::antennaTiltStateCb(const control_msgs::JointControllerState& msg){
   m_ant_tilt_set_point = msg.set_point;
 }
+
 //// Camera listeners
 void FaultDetector::cameraTriggerOriginalCb(const std_msgs::Empty& msg){
   m_cam_og_trigger_time = ros::Time::now();


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-717](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-717) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-721](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-721) |
| Github :octocat:  | epic #140  |

## Summary of Changes
* moved antenna faults detection ti detector node 

## Test
* roslaunch any launch file
* in a new terminal  `rostopic echo /faults/pt_faults_status`
* go to rqt and from Control and Viz tab update value to any value for 'command' for pan to 1
* go to rqt dynamic reconfigure and select either pan or tilt fault (respective to the topic you're observing)
* Control+Viz, update value to 2
* observe fault value of 1 in the rostopic echo terminal. 
* repeat for tilt
