### PR TITLE
OCEANWATER-/833/834/835: address multiple issues within the ros action interface of the lander arm on ROS Noetic

### DIFF
--- a/ow_lander/scripts/all_action_trajectories.py
+++ b/ow_lander/scripts/all_action_trajectories.py
@@ -131,7 +131,7 @@ def go_to_XYZ_coordinate(move_arm, cs, goal_pose, x_start, y_start, z_start, app
     else:
         move_arm.set_pose_target(goal_pose)
 
-    plan = move_arm.plan()
+    _, plan, _, _ = move_arm.plan()
 
     if len(plan.joint_trajectory.points) == 0:  # If no plan found, abort
         return False
@@ -165,7 +165,7 @@ def go_to_Z_coordinate(move_arm, cs, goal_pose, x_start, y_start, z_start, appro
     else:
         move_arm.set_pose_target(goal_pose)
 
-    plan = move_arm.plan()
+    _, plan, _, _ = move_arm.plan()
 
     if len(plan.joint_trajectory.points) == 0:  # If no plan found, abort
         return False
@@ -204,7 +204,8 @@ def move_to_pre_trench_configuration_dig_circ(move_arm, robot, x_start, y_start)
 
     joint_goal[constants.J_SCOOP_YAW] = 0
 
-    plan = move_arm.plan(joint_goal)
+    move_arm.set_pose_target(joint_goal)
+    _, plan, _, _ = move_arm.plan()
     return plan
 
 
@@ -240,7 +241,7 @@ def dig_circular(move_arm, move_limbs, robot, moveit_fk, args):
 
         move_arm.set_start_state(cs)
         move_arm.set_pose_target(end_pose)
-        plan_b = move_arm.plan()
+        _, plan_b, _, _ = move_arm.plan()
         if len(plan_b.joint_trajectory.points) == 0:  # If no plan found, abort
             return False
         circ_traj = cascade_plans(plan_a, plan_b)
@@ -349,7 +350,8 @@ def move_to_pre_trench_configuration(move_arm, robot, x_start, y_start):
         return False
 
     joint_goal[constants.J_SCOOP_YAW] = 0
-    plan = move_arm.plan(joint_goal)
+    move_arm.set_pose_target(joint_goal)
+    _, plan, _, _ = move_arm.plan()
     return plan
 
 
@@ -412,7 +414,8 @@ def change_joint_value(move_arm, cs, start_state, joint_index, target_value):
         joint_goal[k] = start_state[k]
 
     joint_goal[joint_index] = target_value
-    plan = move_arm.plan(joint_goal)
+    move_arm.set_pose_target(joint_goal)
+    _, plan, _, _ = move_arm.plan()
     return plan
 
 
@@ -439,7 +442,7 @@ def go_to_Z_coordinate(move_arm, cs, goal_pose, x_start, y_start, z_start, appro
         move_arm.set_joint_value_target(goal_pose, True)
     else:
         move_arm.set_pose_target(goal_pose)
-    plan = move_arm.plan()
+    _, plan, _, _ = move_arm.plan()
     if len(plan.joint_trajectory.points) == 0:  # If no plan found, abort
         return False
     return plan
@@ -638,7 +641,7 @@ def grind(move_grinder, robot, moveit_fk, args):
     goal_pose.orientation.z = -0.706723318474
     goal_pose.orientation.w = 0.0307192507001
     move_grinder.set_pose_target(goal_pose)
-    plan_a = move_grinder.plan()
+    _, plan_a, _, _ = move_grinder.plan()
     if len(plan_a.joint_trajectory.points) == 0:  # If no plan found, abort
         return False
 
@@ -736,7 +739,8 @@ def guarded_move_plan(move_arm, robot, moveit_fk, args):
 
     joint_goal[constants.J_SCOOP_YAW] = 0
 
-    plan_a = move_arm.plan(joint_goal)
+    move_arm.set_joint_value_target(joint_goal)
+    _, plan_a, _, _ = move_arm.plan()
     if len(plan_a.joint_trajectory.points) == 0:  # If no plan found, abort
         return False
 
@@ -749,7 +753,7 @@ def guarded_move_plan(move_arm, robot, moveit_fk, args):
     goal_pose.position.z = targ_z
 
     move_arm.set_pose_target(goal_pose)
-    plan_b = move_arm.plan()
+    _, plan_b, _, _ = move_arm.plan()
     if len(plan_b.joint_trajectory.points) == 0:  # If no plan found, abort
         return False
     pre_guarded_move_traj = cascade_plans(plan_a, plan_b)
@@ -769,7 +773,7 @@ def guarded_move_plan(move_arm, robot, moveit_fk, args):
     goal_pose.position.z -= direction_z*search_distance
 
     move_arm.set_pose_target(goal_pose)
-    plan_c = move_arm.plan()
+    _, plan_c, _, _ = move_arm.plan()
 
     guarded_move_traj = cascade_plans(pre_guarded_move_traj, plan_c)
 
@@ -814,7 +818,7 @@ def deliver_sample(move_arm, robot, moveit_fk, args):
 
     move_arm.set_pose_target(goal_pose)
 
-    plan_a = move_arm.plan()
+    _, plan_a, _, _ = move_arm.plan()
 
     if len(plan_a.joint_trajectory.points) == 0:  # If no plan found, abort
         return False
@@ -848,7 +852,7 @@ def deliver_sample(move_arm, robot, moveit_fk, args):
     goal_pose.orientation = Quaternion(q[0], q[1], q[2], q[3])
 
     move_arm.set_pose_target(goal_pose)
-    plan_b = move_arm.plan()
+    _, plan_b, _, _ = move_arm.plan()
 
     if len(plan_b.joint_trajectory.points) == 0:  # If no plan found, send the previous plan only
         return plan_a

--- a/ow_lander/scripts/all_action_trajectories.py
+++ b/ow_lander/scripts/all_action_trajectories.py
@@ -138,46 +138,12 @@ def go_to_XYZ_coordinate(move_arm, cs, goal_pose, x_start, y_start, z_start, app
 
     return plan
 
-
-def go_to_Z_coordinate(move_arm, cs, goal_pose, x_start, y_start, z_start, approximate=True):
-    """
-    :param approximate: use an approximate solution. default True
-    :type move_group: class 'moveit_commander.move_group.MoveGroupCommander'
-    :type x_start: float
-    :type y_start: float
-    :type z_start: float
-    :type approximate: bool
-    """
-
-    move_arm.set_start_state(cs)
-    goal_pose.position.z = z_start
-
-    goal_pose.orientation.x = goal_pose.orientation.x
-    goal_pose.orientation.y = goal_pose.orientation.y
-    goal_pose.orientation.z = goal_pose.orientation.z
-    goal_pose.orientation.w = goal_pose.orientation.w
-
-    # Ask the planner to generate a plan to the approximate joint values generated
-    # by kinematics builtin IK solver. For more insight on this issue refer to:
-    # https://github.com/nasa/ow_simulator/pull/60
-    if approximate:
-        move_arm.set_joint_value_target(goal_pose, True)
-    else:
-        move_arm.set_pose_target(goal_pose)
-
-    _, plan, _, _ = move_arm.plan()
-
-    if len(plan.joint_trajectory.points) == 0:  # If no plan found, abort
-        return False
-
-    return plan
-
-def go_to_Z_coordinate_dig_circular(move_arm, cs, goal_pose, x_start, y_start, z_start, approximate=True):
+def go_to_Z_coordinate_dig_circular(move_arm, cs, goal_pose, z_start, approximate=True):
   """
   :param approximate: use an approximate solution. default True
-  :type move_group: class 'moveit_commander.move_group.MoveGroupCommander'
-  :type x_start: float
-  :type y_start: float
+  :type move_arm: class 'moveit_commander.move_group.MoveGroupCommander'
+  :type cs: robot current state
+  :type goal_pose: Pose
   :type z_start: float
   :type approximate: bool
   """
@@ -198,8 +164,7 @@ def go_to_Z_coordinate_dig_circular(move_arm, cs, goal_pose, x_start, y_start, z
   else:
     move_arm.set_pose_target(goal_pose)
 
-  plan = move_arm.plan()
-  
+  _, plan, _, _ = move_arm.plan()
   
   if len(plan.joint_trajectory.points) == 0:  # If no plan found, abort
     return False
@@ -238,7 +203,7 @@ def move_to_pre_trench_configuration_dig_circ(move_arm, robot, x_start, y_start)
 
     joint_goal[constants.J_SCOOP_YAW] = 0
 
-    move_arm.set_pose_target(joint_goal)
+    move_arm.set_joint_value_target(joint_goal)
     _, plan, _, _ = move_arm.plan()
     return plan
 
@@ -297,7 +262,7 @@ def dig_circular(move_arm, move_limbs, robot, moveit_fk, args):
         z_start = ground_position + constants.R_PARALLEL_FALSE_A  # - depth
 
         plan_d = go_to_Z_coordinate_dig_circular(
-            move_arm, cs, end_pose, x_start, y_start, z_start)
+            move_arm, cs, end_pose, z_start)
         circ_traj = cascade_plans(circ_traj, plan_d)
 
         # Rotate hand perpendicular to arm direction
@@ -384,7 +349,7 @@ def move_to_pre_trench_configuration(move_arm, robot, x_start, y_start):
         return False
 
     joint_goal[constants.J_SCOOP_YAW] = 0
-    move_arm.set_pose_target(joint_goal)
+    move_arm.set_joint_value_target(joint_goal)
     _, plan, _, _ = move_arm.plan()
     return plan
 
@@ -448,7 +413,7 @@ def change_joint_value(move_arm, cs, start_state, joint_index, target_value):
         joint_goal[k] = start_state[k]
 
     joint_goal[joint_index] = target_value
-    move_arm.set_pose_target(joint_goal)
+    move_arm.set_joint_value_target(joint_goal)
     _, plan, _, _ = move_arm.plan()
     return plan
 

--- a/ow_lander/scripts/arm_action_servers.py
+++ b/ow_lander/scripts/arm_action_servers.py
@@ -49,7 +49,8 @@ class UnstowActionServer(object):
         rospy.loginfo("Unstow arm activity started")
         goal = self._interface.move_arm.get_current_pose().pose
         goal = self._interface.move_arm.get_named_target_values("arm_unstowed")
-        plan = self._interface.move_arm.plan(goal)
+        self._interface.move_arm.set_joint_value_target(goal)
+        _, plan, _, _ = self._interface.move_arm.plan()
         if len(plan.joint_trajectory.points) < 1:
             return
         else:
@@ -127,7 +128,8 @@ class StowActionServer(object):
         rospy.loginfo("Stow arm activity started")
         goal = self._interface.move_arm.get_current_pose().pose
         goal = self._interface.move_arm.get_named_target_values("arm_stowed")
-        plan = self._interface.move_arm.plan(goal)
+        self._interface.move_arm.set_joint_value_target(goal)
+        _, plan, _, _ = self._interface.move_arm.plan()
         if len(plan.joint_trajectory.points) < 1:
             return
         else:


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [ N/A ] |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-833 / update moveit syntax for noetic](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-833) |
| Jira Ticket 🎟️ | [OCEANWATER-834 / Arm actions fails to perform dig motions on ROS Noetic](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-834) |
| Jira Ticket 🎟️ | [OCEANWATER-835 / Dig Circular fails to perform when using non parallel move](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-835) |
| Github :octocat:  | builds on #187 |


## Summary of Changes
* All changes from #187 
* Address bug arm actions fails to perform dig motions on ROS Noetic
* Address bug "Dig Circular" fails to perform when using non parallel move
* Code cleanup:
  - Remove unused parameters of function `go_to_Z_coordinate_dig_circular`
  - Remove duplicate function `go_to_Z_coordinate` in `all_action_trajectories.py`

## Test
* Run [OceanWATERS Release 9 ROS Actions System Tests](https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/OW-TEST-009-4+ROS+Actions)
  - When testing "Dig Ciruclar" try with the default settings first, then modify the `dig_circular_action_client.py` and select the following settings to test the non parallel dig circular motion too:
  ```python
    # # Default trenching values
    # goal.x_start = 1.65
    # goal.y_start = 0
    # goal.depth = 0.01
    # goal.parallel = True
    # goal.ground_position = constants.DEFAULT_GROUND_HEIGHT
    
    # General trenching values     
    goal.x_start = 1.55
    goal.y_start = 0.2 # also try with -0.2 and other values
    goal.depth = 0.045
    goal.parallel = False
    goal.ground_position = -0.155
  ```