### PR TITLE
HOTFIX/OceanWATERS-819: Suppress the LCP error message

### DIFF
--- a/ow_dynamic_terrain/src/DynamicTerrainModel.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainModel.cpp
@@ -37,7 +37,7 @@ public:
     auto world = model->GetWorld();
     if (world) {
       world->Physics()->SetParam("ode_quiet", true);
-      gzerr << m_plugin_name << ": ODE's LCP Error messages has been suppressed!" << endl;
+      gzerr << m_plugin_name << ": ODE's LCP Error messages have been suppressed!" << endl;
     }
 
     Initialize("collision");

--- a/ow_dynamic_terrain/src/DynamicTerrainModel.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainModel.cpp
@@ -34,6 +34,12 @@ public:
 
     m_model = model;
 
+    auto world = model->GetWorld();
+    if (world) {
+      world->Physics()->SetParam("ode_quiet", true);
+      gzerr << m_plugin_name << ": ODE's LCP Error messages has been suppressed!" << endl;
+    }
+
     Initialize("collision");
   }
 


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | N/A |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-819 / Suppress or prevent "ODE Message 3: LCP internal error"](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-819) |
| Github :octocat:  | N/A |


## Summary of Changes
* This hotfix simply suppresses the LCP error emitted by ODE from being printed to the console

## Test
* Source **OceanWATERS** environment and launch the simulation:
```bash
roslaunch ow atacama_y1a.launch use_rviz:=false rqt_gui:=false
```
* In another terminal, source **OceanWATERS** environment and run the `ReferenceMission1.plx` plan:
```bash
roslaunch ow_plexil ow_exec.launch plan:=ReferenceMission1.plx
```
* Verify that the message `ODE Message 3: LCP internal error, s <= 0 (s=-0.0000e+00)` no longer appears on any of the two cases:
  - When the arm collides with another object (such as the terrain or the lander body itself)
  - When regolith is spawned into the scoop
