### PR TITLE
HOTFIX/OceanWATER-848: Choose a long ros duration (1 year), to delay the automatic disable of wrench force within ow_regolith module

### DIFF
--- a/ow_regolith/src/RegolithSpawner.cpp
+++ b/ow_regolith/src/RegolithSpawner.cpp
@@ -31,6 +31,7 @@ using namespace gazebo_msgs;
 using namespace sensor_msgs;
 using namespace cv_bridge;
 using namespace sdf_utility;
+using namespace std::chrono_literals;
 
 using tf::Vector3;
 
@@ -230,8 +231,9 @@ bool RegolithSpawner::spawnRegolithInScoop(bool with_pushback)
 
   wrench_msg.request.body_name         = body_name.str();
   
-  // negative duration means the force is applied until we clear it
-  wrench_msg.request.duration          = ros::Duration(-1);
+  // Choose a long ros duration (1 year), to delay the automatic disable of wrench force.
+  auto one_year_in_seconds = std::chrono::duration_cast<std::chrono::seconds>(1h*24*365).count();
+  wrench_msg.request.duration          = ros::Duration(one_year_in_seconds);
 
   wrench_msg.request.reference_point.x = 0.0;
   wrench_msg.request.reference_point.y = 0.0;


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | N/A |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-848 / Resolve the intermittent Gazebo crashes under ROS Noetic](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-848) |
| Github :octocat:  | N/A |


## Summary of Changes
* Replace the usage of negative value to disable the time de-activation of wrench force in the ow_regolith plugin with a long ROS duration (1 year). This should avoid the intermittent crashes that were observed in Gazebo.

>Note: After implementing this fix I could not get Gazebo to crash. But please note that this fix probably only addresses part of the problem. If issue is still observed please report it.

## Test
* Source **OceanWATERS** environment and launch the simulation:
```bash
roslaunch ow atacama_y1a.launch use_rviz:=false rqt_gui:=false
```
* In another terminal, source **OceanWATERS** environment and run `Demo.plx` and `ReferenceMission1.plx` plexil plans (Alternate between the two multiple times):
```bash
roslaunch ow_plexil ow_exec.launch plan:=Demo.plx
roslaunch ow_plexil ow_exec.launch plan:=ReferenceMission1.plx
```