### PR TITLE
Oceanwater 829 ros action arguments

### DIFF
--- a/ow_lander/scripts/antenna_pan_tilt_action_client.py
+++ b/ow_lander/scripts/antenna_pan_tilt_action_client.py
@@ -58,7 +58,6 @@ if __name__ == '__main__':
         # Initializes a rospy node
 
         rospy.init_node('antenna_client_py')
-        #result = antenna_client(sys.argv[1:])
         result = antenna_client()
         rospy.loginfo("Result: %s", result)
     except rospy.ROSInterruptException:

--- a/ow_lander/scripts/antenna_pan_tilt_action_client.py
+++ b/ow_lander/scripts/antenna_pan_tilt_action_client.py
@@ -26,7 +26,8 @@ def wrap_angle(angle):
 
 def antenna_client():
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         'pan', type=float, help='Antenna pan value in radians', nargs='?', default=0, const=0)
     parser.add_argument(

--- a/ow_lander/scripts/antenna_pan_tilt_action_client.py
+++ b/ow_lander/scripts/antenna_pan_tilt_action_client.py
@@ -6,8 +6,6 @@
 
 import rospy
 import actionlib
-import sys
-import getopt
 from math import pi
 import argparse
 import ow_lander.msg

--- a/ow_lander/scripts/antenna_pan_tilt_action_client.py
+++ b/ow_lander/scripts/antenna_pan_tilt_action_client.py
@@ -23,22 +23,26 @@ def wrap_angle(angle):
         angle += 2 * pi
     return angle
 
+
 def antenna_client():
-    
+
     parser = argparse.ArgumentParser()
-    parser.add_argument('pan', type=float, help='Antenna pan value in radians', nargs='?', default=0, const=0)
-    parser.add_argument('tilt', type=float, help='Antenna tilt value in radians', nargs='?', default=0, const=0)
+    parser.add_argument(
+        'pan', type=float, help='Antenna pan value in radians', nargs='?', default=0, const=0)
+    parser.add_argument(
+        'tilt', type=float, help='Antenna tilt value in radians', nargs='?', default=0, const=0)
     args = parser.parse_args()
     rospy.loginfo("Requetsed pan value: %s", args.pan)
     rospy.loginfo("Requetsed tilt value: %s", args.tilt)
 
-    client = actionlib.SimpleActionClient('AntennaPanTiltAction', ow_lander.msg.AntennaPanTiltAction)
+    client = actionlib.SimpleActionClient(
+        'AntennaPanTiltAction', ow_lander.msg.AntennaPanTiltAction)
     client.wait_for_server()
 
     goal = ow_lander.msg.AntennaPanTiltGoal()
     goal.pan = args.pan
     goal.tilt = args.tilt
-        
+
     goal.tilt = wrap_angle(goal.tilt)
     goal.pan = wrap_angle(goal.pan)
 
@@ -49,7 +53,8 @@ def antenna_client():
     client.wait_for_result()
 
     # Prints out the result of executing the action
-    return client.get_result()  # 
+    return client.get_result()  #
+
 
 if __name__ == '__main__':
     try:

--- a/ow_lander/scripts/antenna_pan_tilt_action_client.py
+++ b/ow_lander/scripts/antenna_pan_tilt_action_client.py
@@ -6,8 +6,12 @@
 
 import rospy
 import actionlib
+import sys
+import getopt
 from math import pi
+import argparse
 import ow_lander.msg
+
 
 def wrap_angle(angle):
     """
@@ -19,18 +23,24 @@ def wrap_angle(angle):
         angle -= 2 * pi
     while angle < -(pi-tolerance):
         angle += 2 * pi
-    return angle 
+    return angle
 
 def antenna_client():
- 
-    client = actionlib.SimpleActionClient('AntennaPanTiltAction', ow_lander.msg.AntennaPanTiltAction)
+    
+    parser = argparse.ArgumentParser()
+    parser.add_argument('pan', type=float, help='Antenna pan value in radians', nargs='?', default=0, const=0)
+    parser.add_argument('tilt', type=float, help='Antenna tilt value in radians', nargs='?', default=0, const=0)
+    args = parser.parse_args()
+    rospy.loginfo("Requetsed pan value: %s", args.pan)
+    rospy.loginfo("Requetsed tilt value: %s", args.tilt)
 
+    client = actionlib.SimpleActionClient('AntennaPanTiltAction', ow_lander.msg.AntennaPanTiltAction)
     client.wait_for_server()
 
     goal = ow_lander.msg.AntennaPanTiltGoal()
-
-    goal.pan = 0.0
-    goal.tilt = 0.5
+    goal.pan = args.pan
+    goal.tilt = args.tilt
+        
     goal.tilt = wrap_angle(goal.tilt)
     goal.pan = wrap_angle(goal.pan)
 
@@ -45,9 +55,10 @@ def antenna_client():
 
 if __name__ == '__main__':
     try:
-        # Initializes a rospy node so that the UnstowActionClient can
-        # publish and subscribe over ROS.
+        # Initializes a rospy node
+
         rospy.init_node('antenna_client_py')
+        #result = antenna_client(sys.argv[1:])
         result = antenna_client()
         rospy.loginfo("Result: %s", result)
     except rospy.ROSInterruptException:

--- a/ow_lander/scripts/deliver_action_client.py
+++ b/ow_lander/scripts/deliver_action_client.py
@@ -4,13 +4,24 @@
 # Research and Simulation can be found in README.md in the root directory of
 # this repository.
 
+# Default trenching values
+# goal.delivery.x = 0.55
+# goal.delivery.y = -0.3
+# goal.delivery.z = 0.82
+
+# Remove Tailings values
+# goal.delivery.x = 1.5
+# goal.delivery.y = 0.8
+# goal.delivery.z = 0.65
+
 import rospy
 import actionlib
 import ow_lander.msg
 import argparse
 
+
 def deliver_client():
-    
+
     parser = argparse.ArgumentParser()
     parser.add_argument('x_start', type=float,
                         help='x coordinates of sample delivery location', nargs='?', default=0.55, const=0)
@@ -23,25 +34,16 @@ def deliver_client():
     rospy.loginfo("Requested y_start: %s", args.y_start)
     rospy.loginfo("Requested z_start: %s", args.z_start)
 
- 
-    client = actionlib.SimpleActionClient('Deliver', ow_lander.msg.DeliverAction)
+    client = actionlib.SimpleActionClient(
+        'Deliver', ow_lander.msg.DeliverAction)
 
     client.wait_for_server()
 
     goal = ow_lander.msg.DeliverGoal()
-    
+
     goal.delivery.x = args.x_start
     goal.delivery.y = args.y_start
     goal.delivery.z = args.z_start
-    # Default trenching values
-    # goal.delivery.x = 0.55
-    # goal.delivery.y = -0.3
-    # goal.delivery.z = 0.82 
-    
-    # Remove Tailings values
-    #goal.delivery.x = 1.5
-    #goal.delivery.y = 0.8
-    #goal.delivery.z = 0.65 
 
     # Sends the goal to the action server.
     client.send_goal(goal)
@@ -50,11 +52,12 @@ def deliver_client():
     client.wait_for_result()
 
     # Prints out the result of executing the action
-    return client.get_result()  # 
+    return client.get_result()  #
+
 
 if __name__ == '__main__':
     try:
-        # Initializes a rospy node so that the UnstowActionClient can
+        # Initializes a rospy node so that the deliver client can
         # publish and subscribe over ROS.
         rospy.init_node('deliver_client_py')
         result = deliver_client()

--- a/ow_lander/scripts/deliver_action_client.py
+++ b/ow_lander/scripts/deliver_action_client.py
@@ -7,18 +7,36 @@
 import rospy
 import actionlib
 import ow_lander.msg
+import argparse
 
 def deliver_client():
+    
+    parser = argparse.ArgumentParser()
+    parser.add_argument('x_start', type=float,
+                        help='x coordinates of sample delivery location', nargs='?', default=0.55, const=0)
+    parser.add_argument('y_start', type=float,
+                        help='y coordinates of sample delivery location', nargs='?', default=-0.3, const=0)
+    parser.add_argument('z_start', type=float,
+                        help='z coordinates of sample delivery location', nargs='?', default=0.82, const=0)
+    args = parser.parse_args()
+    rospy.loginfo("Requested x_start: %s", args.x_start)
+    rospy.loginfo("Requested y_start: %s", args.y_start)
+    rospy.loginfo("Requested z_start: %s", args.z_start)
+
  
     client = actionlib.SimpleActionClient('Deliver', ow_lander.msg.DeliverAction)
 
     client.wait_for_server()
 
     goal = ow_lander.msg.DeliverGoal()
+    
+    goal.delivery.x = args.x_start
+    goal.delivery.y = args.y_start
+    goal.delivery.z = args.z_start
     # Default trenching values
-    goal.delivery.x = 0.55
-    goal.delivery.y = -0.3
-    goal.delivery.z = 0.82 
+    # goal.delivery.x = 0.55
+    # goal.delivery.y = -0.3
+    # goal.delivery.z = 0.82 
     
     # Remove Tailings values
     #goal.delivery.x = 1.5

--- a/ow_lander/scripts/dig_circular_action_client.py
+++ b/ow_lander/scripts/dig_circular_action_client.py
@@ -4,6 +4,20 @@
 # Research and Simulation can be found in README.md in the root directory of
 # this repository.
 
+# Default trenching values
+# goal.x_start = 1.65
+# goal.y_start = 0
+# goal.depth = 0.01
+# goal.parallel = False
+# goal.ground_position = constants.DEFAULT_GROUND_HEIGHT
+
+# General trenching values
+# goal.x_start = 1.55
+# goal.y_start = 0.2
+# goal.depth = 0.045
+# goal.parallel = False
+# goal.ground_position = -0.155
+
 import rospy
 import actionlib
 import ow_lander.msg
@@ -43,19 +57,6 @@ def DigCircular_client():
     goal.depth = args.depth
     goal.parallel = args.parallel
     goal.ground_position = args.ground_position
-    # Default trenching values
-    # goal.x_start = 1.65
-    # goal.y_start = 0
-    # goal.depth = 0.01
-    # goal.parallel = False
-    # goal.ground_position = constants.DEFAULT_GROUND_HEIGHT
-
-    # General trenching values
-    #goal.x_start = 1.55
-    #goal.y_start = 0.2
-    #goal.depth = 0.045
-    #goal.parallel = False
-    #goal.ground_position = -0.155
 
     # Sends the goal to the action server.
     client.send_goal(goal)
@@ -69,7 +70,7 @@ def DigCircular_client():
 
 if __name__ == '__main__':
     try:
-        # Initializes a rospy node so that the UnstowActionClient can
+        # Initializes a rospy node so that the dig circular client can
         # publish and subscribe over ROS.
         rospy.init_node('digCircular_client_py')
         result = DigCircular_client()

--- a/ow_lander/scripts/dig_circular_action_client.py
+++ b/ow_lander/scripts/dig_circular_action_client.py
@@ -8,29 +8,55 @@ import rospy
 import actionlib
 import ow_lander.msg
 import constants
+import argparse
+
 
 def DigCircular_client():
- 
-    client = actionlib.SimpleActionClient('DigCircular', ow_lander.msg.DigCircularAction)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('x_start', type=float,
+                        help='X coordinate of trenching starting point', nargs='?', default=1.65, const=0)
+    parser.add_argument('y_start', type=float,
+                        help='Y coordinate of trenching starting point', nargs='?', default=0.0, const=0)
+    parser.add_argument('depth', type=float,
+                        help='Desired depth', nargs='?', default=0.01, const=0)
+    parser.add_argument('parallel', type=bool,
+                        help='If True, resulting trench is parallel to arm. If False, perpendicular to arm', nargs='?', default=0, const=0)
+    parser.add_argument('ground_position', type=float, help='Z coordinate of ground level in base_link frame',
+                        nargs='?', default=constants.DEFAULT_GROUND_HEIGHT, const=0)
+    args = parser.parse_args()
+    rospy.loginfo("Requested x_start: %s", args.x_start)
+    rospy.loginfo("Requested y_start: %s", args.y_start)
+    rospy.loginfo("Requested depth: %s", args.depth)
+    rospy.loginfo("Requested parallel: %s", args.parallel)
+    rospy.loginfo("Requested ground_position: %s", args.ground_position)
+
+    client = actionlib.SimpleActionClient(
+        'DigCircular', ow_lander.msg.DigCircularAction)
 
     client.wait_for_server()
 
     goal = ow_lander.msg.DigCircularGoal()
 
+    goal.x_start = args.x_start
+    goal.y_start = args.y_start
+    goal.depth = args.depth
+    goal.parallel = args.parallel
+    goal.ground_position = args.ground_position
     # Default trenching values
-    goal.x_start = 1.65
-    goal.y_start = 0
-    goal.depth = 0.01
-    goal.parallel = True
-    goal.ground_position = constants.DEFAULT_GROUND_HEIGHT
-    
-    # General trenching values     
+    # goal.x_start = 1.65
+    # goal.y_start = 0
+    # goal.depth = 0.01
+    # goal.parallel = False
+    # goal.ground_position = constants.DEFAULT_GROUND_HEIGHT
+
+    # General trenching values
     #goal.x_start = 1.55
     #goal.y_start = 0.2
     #goal.depth = 0.045
     #goal.parallel = False
     #goal.ground_position = -0.155
-    
+
     # Sends the goal to the action server.
     client.send_goal(goal)
 
@@ -38,7 +64,8 @@ def DigCircular_client():
     client.wait_for_result()
 
     # Prints out the result of executing the action
-    return client.get_result()  # 
+    return client.get_result()  #
+
 
 if __name__ == '__main__':
     try:

--- a/ow_lander/scripts/dig_linear_action_client.py
+++ b/ow_lander/scripts/dig_linear_action_client.py
@@ -4,6 +4,20 @@
 # Research and Simulation can be found in README.md in the root directory of
 # this repository.
 
+# Default trenching values
+# goal.x_start = 1.46
+# goal.y_start = 0
+# goal.depth = 0.01
+# goal.length = 0.1
+# goal.ground_position = constants.DEFAULT_GROUND_HEIGHT
+
+# General trenching values
+# goal.x_start = 1.45
+# goal.y_start = 0.2
+# goal.depth = 0.045
+# goal.length = 0.1 #
+# goal.ground_position = -0.155
+
 import rospy
 import actionlib
 import ow_lander.msg
@@ -47,20 +61,6 @@ def DigLinear_client():
     goal.length = args.length
     goal.ground_position = args.ground_position
 
-    # Default trenching values
-    # goal.x_start = 1.46
-    # goal.y_start = 0
-    # goal.depth = 0.01
-    # goal.length = 0.1
-    # goal.ground_position = constants.DEFAULT_GROUND_HEIGHT
-
-    # General trenching values
-    #goal.x_start = 1.45
-    #goal.y_start = 0.2
-    #goal.depth = 0.045
-    #goal.length = 0.1 #
-    #goal.ground_position = -0.155
-
     # Sends the goal to the action server.
     client.send_goal(goal)
 
@@ -73,7 +73,7 @@ def DigLinear_client():
 
 if __name__ == '__main__':
     try:
-        # Initializes a rospy node so that the UnstowActionClient can
+        # Initializes a rospy node so that the deliver client can
         # publish and subscribe over ROS.
         rospy.init_node('digLinear_client_py')
         result = DigLinear_client()

--- a/ow_lander/scripts/dig_linear_action_client.py
+++ b/ow_lander/scripts/dig_linear_action_client.py
@@ -8,27 +8,57 @@ import rospy
 import actionlib
 import ow_lander.msg
 import constants
+import argparse
+
 
 def DigLinear_client():
- 
-    client = actionlib.SimpleActionClient('DigLinear', ow_lander.msg.DigLinearAction)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('x_start', type=float,
+                        help='X coordinate of trenching starting point', nargs='?', default=1.46, const=0)
+    parser.add_argument('y_start', type=float,
+                        help='Y coordinate of trenching starting point', nargs='?', default=0.0, const=0)
+    parser.add_argument('depth', type=float,
+                        help='Desired depth', nargs='?', default=0.01, const=0)
+    parser.add_argument('length', type=float,
+                        help='Desired length', nargs='?', default=0.1, const=0)
+    parser.add_argument('parallel', type=bool,
+                        help='If True, resulting trench is parallel to arm. If False, perpendicular to arm', nargs='?', default=1, const=0)
+    parser.add_argument('ground_position', type=float, help='Z coordinate of ground level in base_link frame',
+                        nargs='?', default=constants.DEFAULT_GROUND_HEIGHT, const=0)
+    args = parser.parse_args()
+    rospy.loginfo("Requested x_start: %s", args.x_start)
+    rospy.loginfo("Requested y_start: %s", args.y_start)
+    rospy.loginfo("Requested depth: %s", args.depth)
+    rospy.loginfo("Requested length: %s", args.length)
+    rospy.loginfo("Requested parallel: %s", args.parallel)
+    rospy.loginfo("Requested ground_position: %s", args.ground_position)
+
+    client = actionlib.SimpleActionClient(
+        'DigLinear', ow_lander.msg.DigLinearAction)
 
     client.wait_for_server()
 
     goal = ow_lander.msg.DigLinearGoal()
 
+    goal.x_start = args.x_start
+    goal.y_start = args.y_start
+    goal.depth = args.depth
+    goal.length = args.length
+    goal.ground_position = args.ground_position
+
     # Default trenching values
-    goal.x_start = 1.46
-    goal.y_start = 0
-    goal.depth = 0.01
-    goal.length = 0.1
-    goal.ground_position = constants.DEFAULT_GROUND_HEIGHT
-    
-    # General trenching values    
+    # goal.x_start = 1.46
+    # goal.y_start = 0
+    # goal.depth = 0.01
+    # goal.length = 0.1
+    # goal.ground_position = constants.DEFAULT_GROUND_HEIGHT
+
+    # General trenching values
     #goal.x_start = 1.45
     #goal.y_start = 0.2
     #goal.depth = 0.045
-    #goal.length = 0.1 # 
+    #goal.length = 0.1 #
     #goal.ground_position = -0.155
 
     # Sends the goal to the action server.
@@ -38,7 +68,8 @@ def DigLinear_client():
     client.wait_for_result()
 
     # Prints out the result of executing the action
-    return client.get_result()  # 
+    return client.get_result()  #
+
 
 if __name__ == '__main__':
     try:

--- a/ow_lander/scripts/grind_action_client.py
+++ b/ow_lander/scripts/grind_action_client.py
@@ -8,23 +8,45 @@ import rospy
 import actionlib
 import ow_lander.msg
 import constants
+import argparse
 
 def Grind_client():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('x_start', type=float, help='X coordinate of grinding starting point', nargs='?', default=1.65, const=0)
+    parser.add_argument('y_start', type=float, help='Y coordinate of grinding starting point', nargs='?', default=0.0, const=0)
+    parser.add_argument('depth', type=float, help='Desired depth', nargs='?', default=0.05, const=0)
+    parser.add_argument('length', type=float, help='Desired length', nargs='?', default=0.6, const=0)
+    parser.add_argument('parallel', type=bool, help='If True, resulting trench is parallel to arm. If False, perpendicular to arm', nargs='?', default=1, const=0)
+    parser.add_argument('ground_position', type=float, help='Desired length', nargs='?', default=constants.DEFAULT_GROUND_HEIGHT, const= 0 )
+    args = parser.parse_args()
+    rospy.loginfo("Requetsed x_start: %s", args.x_start)
+    rospy.loginfo("Requetsed y_start: %s", args.y_start)
+    rospy.loginfo("Requetsed depth: %s", args.depth)
+    rospy.loginfo("Requetsed length: %s", args.length)
+    rospy.loginfo("Requetsed parallel: %s", args.parallel)
+    rospy.loginfo("Requetsed ground_position: %s", args.ground_position)
  
     client = actionlib.SimpleActionClient('Grind', ow_lander.msg.GrindAction)
 
     client.wait_for_server()
 
     goal = ow_lander.msg.GrindGoal()
+    
+    goal.x_start = args.x_start 
+    goal.y_start = args.y_start
+    goal.depth = args.depth
+    goal.length = args.length
+    goal.parallel = args.parallel
+    goal.ground_position = args.ground_position
 
     # Default trenching values
     
-    goal.x_start = 1.65
-    goal.y_start = 0.0
-    goal.depth = 0.05
-    goal.length = 0.6 # 0.6
-    goal.parallel = True
-    goal.ground_position = constants.DEFAULT_GROUND_HEIGHT
+    # goal.x_start = 1.65
+    # goal.y_start = 0.0
+    # goal.depth = 0.05
+    # goal.length = 0.6 # 0.6
+    # goal.parallel = False
+    # goal.ground_position = constants.DEFAULT_GROUND_HEIGHT
 
     # General trenching values for non- parallel circular/linear trenching     
     #goal.x_start = 1.55
@@ -54,7 +76,7 @@ def Grind_client():
 
 if __name__ == '__main__':
     try:
-        # Initializes a rospy node so that the UnstowActionClient can
+        # Initializes a rospy node so that the grind can
         # publish and subscribe over ROS.
         rospy.init_node('Grind_client_py')
         result = Grind_client()

--- a/ow_lander/scripts/grind_action_client.py
+++ b/ow_lander/scripts/grind_action_client.py
@@ -10,29 +10,36 @@ import ow_lander.msg
 import constants
 import argparse
 
+
 def Grind_client():
     parser = argparse.ArgumentParser()
-    parser.add_argument('x_start', type=float, help='X coordinate of grinding starting point', nargs='?', default=1.65, const=0)
-    parser.add_argument('y_start', type=float, help='Y coordinate of grinding starting point', nargs='?', default=0.0, const=0)
-    parser.add_argument('depth', type=float, help='Desired depth', nargs='?', default=0.05, const=0)
-    parser.add_argument('length', type=float, help='Desired length', nargs='?', default=0.6, const=0)
-    parser.add_argument('parallel', type=bool, help='If True, resulting trench is parallel to arm. If False, perpendicular to arm', nargs='?', default=1, const=0)
-    parser.add_argument('ground_position', type=float, help='Desired length', nargs='?', default=constants.DEFAULT_GROUND_HEIGHT, const= 0 )
+    parser.add_argument('x_start', type=float,
+                        help='X coordinate of grinding starting point', nargs='?', default=1.65, const=0)
+    parser.add_argument('y_start', type=float,
+                        help='Y coordinate of grinding starting point', nargs='?', default=0.0, const=0)
+    parser.add_argument('depth', type=float,
+                        help='Desired depth', nargs='?', default=0.05, const=0)
+    parser.add_argument('length', type=float,
+                        help='Desired length', nargs='?', default=0.6, const=0)
+    parser.add_argument('parallel', type=bool,
+                        help='If True, resulting trench is parallel to arm. If False, perpendicular to arm', nargs='?', default=1, const=0)
+    parser.add_argument('ground_position', type=float, help='Z coordinate of ground level in base_link frame',
+                        nargs='?', default=constants.DEFAULT_GROUND_HEIGHT, const=0)
     args = parser.parse_args()
-    rospy.loginfo("Requetsed x_start: %s", args.x_start)
-    rospy.loginfo("Requetsed y_start: %s", args.y_start)
-    rospy.loginfo("Requetsed depth: %s", args.depth)
-    rospy.loginfo("Requetsed length: %s", args.length)
-    rospy.loginfo("Requetsed parallel: %s", args.parallel)
-    rospy.loginfo("Requetsed ground_position: %s", args.ground_position)
- 
+    rospy.loginfo("Requested x_start: %s", args.x_start)
+    rospy.loginfo("Requested y_start: %s", args.y_start)
+    rospy.loginfo("Requested depth: %s", args.depth)
+    rospy.loginfo("Requested length: %s", args.length)
+    rospy.loginfo("Requested parallel: %s", args.parallel)
+    rospy.loginfo("Requested ground_position: %s", args.ground_position)
+
     client = actionlib.SimpleActionClient('Grind', ow_lander.msg.GrindAction)
 
     client.wait_for_server()
 
     goal = ow_lander.msg.GrindGoal()
-    
-    goal.x_start = args.x_start 
+
+    goal.x_start = args.x_start
     goal.y_start = args.y_start
     goal.depth = args.depth
     goal.length = args.length
@@ -40,7 +47,7 @@ def Grind_client():
     goal.ground_position = args.ground_position
 
     # Default trenching values
-    
+
     # goal.x_start = 1.65
     # goal.y_start = 0.0
     # goal.depth = 0.05
@@ -48,20 +55,20 @@ def Grind_client():
     # goal.parallel = False
     # goal.ground_position = constants.DEFAULT_GROUND_HEIGHT
 
-    # General trenching values for non- parallel circular/linear trenching     
+    # General trenching values for non- parallel circular/linear trenching
     #goal.x_start = 1.55
     #goal.y_start = 0.1
     #goal.depth = 0.045
-    #goal.length = 0.5 # 0.6 
+    # goal.length = 0.5 # 0.6
     #goal.parallel = False
     #goal.ground_position = -0.155
 
-    # General trenching values for linear trenching            
+    # General trenching values for linear trenching
     #goal.x_start = 1.65
     #goal.y_start = 0.2
     #goal.depth = 0.045
-    ##choose a generous value for goal length to avoid collision
-    #goal.length = 0.7  
+    # choose a generous value for goal length to avoid collision
+    #goal.length = 0.7
     #goal.parallel = True
     #goal.ground_position = -0.155
 
@@ -72,7 +79,8 @@ def Grind_client():
     client.wait_for_result()
 
     # Prints out the result of executing the action
-    return client.get_result()  # 
+    return client.get_result()  #
+
 
 if __name__ == '__main__':
     try:

--- a/ow_lander/scripts/grind_action_client.py
+++ b/ow_lander/scripts/grind_action_client.py
@@ -4,6 +4,31 @@
 # Research and Simulation can be found in README.md in the root directory of
 # this repository.
 
+# Default trenching values
+# goal.x_start = 1.65
+# goal.y_start = 0.0
+# goal.depth = 0.05
+# goal.length = 0.6 # 0.6
+# goal.parallel = False
+# goal.ground_position = constants.DEFAULT_GROUND_HEIGHT
+
+# General trenching values for non- parallel circular/linear trenching
+# goal.x_start = 1.55
+# goal.y_start = 0.1
+# goal.depth = 0.045
+# goal.length = 0.5 # 0.6
+# goal.parallel = False
+# goal.ground_position = -0.155
+
+# General trenching values for linear trenching
+# goal.x_start = 1.65
+# goal.y_start = 0.2
+# goal.depth = 0.045
+# choose a generous value for goal length to avoid collision
+# goal.length = 0.7
+# goal.parallel = True
+# goal.ground_position = -0.155
+
 import rospy
 import actionlib
 import ow_lander.msg
@@ -45,32 +70,6 @@ def Grind_client():
     goal.length = args.length
     goal.parallel = args.parallel
     goal.ground_position = args.ground_position
-
-    # Default trenching values
-
-    # goal.x_start = 1.65
-    # goal.y_start = 0.0
-    # goal.depth = 0.05
-    # goal.length = 0.6 # 0.6
-    # goal.parallel = False
-    # goal.ground_position = constants.DEFAULT_GROUND_HEIGHT
-
-    # General trenching values for non- parallel circular/linear trenching
-    #goal.x_start = 1.55
-    #goal.y_start = 0.1
-    #goal.depth = 0.045
-    # goal.length = 0.5 # 0.6
-    #goal.parallel = False
-    #goal.ground_position = -0.155
-
-    # General trenching values for linear trenching
-    #goal.x_start = 1.65
-    #goal.y_start = 0.2
-    #goal.depth = 0.045
-    # choose a generous value for goal length to avoid collision
-    #goal.length = 0.7
-    #goal.parallel = True
-    #goal.ground_position = -0.155
 
     # Sends the goal to the action server.
     client.send_goal(goal)

--- a/ow_lander/scripts/guarded_move_action_client.py
+++ b/ow_lander/scripts/guarded_move_action_client.py
@@ -8,23 +8,38 @@ import rospy
 import actionlib
 import ow_lander.msg
 import sys
+import argparse
 
 def guarded_move_client():
- 
+    parser = argparse.ArgumentParser()
+    parser.add_argument('x_start', type=float, help='x coordinates of guarded move starting point', nargs='?', default=2.0, const=0)
+    parser.add_argument('y_start', type=float, help='y coordinates of guarded move starting point', nargs='?', default=0.0, const=0)
+    parser.add_argument('z_start', type=float, help='z coordinates of guarded move starting point', nargs='?', default=0.3, const=0)
+    parser.add_argument('direction_x', type=float, help='x coordinates of the vector normal to the surface', nargs='?', default=0.0, const=0)
+    parser.add_argument('direction_y', type=float, help='y coordinates of the vector normal to the surface', nargs='?', default=0.0, const=0)
+    parser.add_argument('direction_z', type=float, help='z coordinates of the vector normal to the surface', nargs='?', default=1.0, const=0)
+    parser.add_argument('search_distance', type=float, help='Search Distance', nargs='?', default=0.5, const= 0 )
+    args = parser.parse_args()
+    rospy.loginfo("Requetsed x_start: %s", args.x_start)
+    rospy.loginfo("Requetsed y_start: %s", args.y_start)
+    rospy.loginfo("Requetsed z_start: %s", args.z_start)
+    rospy.loginfo("Requetsed normal.x: %s", args.direction_x)
+    rospy.loginfo("Requetsed normal.y: %s", args.direction_y)
+    rospy.loginfo("Requetsed normal.z: %s", args.direction_z)
+    rospy.loginfo("Requetsed search distance: %s", args.search_distance)
     client = actionlib.SimpleActionClient('GuardedMove', ow_lander.msg.GuardedMoveAction)
 
     client.wait_for_server()
 
     goal = ow_lander.msg.GuardedMoveGoal()
     
-    # Default trenching values
-    goal.start.x = 2.0
-    goal.start.y = 0.0
-    goal.start.z = 0.3
-    goal.normal.x = 0.0
-    goal.normal.y = 0.0
-    goal.normal.z = 1.0
-    goal.search_distance = 0.5
+    goal.start.x = args.x_start
+    goal.start.y = args.y_start
+    goal.start.z = args.z_start
+    goal.normal.x = args.direction_x
+    goal.normal.y = args.direction_y
+    goal.normal.z = args.direction_z
+    goal.search_distance = args.search_distance
 
     # Sends the goal to the action server.
     client.send_goal(goal)

--- a/ow_lander/scripts/guarded_move_action_client.py
+++ b/ow_lander/scripts/guarded_move_action_client.py
@@ -61,7 +61,7 @@ def guarded_move_client():
 
 if __name__ == '__main__':
     try:
-        # Initializes a rospy node so that the UnstowActionClient can
+        # Initializes a rospy node so that the guarded_move can
         # publish and subscribe over ROS.
         rospy.init_node('guarded_move_client_py')
         result = guarded_move_client()

--- a/ow_lander/scripts/guarded_move_action_client.py
+++ b/ow_lander/scripts/guarded_move_action_client.py
@@ -7,32 +7,40 @@
 import rospy
 import actionlib
 import ow_lander.msg
-import sys
 import argparse
+
 
 def guarded_move_client():
     parser = argparse.ArgumentParser()
-    parser.add_argument('x_start', type=float, help='x coordinates of guarded move starting point', nargs='?', default=2.0, const=0)
-    parser.add_argument('y_start', type=float, help='y coordinates of guarded move starting point', nargs='?', default=0.0, const=0)
-    parser.add_argument('z_start', type=float, help='z coordinates of guarded move starting point', nargs='?', default=0.3, const=0)
-    parser.add_argument('direction_x', type=float, help='x coordinates of the vector normal to the surface', nargs='?', default=0.0, const=0)
-    parser.add_argument('direction_y', type=float, help='y coordinates of the vector normal to the surface', nargs='?', default=0.0, const=0)
-    parser.add_argument('direction_z', type=float, help='z coordinates of the vector normal to the surface', nargs='?', default=1.0, const=0)
-    parser.add_argument('search_distance', type=float, help='Search Distance', nargs='?', default=0.5, const= 0 )
+    parser.add_argument('x_start', type=float,
+                        help='x coordinates of guarded move starting point', nargs='?', default=2.0, const=0)
+    parser.add_argument('y_start', type=float,
+                        help='y coordinates of guarded move starting point', nargs='?', default=0.0, const=0)
+    parser.add_argument('z_start', type=float,
+                        help='z coordinates of guarded move starting point', nargs='?', default=0.3, const=0)
+    parser.add_argument('direction_x', type=float,
+                        help='x coordinates of the vector normal to the surface', nargs='?', default=0.0, const=0)
+    parser.add_argument('direction_y', type=float,
+                        help='y coordinates of the vector normal to the surface', nargs='?', default=0.0, const=0)
+    parser.add_argument('direction_z', type=float,
+                        help='z coordinates of the vector normal to the surface', nargs='?', default=1.0, const=0)
+    parser.add_argument('search_distance', type=float,
+                        help='Search Distance', nargs='?', default=0.5, const=0)
     args = parser.parse_args()
-    rospy.loginfo("Requetsed x_start: %s", args.x_start)
-    rospy.loginfo("Requetsed y_start: %s", args.y_start)
-    rospy.loginfo("Requetsed z_start: %s", args.z_start)
-    rospy.loginfo("Requetsed normal.x: %s", args.direction_x)
-    rospy.loginfo("Requetsed normal.y: %s", args.direction_y)
-    rospy.loginfo("Requetsed normal.z: %s", args.direction_z)
-    rospy.loginfo("Requetsed search distance: %s", args.search_distance)
-    client = actionlib.SimpleActionClient('GuardedMove', ow_lander.msg.GuardedMoveAction)
+    rospy.loginfo("Requested x_start: %s", args.x_start)
+    rospy.loginfo("Requested y_start: %s", args.y_start)
+    rospy.loginfo("Requested z_start: %s", args.z_start)
+    rospy.loginfo("Requested normal.x: %s", args.direction_x)
+    rospy.loginfo("Requested normal.y: %s", args.direction_y)
+    rospy.loginfo("Requested normal.z: %s", args.direction_z)
+    rospy.loginfo("Requested search distance: %s", args.search_distance)
+    client = actionlib.SimpleActionClient(
+        'GuardedMove', ow_lander.msg.GuardedMoveAction)
 
     client.wait_for_server()
 
     goal = ow_lander.msg.GuardedMoveGoal()
-    
+
     goal.start.x = args.x_start
     goal.start.y = args.y_start
     goal.start.z = args.z_start
@@ -48,7 +56,8 @@ def guarded_move_client():
     client.wait_for_result()
 
     # Prints out the result of executing the action
-    return client.get_result()  # 
+    return client.get_result()  #
+
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
## Linked Issues:
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-829](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-829) |
| Github :octocat:  | # |

https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-811

## Summary of Changes
* The *_action_client.py scripts  can be called from the command line and will run the action using default arguments. This will allow to run action clients with other values from command line 

## Test
* roslaunch ow europa_terminator_workspace.launch 

In a separate terminal:

Test the help file for each of the action clients: 
* python antenna_pan_tilt_action_client.py -h 
* python guarded_move_action_client.py -h
* python grind_action_client.py -h
* python dig_linear_action_client.py -h  
* python dig_circular_action_client.py -h 
* python deliver_action_client.py -h
The help files should display the inputs to each of the action clients. 

Next test the actions with default values:

* python antenna_pan_tilt_action_client.py 
* python guarded_move_action_client.py
* python  grind_action_client.py
* python  dig_linear_action_client.py 
* python python dig_circular_action_client.py
* python deliver_action_client.py

Next test with some custom values. All the action files have suggested custom values in the client codes. 

* python antenna_pan_tilt_action_clinet.py  0.5 1.0
* python guarded_move_action_client.py 2.0 0.5 0.3 0.0 0.0 1.0 0.5
* python  grind_action_client.py 1.65 0.2 0.045 0.7 1 -0.155
* python  dig_linear_action_client.py 1.45 0.2 0.045 0.1 -0.155
* python python dig_circular_action_client.py 1.55 0.2 0.045 0 -0.155
* python deliver_action_client.py 1.5 0.8 0.65 1.5 0.8 0.65




