### PR TITLE
OCEANWATER-845: Upgrade sdf version to 1.7 and remove frame attribute from pose

### DIFF
--- a/ow_dynamic_terrain/models/europa_terrain/model.sdf
+++ b/ow_dynamic_terrain/models/europa_terrain/model.sdf
@@ -1,10 +1,7 @@
 <?xml version="1.0" ?>
-<sdf version="1.6">
-
+<sdf version="1.7">
   <model name="heightmap">
-
     <plugin name="ow_dynamic_terrain_model" filename="libow_dynamic_terrain_model.so"/>
-
     <pose>0 0 0  0 0 0</pose>
     <static>true</static>
     <link name="terrain-link">

--- a/ow_dynamic_terrain/models/ogre_terrain/model.sdf
+++ b/ow_dynamic_terrain/models/ogre_terrain/model.sdf
@@ -1,15 +1,9 @@
 <?xml version="1.0" ?>
-
-<sdf version="1.0">
-
+<sdf version="1.7">
   <model name="heightmap">
-
     <plugin name="ow_dynamic_terrain_model" filename="libow_dynamic_terrain_model.so"/>
-
     <static>true</static>
-
     <link name="terrain-link">
-
       <collision name="collision">
         <geometry>
           <heightmap>
@@ -19,7 +13,6 @@
           </heightmap>
         </geometry>
       </collision>
-
       <visual name="terrain-visual">
         <plugin name="ow_dynamic_terrain_visual" filename="libow_dynamic_terrain_visual.so"/>
         <geometry>
@@ -53,9 +46,6 @@
           </heightmap>
         </geometry>
       </visual>
-
     </link>
-
   </model>
-
 </sdf>

--- a/ow_dynamic_terrain/models/small_box/model.sdf
+++ b/ow_dynamic_terrain/models/small_box/model.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<sdf version="1.0">
+<sdf version="1.7">
   <model name='small_box'>
     <link name='link'>
       <inertial>
@@ -13,7 +13,7 @@
           <iyz>0</iyz>
           <izz>0.166667</izz>
         </inertia>
-        <pose frame=''>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 -0 0</pose>
       </inertial>
       <collision name='collision'>
         <geometry>


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [N/A] |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-845 / Address ow_dynamic_terrain sdf warnings](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-845) |
| Github :octocat:  | # |


## Summary of Changes
* Upgrade ow_dynamic_terrain models SDF version to 1.7
* Remove frame attribute from pose

## Test
* Launch the simulation and monitor the log 
```bash
roslaunch ow_dynamic_terrain europa.launch
```
* Verify that all SDF warnings and errors are gone