### PR TITLE
fixed the issue causing the FaultDetector node to crash

### DIFF
--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -81,8 +81,7 @@ private:
   void armJointStatesCb(const sensor_msgs::JointStateConstPtr& msg);
   void armControllerStateCb(const control_msgs::JointTrajectoryControllerState::ConstPtr& msg);
   void jointStatesFlagCb(const ow_faults_injection::JointStatesFlagConstPtr& msg);
-  template<typename name, typename flagsList>
-  bool isFlagSet(name n, flagsList flags);
+  bool isFlagSet(uint joint, const std::vector<double>& flags);
   // Find an item in an std::vector or other find-able data structure, and
   // return its index. Return -1 if not found.
   template<typename group_t, typename item_t>

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -174,7 +174,6 @@ void FaultDetector::jointStatesFlagCb(const ow_faults_injection::JointStatesFlag
 
   //arm faults
   for (auto& name : armList) {
-    std::cout << name << std::endl;
     armFault = armFault || isFlagSet( name, msg->flags);
   }
 

--- a/ow_faults_injection/src/FaultInjector.cpp
+++ b/ow_faults_injection/src/FaultInjector.cpp
@@ -191,7 +191,7 @@ int FaultInjector::findPositionInGroup(const group_t& group, const item_t& item)
 
 bool FaultInjector::findJointIndex(const unsigned int joint, unsigned int& out_index)
 {
-  if(joint >= NUM_JOINTS)
+  if(joint >= m_joint_state_indices.size())
     return false;
 
   out_index = m_joint_state_indices[joint];


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-718 / detection epic](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-718) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | N/A |
| Github :octocat:  | #140 |


## Summary of Changes
* Check the return value of findJointIndex within isFlagSet before using the returned index

## Test
* Launch the simulation
```bash
roslaunch ow atacama_y1a.launch
```
Check that the FaultDetector node launches successfully and doesn't crash
