### PR TITLE
Oceanwater 759 spotlight control

### DIFF
--- a/ow_lander/CMakeLists.txt
+++ b/ow_lander/CMakeLists.txt
@@ -20,10 +20,11 @@ add_service_files(
   DigLinear.srv
   Grind.srv
   GuardedMove.srv
+  Light.srv
   PublishTrajectory.srv
+  Stop.srv
   Stow.srv
   Unstow.srv
-  Stop.srv
 )
 
 add_action_files(

--- a/ow_lander/launch/spawn.launch
+++ b/ow_lander/launch/spawn.launch
@@ -96,11 +96,11 @@
     <arg name="debug" value="$(arg debug)"/>
   </include>
 
-  <!-- == launch the path planner services node ============== -->
+  <!-- == launch the services servers ============== -->
   <node pkg="ow_lander" name="path_planning_commander" type="path_planning_commander.py" output="screen" ></node>
+  <node pkg="ow_lander" name="lander_service_server" type="lander_service_server.py" output="screen" ></node>
   
-    <!-- == launch the action servers============== -->
-  
+  <!-- == launch the action servers ============== -->
   <arg name="node_start_delay" default="10.0" />  
   <node pkg="ow_lander" name="Unstow" type="unstow_action_server.py" launch-prefix="bash -c 'sleep $(arg node_start_delay); $0 $@' " />
   <node pkg="ow_lander" name="Stow" type="stow_action_server.py" launch-prefix="bash -c 'sleep $(arg node_start_delay); $0 $@' " />

--- a/ow_lander/materials/scripts/ow_lander.frag
+++ b/ow_lander/materials/scripts/ow_lander.frag
@@ -39,6 +39,8 @@ in vec4 lsPos0;
 in vec4 lsPos1;
 in vec4 lsPos2;
 
+uniform float spotlightIntensityScale0;
+uniform float spotlightIntensityScale1;
 uniform vec4 vsSpotlightPos0;
 uniform vec4 vsSpotlightPos1;
 uniform vec4 vsSpotlightDir0;
@@ -226,11 +228,13 @@ void lighting(vec3 wsDirToSun, vec3 wsDirToEye, vec3 wsNormal, vec4 wsDetailNorm
   vec3 vsDirToEye = normalize(normalMatrix * wsDirToEye);
   vec3 vsDetailNormal = normalize(normalMatrix * wsDetailNormalHeight.xyz);
   spotlight(vsSpotlightPos0.xyz - vsPos, -vsSpotlightDir0.xyz, spotlightAtten0,
-            spotlightParams0.xyz, spotlightColor0.rgb, spotlightTexCoord0,
-            vsDirToEye, vsDetailNormal, specular_power, diffuse, specular);
+            spotlightParams0.xyz, spotlightColor0.rgb * spotlightIntensityScale0,
+            spotlightTexCoord0, vsDirToEye, vsDetailNormal, specular_power,
+            diffuse, specular);
   spotlight(vsSpotlightPos1.xyz - vsPos, -vsSpotlightDir1.xyz, spotlightAtten0,
-            spotlightParams0.xyz, spotlightColor0.rgb, spotlightTexCoord1,
-            vsDirToEye, vsDetailNormal, specular_power, diffuse, specular);
+            spotlightParams0.xyz, spotlightColor0.rgb * spotlightIntensityScale1,
+            spotlightTexCoord1, vsDirToEye, vsDetailNormal, specular_power,
+            diffuse, specular);
 }
 
 void main()

--- a/ow_lander/materials/scripts/ow_lander.material
+++ b/ow_lander/materials/scripts/ow_lander.material
@@ -52,17 +52,19 @@ fragment_program ow_lander_frag glsl
     param_named irradianceMap           int 3
 
     // lander lights
-    param_named_auto vsSpotlightPos0    light_position_view_space 1
-    param_named_auto vsSpotlightPos1    light_position_view_space 2
-    param_named_auto vsSpotlightDir0    light_direction_view_space 1
-    param_named_auto vsSpotlightDir1    light_direction_view_space 2
+    param_named spotlightIntensityScale0  float 1.0
+    param_named spotlightIntensityScale1  float 1.0
+    param_named_auto vsSpotlightPos0      light_position_view_space 1
+    param_named_auto vsSpotlightPos1      light_position_view_space 2
+    param_named_auto vsSpotlightDir0      light_direction_view_space 1
+    param_named_auto vsSpotlightDir1      light_direction_view_space 2
     // Assuming these spotlights are the same, these parameters can be reused for each.
-    param_named_auto spotlightColor0  light_diffuse_colour 1
-    param_named_auto spotlightAtten0    light_attenuation 1
-    param_named_auto spotlightParams0   spotlight_params 1
-    //param_named spotlightColor0         float4 1.0 1.0 1.0 1.0
+    param_named_auto spotlightColor0      light_diffuse_colour 1
+    param_named_auto spotlightAtten0      light_attenuation 1
+    param_named_auto spotlightParams0     spotlight_params 1
+    //param_named spotlightColor0           float4 1.0 1.0 1.0 1.0
     // spotlight texture
-    param_named spotlightMap            int 4
+    param_named spotlightMap              int 4
   }
 }
 

