### PR TITLE
Removed extraneous joint_state_publisher.

### DIFF
--- a/ow_lander/launch/spawn.launch
+++ b/ow_lander/launch/spawn.launch
@@ -64,12 +64,6 @@
     <arg name="load_robot_description" value="false"/>
   </include>
 
-  <!-- We do not have a robot connected, so publish fake joint states -->
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="use_gui" value="$(arg use_gui)"/>
-    <rosparam param="source_list">[/joint_states]</rosparam>
-  </node>
-
   <!-- Convert joint states from Gazebo to tf-tree for rviz -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" >
     <param name="publish_frequency" value="30"/>


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️ | [OCEANWATER-888](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-888) |


## Summary of Changes
* Removed a joint_state_publisher from spawn.launch. It was unnecessary because /_original/joint_states is already being published by /gazebo due to specifying a joint_state_controller in ros_controllers.launch. The joints published by joint_state_controller are in alphabetical order while joint_state_publisher publishes them in the order they appear in the urdf, which is why something like `/joint_states/position[0]` shows different values from each of these programs.

## Test
* Use `rostopic info` to ensure that `/joint_states` and `/_original/joint_states` each have only one publisher.
* Run your favorite plexil plan to see if the sim still works as expected.
