### PR TITLE
OCEANWATER-791: prototype arm faulting utilizing joints locking

### DIFF
--- a/ow_faults/include/ow_faults/JointsFaults.h
+++ b/ow_faults/include/ow_faults/JointsFaults.h
@@ -7,6 +7,18 @@
 
 #include <gazebo/common/Plugin.hh>
 
+struct JointFaultInfo
+{
+  const std::string fault;
+  bool activated;
+  double lower;
+  double upper;
+
+  JointFaultInfo(const std::string& fault_, bool activated_ = false, double lower_ = 0.0, double upper_ = 0.0)
+  : fault(fault_), activated(activated_), lower(lower_), upper(upper_)
+  {
+  }
+};
 
 class JointsFaults : public gazebo::ModelPlugin
 {
@@ -30,7 +42,7 @@ private:
   bool m_antennaTiltFaultActivated;
   bool m_antennaPanFaultActivated;
 
-
+  std::map<std::string, JointFaultInfo> m_JointsFaultsMap;
 
   // Connection to the update event
   gazebo::event::ConnectionPtr m_updateConnection;

--- a/ow_faults/include/ow_faults/JointsFaults.h
+++ b/ow_faults/include/ow_faults/JointsFaults.h
@@ -11,11 +11,10 @@ struct JointFaultInfo
 {
   const std::string fault;
   bool activated;
-  double lower;
-  double upper;
+  double friction;
 
-  JointFaultInfo(const std::string& fault_, bool activated_ = false, double lower_ = 0.0, double upper_ = 0.0)
-  : fault(fault_), activated(activated_), lower(lower_), upper(upper_)
+  JointFaultInfo(const std::string& fault_, bool activated_ = false, double friction_ = 0.0)
+  : fault(fault_), activated(activated_), friction(friction_)
   {
   }
 };
@@ -31,20 +30,12 @@ public:
 private:
   void onUpdate();
 
-  void injectFault(const std::string& joint_fault, bool& fault_activated, const std::string& joint_name,
-                   double lower_limit, double upper_limit);
+  void injectFault(const std::string& joint_name, JointFaultInfo& jfi);
+
+  static constexpr double MAX_FRICTION = 3000.0;
 
   gazebo::physics::ModelPtr m_model;
-  double m_antennaTiltLowerLimit;
-  double m_antennaTiltUpperLimit;
-  double m_antennaPanLowerLimit;
-  double m_antennaPanUpperLimit;
-  bool m_antennaTiltFaultActivated;
-  bool m_antennaPanFaultActivated;
-
   std::map<std::string, JointFaultInfo> m_JointsFaultsMap;
-
-  // Connection to the update event
   gazebo::event::ConnectionPtr m_updateConnection;
 };
 

--- a/ow_faults/src/FaultInjector.cpp
+++ b/ow_faults/src/FaultInjector.cpp
@@ -162,8 +162,8 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
   // Set failed sensor values to 0
   unsigned int index;
 
-  checkArmFaults();
-  checkAntFaults();
+  // checkArmFaults();
+  // checkAntFaults();
   checkCamFaults();
 
   if (m_ant_fault){
@@ -273,7 +273,7 @@ void FaultInjector::distPitchFtSensorCb(const geometry_msgs::WrenchStamped& msg)
   m_dist_pitch_ft_sensor_pub.publish(out_msg);
 }
 