--- a/ow_lander/materials/scripts/ow_lander.material
+++ b/ow_lander/materials/scripts/ow_lander.material
@@ -62,7 +62,6 @@ fragment_program ow_lander_frag glsl
     param_named_auto spotlightColor0      light_diffuse_colour 1
     param_named_auto spotlightAtten0      light_attenuation 1
     param_named_auto spotlightParams0     spotlight_params 1
-    //param_named spotlightColor0           float4 1.0 1.0 1.0 1.0
     // spotlight texture
     param_named spotlightMap              int 4
   }

--- a/ow_lander/scripts/lander_service_server.py
+++ b/ow_lander/scripts/lander_service_server.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python2
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import rospy
+
+from ow_lander.srv import Light
+from irg_gazebo_plugins.msg import ShaderParamUpdate
+
+
+class LanderServiceServer(object):
+
+  def __init__(self):
+    super(LanderServiceServer, self).__init__()
+
+  def run(self):
+    rospy.init_node('lander_service_server', anonymous=True)
+ 
+    # Create publishers and messages
+    self.light_pub = rospy.Publisher("/gazebo/global_shader_param", ShaderParamUpdate, queue_size=1)
+    self.light_msg = ShaderParamUpdate()
+    self.light_msg.shaderType = ShaderParamUpdate.SHADER_TYPE_FRAGMENT
+
+    # Advertise services
+    self.lander_light_srv = rospy.Service(
+        'lander/light', Light, self.handle_light)
+
+    print("Lander service server has started.")
+
+    rospy.spin()
+
+  def handle_light(self, req):
+    """
+    :type req: class 'ow_lander.srv.Light.LightRequest'
+    """
+    if req.name != 'left' and req.name != 'right':
+      return False, 'Light intensity setting failed. "{}" is not a light identifier.'.format(req.name)
+
+    if req.intensity < 0.0 or req.intensity > 1.0:
+      return False, 'Light intensity setting failed. Intensity = {} is out of range.'.format(req.intensity)
+
+    self.light_msg.paramName = 'spotlightIntensityScale0' if req.name == 'left' else 'spotlightIntensityScale1'
+    self.light_msg.paramValue = str(req.intensity)
+    self.light_pub.publish(self.light_msg)
+    return True, '{} light intensity setting succeeded.'.format(req.name)
+
+
+if __name__ == '__main__':
+  lss = LanderServiceServer()
+  lss.run()

--- a/ow_lander/scripts/lander_service_server.py
+++ b/ow_lander/scripts/lander_service_server.py
@@ -19,7 +19,8 @@ class LanderServiceServer(object):
     rospy.init_node('lander_service_server', anonymous=True)
  
     # Create publishers and messages
-    self.light_pub = rospy.Publisher("/gazebo/global_shader_param", ShaderParamUpdate, queue_size=1)
+    self.light_pub = rospy.Publisher("/gazebo/global_shader_param",
+                                     ShaderParamUpdate, queue_size=1)
     self.light_msg = ShaderParamUpdate()
     self.light_msg.shaderType = ShaderParamUpdate.SHADER_TYPE_FRAGMENT
 
@@ -36,12 +37,16 @@ class LanderServiceServer(object):
     :type req: class 'ow_lander.srv.Light.LightRequest'
     """
     if req.name != 'left' and req.name != 'right':
-      return False, 'Light intensity setting failed. "{}" is not a light identifier.'.format(req.name)
+      return False, 'Light intensity setting failed. "{}" is not a light '\
+             'identifier.'.format(req.name)
 
     if req.intensity < 0.0 or req.intensity > 1.0:
-      return False, 'Light intensity setting failed. Intensity = {} is out of range.'.format(req.intensity)
+      return False, 'Light intensity setting failed. Intensity = {} is out '\
+             'of range.'.format(req.intensity)
 
-    self.light_msg.paramName = 'spotlightIntensityScale0' if req.name == 'left' else 'spotlightIntensityScale1'
+    self.light_msg.paramName = 'spotlightIntensityScale0'
+    if req.name == 'right':
+        self.light_msg.paramName = 'spotlightIntensityScale1'
     self.light_msg.paramValue = str(req.intensity)
     self.light_pub.publish(self.light_msg)
     return True, '{} light intensity setting succeeded.'.format(req.name)

--- a/ow_lander/srv/Light.srv
+++ b/ow_lander/srv/Light.srv
@@ -1,0 +1,5 @@
+string name         # Set to "left" or "right"
+float32 intensity   # Set intensity in range {0.0, 1.0}. O.0 turns the light off.
+---
+bool success
+string message


### PR DESCRIPTION
| Jira Ticket 🎟️ | [OCEANWATER-XXX](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-759) |

## Summary of Changes
* Added ability to set light intensity from 0.0 to 1.0

## Test
* Check out the same branch in ow_europa
* roslaunch ow atacama_y1a.launch
* rostopic pub -1 /_original/ant_tilt_position_controller/command std_msgs/Float64 1.3
* rostopic pub -1 /_original/ant_pan_position_controller/command std_msgs/Float64 1.5
* rosservice call /lander/light    Use tab completion and set to "name: 'left' intensity: 0.0"
* rosservice call /lander/light    Use tab completion and set to "name: 'right' intensity: 0.0"
* rosservice call /lander/light    Use tab completion and set to "name: 'left' intensity: 1.0"
* rosservice call /lander/light    Use tab completion and set to "name: 'right' intensity: 1.0"

It's difficult to see the effect of the lights on the terrain. Watch closely and you'll see a change when you do the rosservice calls.