### PR TITLE
Oceanwater 852 fixed regolith spawned during grind

### DIFF
--- a/ow_dynamic_terrain/scripts/modify_terrain_scoop_pub.py
+++ b/ow_dynamic_terrain/scripts/modify_terrain_scoop_pub.py
@@ -24,8 +24,6 @@ class ModifyTerrainScoop:
     self.scoop_yaw_position = 0.0
     self.visual_pub = rospy.Publisher(
         'ow_dynamic_terrain/modify_terrain_ellipse/visual', modify_terrain_ellipse, queue_size=1)
-    self.collision_pub = rospy.Publisher(
-        'ow_dynamic_terrain/modify_terrain_ellipse/collision', modify_terrain_ellipse, queue_size=1)
     self.link_states_sub = rospy.Subscriber(
         "/gazebo/link_states", LinkStates, self.handle_link_states)
     self.joint_states_sub = rospy.Subscriber(


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-680](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-680) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-852](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-852) |
| Github :octocat:  | # |


## Summary of Changes
* Scoop yaw now has to be at 90 deg before scoop may modify the terrain
  - Fewer unnecessary publishes to `ow_dynamic_terrain/modify_terrain_ellipse/visual` topic
  - Guarded move no longer deforms the terrain
  - Fewer sporadic visual terrain modifications, which sometimes would result in regolith being spawned during a grind operation.

## Caveat
This change does not entirely eliminate the sporadic visual terrain mods, but does reduce them. This is probably because grinding does modify the visual terrain, but in a way that rarely produces any real change to the terrain. 
@Samahu What do you think about removing the visual terrain modification call in the grinder script to ensure this no longer happens? I can't seem to notice the affects of this call in general anyways.

## Test
1. Launch whatever world you'd like.
2. Run a grind action. Ensure no regolith particles are spawned during it.
3. Run a scoop action. Ensure regolith particles are spawned during it.