-void FaultInjector::checkArmFaults(){
+void FaultInjector::checkArmFaults() {
   m_arm_fault = (m_faults.shou_yaw_encoder_failure || m_faults.shou_yaw_effort_failure ||
                 m_faults.shou_pitch_encoder_failure || m_faults.shou_pitch_effort_failure ||
                 m_faults.prox_pitch_encoder_failure || m_faults.prox_pitch_effort_failure ||

--- a/ow_faults/src/JointsFaults.cpp
+++ b/ow_faults/src/JointsFaults.cpp
@@ -17,6 +17,15 @@ GZ_REGISTER_MODEL_PLUGIN(JointsFaults)
 JointsFaults::JointsFaults() :
   ModelPlugin()
 {
+  m_JointsFaultsMap = {
+    {"j_shou_yaw", JointFaultInfo("shou_yaw_effort_failure")},
+    {"j_shou_pitch", JointFaultInfo("shou_pitch_effort_failure")},
+    {"j_prox_pitch", JointFaultInfo("prox_pitch_effort_failure")},
+    {"j_dist_pitch", JointFaultInfo("dist_pitch_effort_failure")},
+    {"j_hand_yaw", JointFaultInfo("hand_yaw_effort_failure")},
+    {"j_scoop_yaw", JointFaultInfo("scoop_yaw_effort_failure")},
+    {"j_ant_pan", JointFaultInfo("ant_pan_effort_failure")},
+    {"j_ant_tilt", JointFaultInfo("ant_pan_effort_failure")} };
 }
 
 JointsFaults::~JointsFaults()
@@ -27,13 +36,12 @@ void JointsFaults::Load(physics::ModelPtr model, sdf::ElementPtr /* sdf */)
 {
   m_model = model;
 
-  auto j_ant_tilt = m_model->GetJoint("j_ant_tilt");
-  m_antennaTiltLowerLimit = j_ant_tilt->LowerLimit(0);
-  m_antennaTiltUpperLimit = j_ant_tilt->UpperLimit(0);
-
-  auto j_ant_pan = m_model->GetJoint("j_ant_pan");
-  m_antennaPanLowerLimit = j_ant_pan->LowerLimit(0);
-  m_antennaPanUpperLimit = j_ant_pan->UpperLimit(0);
+  for (auto& kv : m_JointsFaultsMap)
+  {
+    auto j = m_model->GetJoint(kv.first);
+    kv.second.lower = j->LowerLimit(0);
+    kv.second.upper = j->UpperLimit(0);
+  }
 
   // Listen to the update event. This event is broadcast every sim iteration.
   // If result goes out of scope updates will stop, so it is assigned to a member variable.
@@ -44,11 +52,9 @@ void JointsFaults::Load(physics::ModelPtr model, sdf::ElementPtr /* sdf */)
 
 void JointsFaults::onUpdate()
 {
-  injectFault("ant_tilt_effort_failure", m_antennaTiltFaultActivated, "j_ant_tilt",
-            m_antennaTiltLowerLimit, m_antennaTiltUpperLimit);
-
-  injectFault("ant_pan_effort_failure", m_antennaPanFaultActivated, "j_ant_pan",
-            m_antennaPanLowerLimit, m_antennaPanUpperLimit);
+  for (auto& kv : m_JointsFaultsMap)
+    injectFault(kv.second.fault, kv.second.activated, kv.first,
+            kv.second.lower, kv.second.upper);
 }
 
 void JointsFaults::injectFault(const std::string& joint_fault, bool& fault_activated,

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -306,7 +306,7 @@
   </gazebo>
   <joint
     name="j_prox_pitch"
-    type="revolute">
+    type="continuous">
     <origin
       xyz="0.53 0 0"
       rpy="9.7855E-17 0 -4.9304E-32" />
@@ -317,7 +317,7 @@
     <axis
       xyz="0 0 -1" />
     <dynamics damping="50.0" friction="2.7"/>
-    <limit effort="73.0" velocity="0.2" lower="-1000000" upper="1000000"/>
+    <limit effort="73.0" velocity="0.2"/>
   </joint>
   <transmission name="prox_pitch_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -382,7 +382,7 @@
   </gazebo>
   <joint
     name="j_dist_pitch"
-    type="revolute">
+    type="continuous">
     <origin
       xyz="0.586 0 -0.15"
       rpy="3.1416 2.1341E-16 1.5708" />
@@ -393,7 +393,7 @@
     <axis
       xyz="0 0 1" />
     <dynamics damping="50.0" friction="0.3"/>
-    <limit effort="25.7" velocity="0.2" lower="-1000000" upper="1000000"/>
+    <limit effort="25.7" velocity="0.2" />
   </joint>
   <transmission name="dist_pitch_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -482,7 +482,7 @@
 
   <joint
     name="j_hand_yaw"
-    type="revolute">
+    type="continuous">
     <origin
       xyz="0.163 0.2 0"
       rpy="1.5708 2.8911E-17 -3.228E-16" />
@@ -493,7 +493,7 @@
     <axis
       xyz="0 0 -1" />
     <dynamics damping="50.0" friction="0.3"/>
-    <limit effort="25.7" velocity="0.2" lower="-1000000" upper="1000000"/>
+    <limit effort="25.7" velocity="0.2" />
   </joint>
   <transmission name="hand_yaw_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -642,7 +642,7 @@
 
   <joint
     name="j_scoop_yaw"
-    type="revolute">
+    type="continuous">
     <origin
       xyz="0.15 0 0"
       rpy="1.5708 -1.1102E-16 1.5708" />
@@ -653,7 +653,7 @@
     <axis
       xyz="0 0 -1" />
     <dynamics damping="50.0" friction="0.5"/>
-    <limit effort="20.0" velocity="0.2" lower="-1000000" upper="1000000"/>
+    <limit effort="20.0" velocity="0.2" />
   </joint>
   <transmission name="scoop_yaw_transmission">
     <type>transmission_interface/SimpleTransmission</type>

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -306,7 +306,7 @@
   </gazebo>
   <joint
     name="j_prox_pitch"
-    type="continuous">
+    type="revolute">
     <origin
       xyz="0.53 0 0"
       rpy="9.7855E-17 0 -4.9304E-32" />
@@ -317,7 +317,7 @@
     <axis
       xyz="0 0 -1" />
     <dynamics damping="50.0" friction="2.7"/>
-    <limit effort="73.0" velocity="0.2"/>
+    <limit effort="73.0" velocity="0.2" lower="1000000" upper="1000000"/>
   </joint>
   <transmission name="prox_pitch_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -382,7 +382,7 @@
   </gazebo>
   <joint
     name="j_dist_pitch"
-    type="continuous">
+    type="revolute">
     <origin
       xyz="0.586 0 -0.15"
       rpy="3.1416 2.1341E-16 1.5708" />
@@ -393,7 +393,7 @@
     <axis
       xyz="0 0 1" />
     <dynamics damping="50.0" friction="0.3"/>
-    <limit effort="25.7" velocity="0.2" />
+    <limit effort="25.7" velocity="0.2" lower="1000000" upper="1000000"/>
   </joint>
   <transmission name="dist_pitch_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -482,7 +482,7 @@
 
   <joint
     name="j_hand_yaw"
-    type="continuous">
+    type="revolute">
     <origin
       xyz="0.163 0.2 0"
       rpy="1.5708 2.8911E-17 -3.228E-16" />
@@ -493,7 +493,7 @@
     <axis
       xyz="0 0 -1" />
     <dynamics damping="50.0" friction="0.3"/>
-    <limit effort="25.7" velocity="0.2" />
+    <limit effort="25.7" velocity="0.2" lower="1000000" upper="1000000"/>
   </joint>
   <transmission name="hand_yaw_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -642,7 +642,7 @@
 
   <joint
     name="j_scoop_yaw"
-    type="continuous">
+    type="revolute">
     <origin
       xyz="0.15 0 0"
       rpy="1.5708 -1.1102E-16 1.5708" />
@@ -653,7 +653,7 @@
     <axis
       xyz="0 0 -1" />
     <dynamics damping="50.0" friction="0.5"/>
-    <limit effort="20.0" velocity="0.2" />
+    <limit effort="20.0" velocity="0.2" lower="1000000" upper="1000000"/>
   </joint>
   <transmission name="scoop_yaw_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -767,7 +767,7 @@
     <child link="l_grinder" />
     <axis xyz="-1 0 0" />
     <dynamics damping="1" />
-    <limit lower="-3.14" upper="3.14" effort="1.0" velocity="0.1" />
+    <limit effort="1.0" velocity="0.1" lower="-3.14" upper="3.14"/>
   </joint>
   <transmission name="grinder_yaw_transmission">
     <type>transmission_interface/SimpleTransmission</type>

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -317,7 +317,7 @@
     <axis
       xyz="0 0 -1" />
     <dynamics damping="50.0" friction="2.7"/>
-    <limit effort="73.0" velocity="0.2" lower="1000000" upper="1000000"/>
+    <limit effort="73.0" velocity="0.2" lower="-1000000" upper="1000000"/>
   </joint>
   <transmission name="prox_pitch_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -393,7 +393,7 @@
     <axis
       xyz="0 0 1" />
     <dynamics damping="50.0" friction="0.3"/>
-    <limit effort="25.7" velocity="0.2" lower="1000000" upper="1000000"/>
+    <limit effort="25.7" velocity="0.2" lower="-1000000" upper="1000000"/>
   </joint>
   <transmission name="dist_pitch_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -493,7 +493,7 @@
     <axis
       xyz="0 0 -1" />
     <dynamics damping="50.0" friction="0.3"/>
-    <limit effort="25.7" velocity="0.2" lower="1000000" upper="1000000"/>
+    <limit effort="25.7" velocity="0.2" lower="-1000000" upper="1000000"/>
   </joint>
   <transmission name="hand_yaw_transmission">
     <type>transmission_interface/SimpleTransmission</type>
@@ -653,7 +653,7 @@
     <axis
       xyz="0 0 -1" />
     <dynamics damping="50.0" friction="0.5"/>
-    <limit effort="20.0" velocity="0.2" lower="1000000" upper="1000000"/>
+    <limit effort="20.0" velocity="0.2" lower="-1000000" upper="1000000"/>
   </joint>
   <transmission name="scoop_yaw_transmission">
     <type>transmission_interface/SimpleTransmission</type>


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-551 / OW Faults Injection](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-551) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-791 / prototype arm joint faults utilizing joints locking](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-791) |
| Github :octocat:  | related: #170 |


## Summary of Changes
* Arm Fault Inject through joint locking
* Switched from using _Joint Upper/Lower Limits_ to lock the joint to using _Joint Friction_
* Disabled the check for arm_fault such that no fault injection is placed through the arm action servers

## Test
* Launch the simulation
```bash
roslaunch ow atacama_y1a.launch
```
* Verify that you can freely control the arm
```bash
rosservice call /arm/unstow
# or rosservice call /arm/stow
```
* Enable a fault on one or more of the arm joints:
```bash
rosrun dynamic_reconfigure dynparam set /faults shou_yaw_effort_failure True
# other options: shou_pitch_effort_failure, prox_pitch_effort_failure,
# dist_pitch_effort_failure, hand_yaw_effort_failure, scoop_yaw_effort_failure
```
* Verify that the arm cripples during motion due of the specific joint that was disabled
```bash
rosservice call /arm/stow
# or rosservice call /arm/unstow
# or rosservice call /arm/deliver_sample
# or ...
```
* Verify that you can lock/unlock any specific joint anytime during its motion
```bash
rosrun dynamic_reconfigure dynparam set /faults shou_yaw_effort_failure True/False
```
* Redo the same test steps towards action servers
```bash
python src/ow_simulator/ow_lander/scripts/unstow_action_client.py
# or src/ow_simulator/ow_lander/scripts/stow_action_client.py
# or ...
```