### PR TITLE
HOTFIX/OceanWATERS-847: Resolve warning could not fill color channel of point cloud

### DIFF
--- a/ow_lander/urdf/stereo_camera_triggered.xacro
+++ b/ow_lander/urdf/stereo_camera_triggered.xacro
@@ -118,7 +118,7 @@
         <image>
           <width>${img_w}</width>
           <height>${img_h}</height>
-          <format>R16G16B16</format>
+          <format>R8G8B8</format>
         </image>
         <clip>
           <near>0.1</near>
@@ -132,7 +132,7 @@
         <image>
           <width>${img_w}</width>
           <height>${img_h}</height>
-          <format>R16G16B16</format>
+          <format>R8G8B8</format>
         </image>
         <clip>
           <near>0.1</near>


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | N/A |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-847 / Resolve the warning message "Could not fill color channel of the point cloud, unsupported encoding 'rgb16'"](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-847) |
| Github :octocat:  | N/A |


## Summary of Changes
* Update the output format of the stereo camera to match the formats supported by stereo_image_proc node
* The generate point cloud now correctly displays colors:

| Before Fix | After Fix |
| :------------: | :------------: |
| ![image](https://user-images.githubusercontent.com/606033/144503540-c516087e-fbd6-4c8c-9381-2780edf842cb.png) | ![image](https://user-images.githubusercontent.com/606033/144502369-392878f2-f3d9-48d1-91e3-807794ba3c35.png) |
| ![image](https://user-images.githubusercontent.com/606033/144503643-a0e52528-1fe9-4604-93a5-2570811bd577.png) | ![image](https://user-images.githubusercontent.com/606033/144502514-33dc4b15-faf0-46b1-bd8c-8823af465592.png) |

## Test
* Launch the simulation
```bash
roslaunch ow atacama_y1a.launch
```
* In another terminal (with OceanWATERS environment sourced) launch the **ow_exec** node with the `Demo.plx` plan:
```bash
roslaunch ow_plexil ow_exec.launch plan:=Demo.plx
```
* Verify that the following warning message is no longer emitted by the simulation whenever the _IdentifySampleLocation_ procedure is invoked: 
![image](https://user-images.githubusercontent.com/606033/144504219-4f428a21-2840-49fc-acc4-8d55f5ff5c96.png)
* Continue running the entire `Demo.plx` and verify no side effects are caused by this change
* Optional: Verify that the generated point cloud renders the colors correctly after the fix:
  - Launch the sim
  - In RVIZ: Add the PointCloud2 display as shown below:
![image](https://user-images.githubusercontent.com/606033/144505171-89ca8af5-a4b9-4058-a640-e4d10d93cdb8.png)
  - Launch the **ow_exec** node with the `Demo.plx` plan
  - Observe that colors are correctly associated with generated point cloud as illustrated in the **Summary of Changes** section of this PR