### PR TITLE
HOTFIX/OceanWATER-857: Mechanical Power is not an accumulate of all joints

### DIFF
--- a/ow_power_system/include/power_system_node.h
+++ b/ow_power_system/include/power_system_node.h
@@ -75,8 +75,8 @@ private:
   std::vector<std::map<PCOE::MessageId, PCOE::Datum<double>>> m_thermal_power_failure_sequence;
   size_t m_thermal_power_failure_sequence_index = 0;
 
-  double m_power_node_processing_rate = 0.5;   // [Hz] hard code processing rate for now 
-  bool m_processing_power_batch = false;        // flag that indicates that the prognoser is handling current batch
+  double m_power_node_processing_rate = 0.5;   // [Hz] hard code processing rate for now
+  bool m_processing_power_batch = false;       // flag that indicates that the prognoser is handling current batch
   bool m_trigger_processing_new_power_batch = false;
   double m_unprocessed_mechanical_power = 0.0;
   double m_mechanical_power_to_be_processed = 0.0;

--- a/ow_power_system/src/power_system_node.cpp
+++ b/ow_power_system/src/power_system_node.cpp
@@ -160,7 +160,7 @@ void PowerSystemNode::jointStatesCb(const sensor_msgs::JointStateConstPtr& msg)
 {
   auto power_watts = 0.0;  // This includes the arm + antenna
   for (auto i = 0; i < ow_lander::NUM_JOINTS; ++i)
-    power_watts += fabs(msg->velocity[i]) * fabs(msg->effort[i]);
+    power_watts += fabs(msg->velocity[i] * msg->effort[i]);
 
   m_power_values[++m_power_values_index % m_power_values.size()] = power_watts;   // [W]
   auto mean_mechanical_power =


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | N/A |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-857 / Mechanical Power is not an accumulate of all joints](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-857) |
| Github :octocat:  | N/A |


## Summary of Changes
* Accumlate the mechanical power of all joints
* Use absolute values for velocity when computing mech power
* Use `ros::param::getCached` to read fault flag value to speed up the check

## Test
* Verify that the change resolves issues found during [OceanWATERS Release 9 System Tests for Power System Node](https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/OW-TEST-009-8+Power+System)