### PR TITLE
OCEANWATER 760 - Gave every package.xml file the proper license tag

### DIFF
--- a/ow/package.xml
+++ b/ow/package.xml
@@ -6,6 +6,6 @@
 
   <maintainer email="people@nasa.gov">people</maintainer>
 
-  <license>TODO</license>
+  <license>NASA OPEN SOURCE AGREEMENT VERSION 1.3</license>
   
 </package>

--- a/ow_bag_recorder/package.xml
+++ b/ow_bag_recorder/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="thomas.stucky@nasa.gov">Thomas Stucky</maintainer>
 
   <!-- One license tag required, multiple allowed, one license per tag -->
-  <license>NASA Internal - OpenSourcing is TODO</license>
+  <license>NASA OPEN SOURCE AGREEMENT VERSION 1.3</license>
 
   <!-- Author tags are optional, multiple are allowed, one per tag -->
   <author email="thomas.stucky@nasa.gov">Thomas Stucky</author>

--- a/ow_dynamic_terrain/package.xml
+++ b/ow_dynamic_terrain/package.xml
@@ -13,7 +13,7 @@
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>NASA OPEN SOURCE AGREEMENT VERSION 1.3</license>
 
   <!-- Author tags are optional, multiple are allowed, one per tag -->
   <!-- Authors do not have to be maintainers, but could be -->

--- a/ow_ephemeris/package.xml
+++ b/ow_ephemeris/package.xml
@@ -13,7 +13,7 @@
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>NASA OPEN SOURCE AGREEMENT VERSION 1.3</license>
 
 
   <!-- Url tags are optional, but multiple are allowed, one per tag -->

--- a/ow_faults/package.xml
+++ b/ow_faults/package.xml
@@ -14,7 +14,7 @@
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>NASA OPEN SOURCE AGREEMENT VERSION 1.3</license>
 
 
   <!-- Url tags are optional, but multiple are allowed, one per tag -->

--- a/ow_gazebo_plugins/package.xml
+++ b/ow_gazebo_plugins/package.xml
@@ -13,7 +13,7 @@
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>NASA OPEN SOURCE AGREEMENT VERSION 1.3</license>
 
 
   <!-- Author tags are optional, mutiple are allowed, one per tag -->

--- a/ow_sim_tests/package.xml
+++ b/ow_sim_tests/package.xml
@@ -13,7 +13,7 @@
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>NASA OPEN SOURCE AGREEMENT VERSION 1.3</license>
 
   <!-- Author tags are optional, multiple are allowed, one per tag -->
   <!-- Authors do not have to be maintainers, but could be -->

--- a/ow_testbed/package.xml
+++ b/ow_testbed/package.xml
@@ -10,7 +10,7 @@
   <author>Antoine Tardy</author>
   <maintainer email="antoine.tardy@nasa.gov" />
 
-  <license>todo</license>
+  <license>NASA OPEN SOURCE AGREEMENT VERSION 1.3</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roslaunch</build_depend>


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | N/A |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-760](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-760) |
| Github :octocat:  | # |


## Summary of Changes
* Added proper license tag too all package.xml files

## Test
No testing required, but please verify that the tag is correct and that I got all package.xml files that needed it.
