### PR TITLE
OceanWATER-840 Added spawn regolith and remove regolith services

### DIFF
--- a/ow_regolith/CMakeLists.txt
+++ b/ow_regolith/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
   cv_bridge
   ow_dynamic_terrain
   ow_lander
+  message_generation
 )
 
 include(FindPkgConfig)
@@ -61,14 +62,16 @@ link_directories(
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
 # Generate messages in the 'msg' folder
-#add_message_files(
-#  FILES
-#)
+add_service_files(
+  FILES
+  SpawnRegolithInScoop.srv
+  RemoveAllRegolith.srv
+)
 
-#generate_messages(
-#    DEPENDENCIES
-#    std_msgs
-#)
+generate_messages(
+    DEPENDENCIES
+    std_msgs
+)
 
 ###################################
 ## catkin specific configuration ##
@@ -80,7 +83,10 @@ link_directories(
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-   CATKIN_DEPENDS message_runtime ow_dynamic_terrain ow_lander
+   CATKIN_DEPENDS
+   ow_dynamic_terrain
+   ow_lander 
+   message_runtime
 )
 
 catkin_add_env_hooks(

--- a/ow_regolith/README.md
+++ b/ow_regolith/README.md
@@ -55,9 +55,10 @@ incorporate smarter logic around when to clean-up regolith models.
 ## Caveats
 
 - The *fake force* applied to particles during any dig operation will be 
-transferred to the joints of the arm, but the magnitude of the force itself is 
-not necessarily realistic to what a digging scoop may experience. Keep this in 
-mind when using this plug-in for any study that records forces on the arm.
+transferred to the joints of the arm, but the magnitude and direction of the 
+force itself is not necessarily realistic to what a digging scoop may 
+experience. Keep this in mind when using this plug-in for any study that records
+forces on the arm.
 - ROS services arm activities are not supported by this node, and it will not 
 work properly if the user calls either the dig linear, dig circular, or delivery
 ROS service.

--- a/ow_regolith/README.md
+++ b/ow_regolith/README.md
@@ -54,7 +54,7 @@ incorporate smarter logic around when to clean-up regolith models.
 
 ## Caveats
 
-- The fake force applied to particles during any dig operation will be 
+- The *fake force* applied to particles during any dig operation will be 
 transferred to the joints of the arm, but the magnitude of the force itself is 
 not necessarily realistic to what a digging scoop may experience. Keep this in 
 mind when using this plug-in for any study that records forces on the arm.
@@ -81,17 +81,28 @@ The two parameters, `spawn_volume_threshold` and `regolith_model_uri`, are
 required by the node, and there will be an error printed if it is ran without
 these two being set. 
 
-`spawn_volume_threshold` is the cubic meters that must be removed from the
+#### Parameters
+
+- `spawn_volume_threshold` is the cubic meters that must be removed from the
 terrain before a regolith model is spawned. It may have to be fine-tuned if a 
 regolith model of larger size is used in place of the default to avoid 
 consecutively spawned models colliding with each other.
-
-`regolith_model_uri` tells the node which model out of the Gazebo model database
+- `regolith_model_uri` tells the node which model out of the Gazebo model database
 should be spawned each time the `spawn_volume_threshold` is reached.
 
-### ROS Service
+### ROS Services
 
-ROS services are not supported by this package at this time.
+A minimal interface to `regolith_node` is supported via ROS Services that 
+enables debugging and manual handling of specific test cases.
+
+#### Services
+
+- `ow_regolith/spawn_regolith_in_scoop` will spawn a single regolith model just 
+above the tip of the scoop. Unlike when spawning is triggered by terrain 
+modification, there will be no *fake force* applied to the model when this 
+service is called.
+- `ow_regolith/remove_all_regolith` will delete all regolith models from the 
+Gazebo world.
 
 ## Generating Custom Regolith Models
 

--- a/ow_regolith/include/RegolithSpawner.h
+++ b/ow_regolith/include/RegolithSpawner.h
@@ -9,10 +9,15 @@
 #include <tf/tf.h>
 
 #include "gazebo_msgs/LinkStates.h"
+
 #include "ow_dynamic_terrain/modified_terrain_diff.h"
+
 #include "ow_lander/DigLinearActionResult.h"
 #include "ow_lander/DigCircularActionResult.h"
 #include "ow_lander/DeliverActionResult.h"
+
+#include "ow_regolith/SpawnRegolithInScoop.h"
+#include "ow_regolith/RemoveAllRegolith.h"
 
 class RegolithSpawner
 {
@@ -33,10 +38,18 @@ public:
   bool spawnRegolithInScoop(bool with_pushback);
 
   // clears all artificial forces still being applied to regolith models
-  void clearAllPsuedoForces();
+  bool clearAllPsuedoForces();
 
   // deletes all regolith models
-  void removeAllRegolithModels();
+  bool removeAllRegolithModels();
+
+  // service callback for spawnRegolithInScoop
+  bool spawnRegolithInScoopSrv(ow_regolith::SpawnRegolithInScoopRequest &request,
+                               ow_regolith::SpawnRegolithInScoopResponse &response);
+
+  // servcie callback for removeAllRegolithModels
+  bool removeAllRegolithSrv(ow_regolith::RemoveAllRegolithRequest &request,
+                            ow_regolith::RemoveAllRegolithResponse &response);
 
   // saves the orientation of scoop to a member variable
   void onLinkStatesMsg(const gazebo_msgs::LinkStates::ConstPtr &msg);
@@ -56,10 +69,15 @@ public:
 private:
   // ROS interfaces
   std::unique_ptr<ros::NodeHandle> m_node_handle;
+
   ros::ServiceClient m_gz_spawn_model;
   ros::ServiceClient m_gz_delete_model;
   ros::ServiceClient m_gz_apply_wrench;
   ros::ServiceClient m_gz_clear_wrench;
+
+  ros::ServiceServer m_spawn_regolith_in_scoop;
+  ros::ServiceServer m_remove_all_regolith;
+
   ros::Subscriber m_link_states;
   ros::Subscriber m_mod_diff_visual;
   ros::Subscriber m_dig_linear_result;

--- a/ow_regolith/package.xml
+++ b/ow_regolith/package.xml
@@ -26,6 +26,7 @@
   <build_depend>gazebo_ros</build_depend>
   <build_depend>ow_dynamic_terrain</build_depend>
   <build_depend>ow_lander</build_depend>
+  <build_depend>message_generation</build_depend>
 
   <build_export_depend>roscpp</build_export_depend>
 

--- a/ow_regolith/src/RegolithSpawner.cpp
+++ b/ow_regolith/src/RegolithSpawner.cpp
@@ -27,6 +27,7 @@
 
 using namespace ow_dynamic_terrain;
 using namespace ow_lander;
+using namespace ow_regolith;
 using namespace gazebo_msgs;
 using namespace sensor_msgs;
 using namespace cv_bridge;
@@ -50,6 +51,10 @@ const static std::string SRV_SPAWN_MODEL     = "/gazebo/spawn_sdf_model";
 const static std::string SRV_DELETE_MODEL    = "/gazebo/delete_model";
 const static std::string SRV_APPLY_WRENCH    = "/gazebo/apply_body_wrench";
 const static std::string SRV_CLEAR_WRENCH    = "/gazebo/clear_body_wrenches";
+
+// service paths served by this class
+const static std::string SRV_SPAWN_REGOLITH_IN_SCOOP = "/ow_regolith/spawn_regolith_in_scoop";
+const static std::string SRV_REMOVE_ALL_REGOLITH     = "/ow_regolith/remove_all_regolith";
 
 // topic paths used in class
 const static std::string TOPIC_LINK_STATES           = "/gazebo/link_states";
@@ -153,6 +158,12 @@ bool RegolithSpawner::initialize()
     return false;
   }
 
+  // advertise services served by this class
+  m_spawn_regolith_in_scoop = m_node_handle->advertiseService(
+    SRV_SPAWN_REGOLITH_IN_SCOOP, &RegolithSpawner::spawnRegolithInScoopSrv, this);
+  m_remove_all_regolith = m_node_handle->advertiseService(
+    SRV_REMOVE_ALL_REGOLITH, &RegolithSpawner::removeAllRegolithSrv, this);
+
   // subscribe to all ROS topics
   m_link_states         = m_node_handle->subscribe(
     TOPIC_LINK_STATES, 1, &RegolithSpawner::onLinkStatesMsg, this);
@@ -184,10 +195,10 @@ bool RegolithSpawner::spawnRegolithInScoop(bool with_pushback)
 {
   ROS_INFO("Spawning regolith");
 
-  // spawn model
   static auto spawn_count = 0;
-  stringstream model_name;
+  stringstream model_name, body_name;
   model_name << "regolith_" << spawn_count++;
+  body_name << model_name.str() << "::" << m_model_link_name;
 
   SpawnModel spawn_msg;
   
@@ -208,6 +219,8 @@ bool RegolithSpawner::spawnRegolithInScoop(bool with_pushback)
   if (!callRosService(m_gz_spawn_model, spawn_msg))
     return false;
 
+  m_active_models.push_back({model_name.str(), body_name.str()});
+
   // if no pushback is desired, we're done
   if (!with_pushback)
     return true;
@@ -220,11 +233,7 @@ bool RegolithSpawner::spawnRegolithInScoop(bool with_pushback)
   Vector3 pushback_vec(-scooping_vec.normalize());
 
   // apply psuedo force to keep model in the scoop
-  stringstream body_name;
-  body_name << model_name.str() << "::" << m_model_link_name;
-
   ApplyBodyWrench wrench_msg;
-  
   tf::vector3TFToMsg(m_psuedo_force_mag * pushback_vec, 
                      wrench_msg.request.wrench.force);
 
@@ -241,35 +250,53 @@ bool RegolithSpawner::spawnRegolithInScoop(bool with_pushback)
   wrench_msg.request.wrench.torque.y   = 0.0;
   wrench_msg.request.wrench.torque.z   = 0.0;
 
-  m_active_models.push_back({model_name.str(), body_name.str()});
-
   return callRosService(m_gz_apply_wrench, wrench_msg);
 }
 
-
-void RegolithSpawner::clearAllPsuedoForces()
+bool RegolithSpawner::clearAllPsuedoForces()
 {
+  bool service_call_error_occurred = false;
   BodyRequest msg;
   for (auto &regolith : m_active_models) {
     msg.request.body_name = regolith.body_name;
-    if (!callRosService(m_gz_clear_wrench, msg))
+    if (!callRosService(m_gz_clear_wrench, msg)) {
       ROS_WARN("Failed to clear force on %s", regolith.body_name.c_str());
+      service_call_error_occurred = true;
+    }
   }
+  return !service_call_error_occurred;
 }
 
-void RegolithSpawner::removeAllRegolithModels()
+bool RegolithSpawner::removeAllRegolithModels()
 {
+  bool service_call_error_occurred = false;
+  DeleteModel msg;
   auto it = m_active_models.begin();
   while (it != m_active_models.end()) {
-    DeleteModel msg;
     msg.request.model_name = it->model_name;
     if (callRosService(m_gz_delete_model, msg)) {
       it = m_active_models.erase(it);
     } else {
       ROS_WARN("Failed to delete model %s", it->model_name.c_str());
       ++it;
+      service_call_error_occurred = true;
     }
   }
+  return !service_call_error_occurred;
+}
+
+bool RegolithSpawner::spawnRegolithInScoopSrv(SpawnRegolithInScoopRequest &request,
+                                              SpawnRegolithInScoopResponse &response)
+{
+  response.success = spawnRegolithInScoop(false);
+  return response.success;
+}
+
+bool RegolithSpawner::removeAllRegolithSrv(RemoveAllRegolithRequest &request,
+                                           RemoveAllRegolithResponse &response)
+{
+  response.success = removeAllRegolithModels();
+  return response.success;
 }
 
 void RegolithSpawner::onLinkStatesMsg(const LinkStates::ConstPtr &msg) 

--- a/ow_regolith/srv/RemoveAllRegolith.srv
+++ b/ow_regolith/srv/RemoveAllRegolith.srv
@@ -1,0 +1,3 @@
+# Removes all regolith bodies from the world or only the specified one
+---
+bool success

--- a/ow_regolith/srv/SpawnRegolithInScoop.srv
+++ b/ow_regolith/srv/SpawnRegolithInScoop.srv
@@ -1,0 +1,3 @@
+# Spawns a single regolith body just above the tip of the scoop
+---
+bool success


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-680](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-680) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-840](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-840) |
| Github :octocat:  | # |


## Summary of Changes
* Added `ow_regolith/spawn_regolith_in_scoop` and `/ow_regolith/remove_all_regolith`.

`ow_regolith/spawn_regolith_in_scoop` will spawn a single regolith model just above the tip of the scoop. Unlike when spawning is triggered by terrain modification, there will be no psuedo force applied to the model when this service is called.

`ow_regolith/remove_all_regolith` will delete all regolith models from the simulation.

Both services together provide a minimal interface into regolith_node that can be helpful for both debugging purposes and some specific test cases.

## Test
1. Launch whatever world you'd like.
2. Move the arm into whatever pose you'd like it to receive regolith in. Note that any pose that does not point the scoop up will cause regolith models to fall to the ground because there is no force to keep them in the scoop. This is intended behavior.
3. Use either RQT or the command line to call `/ow_regolith/spawn_regolith_in_scoop`. Call the service as many times as you'd like.
4. Open the **Models** dropdown box in gzclient and verify as many regolith models have spawned as times you called the service from step 3. 
5. Call `/ow_regolith/remove_all_regolith` and verify that all models are removed from the Gazebo world.
