### PR TITLE
Removed legacy code that was causing grind failures.

### DIFF
--- a/ow_lander/scripts/arm_action_servers.py
+++ b/ow_lander/scripts/arm_action_servers.py
@@ -231,7 +231,7 @@ class GrindActionServer(object):
             self._timeout = (end_time - start_time)
 
     def on_Grind_action(self, goal):
-        plan = self._update_motion(goal)
+        self._update_motion(goal)
         if self.current_traj == False:
             self._server.set_aborted(self._result)
             return
@@ -353,7 +353,7 @@ class GuardedMoveActionServer(object):
             self._timeout = end_time - start_time
 
     def on_guarded_move_action(self, goal):
-        plan = self._update_motion(goal)
+        self._update_motion(goal)
         if self.guarded_move_traj == False:
             self._server.set_aborted(self._result)
             return
@@ -452,7 +452,7 @@ class DigCircularActionServer(object):
             self._timeout = (end_time - start_time)
 
     def on_DigCircular_action(self, goal):
-        plan = self._update_motion(goal)
+        self._update_motion(goal)
         if self.current_traj == False:
             self._server.set_aborted(self._result)
             return
@@ -530,7 +530,7 @@ class DigLinearActionServer(object):
             self._timeout = (end_time - start_time)
 
     def on_DigLinear_action(self, goal):
-        plan = self._update_motion(goal)
+        self._update_motion(goal)
         if self.current_traj == False:
             self._server.set_aborted(self._result)
             return
@@ -605,7 +605,7 @@ class DeliverActionServer(object):
             self._timeout = end_time - start_time
 
     def on_deliver_action(self, goal):
-        plan = self._update_motion(goal)
+        self._update_motion(goal)
         if self.deliver_sample_traj == False:
             self._server.set_aborted(self._result)
             return


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️ | [OCEANWATER-832](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-832) |


## Summary of Changes
* Removed unused code

## Test
* roslaunch ow atacama_y1a.launch
* roslaunch ow_plexil ow_exec.launch plan:=ReferenceMission1.plx
* Without this change you should see 3 instances of "Grind finished in state ABORTED"
* With this change you should instead see "Grind finished in state SUCCEEDED"
