### PR TITLE
Oceanwater 843 Reinstate persistent service clients and code clean-up

### DIFF
--- a/ow_regolith/include/PersistentServiceClient.h
+++ b/ow_regolith/include/PersistentServiceClient.h
@@ -1,0 +1,67 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+#ifndef PERSISTENT_SERVICE_CLIENT_H
+#define PERSISTENT_SERVICE_CLIENT_H
+
+#include <ros/ros.h>
+
+namespace ow_regolith {
+
+template <class T>
+class PersistentServiceClient
+{
+public:
+  PersistentServiceClient(ros::NodeHandle* nh, bool persistent = true)
+    : m_node_handle(nh), m_persistent(persistent)
+  {
+    // do nothing
+  }
+
+  bool connect(std::string service_path, int timeout = 5.0)
+  {
+    m_client = m_node_handle->serviceClient<T>(service_path, m_persistent);
+    if (!m_client.waitForExistence(ros::Duration(timeout))) {
+      ROS_ERROR("Timed out waiting for service %s to advertise",
+                service_path.c_str());
+      return false;
+    }
+    return true;
+  }
+
+  bool call(T &message)
+  {
+    if (!m_client.isValid() && !attempt_reconnect()) {
+      ROS_ERROR(
+        "Connection to service %s has been lost and reconnection failed",
+        m_client.getService().c_str()
+      );
+      return false;
+    }
+
+    if (!m_client.call(message)) {
+      ROS_ERROR("Failed to call service %s", m_client.getService().c_str());
+      return false;
+    }
+    return true;
+  }
+
+private: 
+  bool attempt_reconnect()
+  {
+    constexpr auto RECONNECT_TIMEOUT = 0.5;
+    return connect(m_client.getService().c_str(), RECONNECT_TIMEOUT);
+  }
+
+  bool m_persistent;
+
+  ros::ServiceClient m_client;
+
+  std::unique_ptr<ros::NodeHandle> m_node_handle;
+
+};
+
+}
+
+#endif //PERSISTENT_SERVICE_CLIENT_H

--- a/ow_regolith/include/RegolithSpawner.h
+++ b/ow_regolith/include/RegolithSpawner.h
@@ -8,6 +8,8 @@
 #include <ros/ros.h>
 #include <tf/tf.h>
 
+#include <ServiceClientFacade.h>
+
 #include <gazebo_msgs/LinkStates.h>
 
 #include <gazebo_msgs/SpawnModel.h>
@@ -15,17 +17,15 @@
 #include <gazebo_msgs/ApplyBodyWrench.h>
 #include <gazebo_msgs/BodyRequest.h>
 
-#include "ow_dynamic_terrain/modified_terrain_diff.h"
+#include <ow_dynamic_terrain/modified_terrain_diff.h>
 
-#include "ServiceClientFacade.h"
+#include <ow_lander/DigLinearActionResult.h>
+#include <ow_lander/DigCircularActionResult.h>
+#include <ow_lander/DeliverActionResult.h>
+#include <ow_lander/DiscardActionResult.h>
 
-#include "ow_lander/DigLinearActionResult.h"
-#include "ow_lander/DigCircularActionResult.h"
-#include "ow_lander/DeliverActionResult.h"
-#include "ow_lander/DiscardActionResult.h"
-
-#include "ow_regolith/SpawnRegolithInScoop.h"
-#include "ow_regolith/RemoveAllRegolith.h"
+#include <ow_regolith/SpawnRegolithInScoop.h>
+#include <ow_regolith/RemoveAllRegolith.h>
 
 namespace ow_regolith {
 

--- a/ow_regolith/include/RegolithSpawner.h
+++ b/ow_regolith/include/RegolithSpawner.h
@@ -8,9 +8,16 @@
 #include <ros/ros.h>
 #include <tf/tf.h>
 
-#include "gazebo_msgs/LinkStates.h"
+#include <gazebo_msgs/LinkStates.h>
+
+#include <gazebo_msgs/SpawnModel.h>
+#include <gazebo_msgs/DeleteModel.h>
+#include <gazebo_msgs/ApplyBodyWrench.h>
+#include <gazebo_msgs/BodyRequest.h>
 
 #include "ow_dynamic_terrain/modified_terrain_diff.h"
+
+#include "PersistentServiceClient.h"
 
 #include "ow_lander/DigLinearActionResult.h"
 #include "ow_lander/DigCircularActionResult.h"
@@ -19,6 +26,8 @@
 
 #include "ow_regolith/SpawnRegolithInScoop.h"
 #include "ow_regolith/RemoveAllRegolith.h"
+
+namespace ow_regolith {
 
 class RegolithSpawner
 {
@@ -72,10 +81,10 @@ private:
   // ROS interfaces
   std::unique_ptr<ros::NodeHandle> m_node_handle;
 
-  ros::ServiceClient m_gz_spawn_model;
-  ros::ServiceClient m_gz_delete_model;
-  ros::ServiceClient m_gz_apply_wrench;
-  ros::ServiceClient m_gz_clear_wrench;
+  PersistentServiceClient<gazebo_msgs::SpawnModel>      m_gz_spawn_model;
+  PersistentServiceClient<gazebo_msgs::DeleteModel>     m_gz_delete_model;
+  PersistentServiceClient<gazebo_msgs::ApplyBodyWrench> m_gz_apply_wrench;
+  PersistentServiceClient<gazebo_msgs::BodyRequest>     m_gz_clear_wrench;
 
   ros::ServiceServer m_spawn_regolith_in_scoop;
   ros::ServiceServer m_remove_all_regolith;
@@ -109,5 +118,7 @@ private:
   };
   std::vector<Regolith> m_active_models;
 };
+
+} // namespace ow_regolith
 
 #endif // REGOLITH_SPAWNER_H

--- a/ow_regolith/include/RegolithSpawner.h
+++ b/ow_regolith/include/RegolithSpawner.h
@@ -2,6 +2,11 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
+// RegolithSpawner is a ROS node that detects when digging by the scoop
+// end-effector occurs and spawns a model in the scoop to represent collected
+// material. The node will also clean-up models it has spawned when a
+// deliver/discard action occurs.
+
 #ifndef REGOLITH_SPAWNER_H
 #define REGOLITH_SPAWNER_H
 
@@ -11,11 +16,6 @@
 #include <ServiceClientFacade.h>
 
 #include <gazebo_msgs/LinkStates.h>
-
-#include <gazebo_msgs/SpawnModel.h>
-#include <gazebo_msgs/DeleteModel.h>
-#include <gazebo_msgs/ApplyBodyWrench.h>
-#include <gazebo_msgs/BodyRequest.h>
 
 #include <ow_dynamic_terrain/modified_terrain_diff.h>
 
@@ -81,10 +81,8 @@ private:
   // ROS interfaces
   std::shared_ptr<ros::NodeHandle> m_node_handle;
 
-  ServiceClientFacade<gazebo_msgs::SpawnModel>      m_gz_spawn_model;
-  ServiceClientFacade<gazebo_msgs::DeleteModel>     m_gz_delete_model;
-  ServiceClientFacade<gazebo_msgs::ApplyBodyWrench> m_gz_apply_wrench;
-  ServiceClientFacade<gazebo_msgs::BodyRequest>     m_gz_clear_wrench;
+  ServiceClientFacade m_gz_spawn_model, m_gz_delete_model,
+                      m_gz_apply_wrench, m_gz_clear_wrench;
 
   ros::ServiceServer m_spawn_regolith_in_scoop;
   ros::ServiceServer m_remove_all_regolith;

--- a/ow_regolith/include/RegolithSpawner.h
+++ b/ow_regolith/include/RegolithSpawner.h
@@ -17,7 +17,7 @@
 
 #include "ow_dynamic_terrain/modified_terrain_diff.h"
 
-#include "PersistentServiceClient.h"
+#include "ServiceClientFacade.h"
 
 #include "ow_lander/DigLinearActionResult.h"
 #include "ow_lander/DigCircularActionResult.h"
@@ -37,7 +37,7 @@ public:
   RegolithSpawner(const RegolithSpawner&) = delete;
   RegolithSpawner& operator=(const RegolithSpawner&) = delete;
 
-  RegolithSpawner(ros::NodeHandle* nh);
+  RegolithSpawner(std::string node_name);
 
   // loads regolith SDF and computes its mass
   // NOTE: this must be called before any other functions
@@ -79,12 +79,12 @@ public:
 
 private:
   // ROS interfaces
-  std::unique_ptr<ros::NodeHandle> m_node_handle;
+  std::shared_ptr<ros::NodeHandle> m_node_handle;
 
-  PersistentServiceClient<gazebo_msgs::SpawnModel>      m_gz_spawn_model;
-  PersistentServiceClient<gazebo_msgs::DeleteModel>     m_gz_delete_model;
-  PersistentServiceClient<gazebo_msgs::ApplyBodyWrench> m_gz_apply_wrench;
-  PersistentServiceClient<gazebo_msgs::BodyRequest>     m_gz_clear_wrench;
+  ServiceClientFacade<gazebo_msgs::SpawnModel>      m_gz_spawn_model;
+  ServiceClientFacade<gazebo_msgs::DeleteModel>     m_gz_delete_model;
+  ServiceClientFacade<gazebo_msgs::ApplyBodyWrench> m_gz_apply_wrench;
+  ServiceClientFacade<gazebo_msgs::BodyRequest>     m_gz_clear_wrench;
 
   ros::ServiceServer m_spawn_regolith_in_scoop;
   ros::ServiceServer m_remove_all_regolith;

--- a/ow_regolith/include/RegolithSpawner.h
+++ b/ow_regolith/include/RegolithSpawner.h
@@ -37,7 +37,7 @@ public:
   RegolithSpawner(const RegolithSpawner&) = delete;
   RegolithSpawner& operator=(const RegolithSpawner&) = delete;
 
-  RegolithSpawner(std::string node_name);
+  RegolithSpawner(const std::string &node_name);
 
   // loads regolith SDF and computes its mass
   // NOTE: this must be called before any other functions

--- a/ow_regolith/include/ServiceClientFacade.h
+++ b/ow_regolith/include/ServiceClientFacade.h
@@ -53,7 +53,7 @@ public:
 private:
 
   template <typename T>
-  bool attempt_reconnect();
+  bool attemptReconnect();
 
   std::shared_ptr<ros::NodeHandle> m_node_handle;
 
@@ -89,7 +89,7 @@ bool ServiceClientFacade::call(T &message)
     return false;
   }
 
-  if (!m_client.isValid() && !attempt_reconnect<T>()) {
+  if (!m_client.isValid() && !attemptReconnect<T>()) {
     ROS_ERROR(
       "Connection to service %s has been lost and reconnection failed",
       m_client.getService().c_str()
@@ -105,7 +105,7 @@ bool ServiceClientFacade::call(T &message)
 };
 
 template <typename T>
-bool ServiceClientFacade::attempt_reconnect()
+bool ServiceClientFacade::attemptReconnect()
 {
   m_client = m_node_handle->serviceClient<T>(m_client.getService().c_str(),
                                              m_persistent);

--- a/ow_regolith/include/ServiceClientFacade.h
+++ b/ow_regolith/include/ServiceClientFacade.h
@@ -15,12 +15,16 @@ template <class T>
 class ServiceClientFacade
 {
 public:
-  ServiceClientFacade() : m_node_handle(nullptr)
+  ServiceClientFacade() : m_node_handle(nullptr), m_persistent(false)
   {
     // do nothing
   }
+  ServiceClientFacade(const ServiceClientFacade&) = delete;
+  ~ServiceClientFacade() = default;
+  ServiceClientFacade& operator=(const ServiceClientFacade&) = delete;
 
-  bool connect(std::shared_ptr<ros::NodeHandle> &nh, std::string service_path,
+  bool connect(std::shared_ptr<ros::NodeHandle> &nh,
+               const std::string &service_path,
                ros::Duration timeout, bool persistent)
   {
     m_node_handle = nh;

--- a/ow_regolith/include/ServiceClientFacade.h
+++ b/ow_regolith/include/ServiceClientFacade.h
@@ -38,7 +38,7 @@ public:
   {
     if (!m_node_handle) {
       ROS_ERROR(
-        "ServiceClientFacade::call was called before its connect method."
+        "ServiceClientFacade called before being connected."
       );
       return false;
     }
@@ -58,7 +58,7 @@ public:
     return true;
   }
 
-private: 
+private:
 
   bool attempt_reconnect()
   {

--- a/ow_regolith/src/RegolithSpawner.cpp
+++ b/ow_regolith/src/RegolithSpawner.cpp
@@ -6,18 +6,18 @@
 //  1. Support sloped scooping.
 //  2. Work around reliance on action callbacks from ow_lander.
 
-#include "RegolithSpawner.h"
-
-#include "sdf_utility.h"
-
 #define _USE_MATH_DEFINES
 #include <cmath>
 
-#include <sensor_msgs/image_encodings.h>
+#include <gazebo_msgs/GetPhysicsProperties.h>
+
 #include <cv_bridge/cv_bridge.h>
 
-#include <gazebo_msgs/GetPhysicsProperties.h>
-#include <gazebo_msgs/LinkStates.h>
+#include <sdf_utility.h>
+
+#include <RegolithSpawner.h>
+
+using namespace ow_regolith;
 
 using namespace ow_dynamic_terrain;
 using namespace ow_lander;
@@ -26,8 +26,17 @@ using namespace gazebo_msgs;
 using namespace sensor_msgs;
 using namespace cv_bridge;
 using namespace sdf_utility;
-using namespace std::chrono_literals;
-using namespace ow_regolith;
+using namespace std::literals::chrono_literals;
+
+using std::string;
+using std::stringstream;
+using std::cos;
+using std::find;
+using std::distance;
+using std::begin;
+using std::end;
+using std::chrono::duration_cast;
+using std::chrono::seconds;
 
 using tf::Vector3;
 using tf::tfDot;
@@ -35,15 +44,6 @@ using tf::quatRotate;
 using tf::vector3MsgToTF;
 using tf::vector3TFToMsg;
 using tf::quaternionMsgToTF;
-
-using std::string;
-using std::stringstream;
-using std::cos;
-using std::unique_ptr;
-using std::find;
-using std::distance;
-using std::begin;
-using std::end;
 
 // service paths used in class
 const static string SRV_GET_PHYS_PROPS  = "/gazebo/get_physics_properties";
@@ -212,7 +212,7 @@ bool RegolithSpawner::spawnRegolithInScoop(bool with_pushback)
   wrench_msg.request.body_name         = body_name.str();
   
   // Choose a long ros duration (1 year), to delay the disabling of wrench force
-  auto one_year_in_seconds = std::chrono::duration_cast<std::chrono::seconds>(1h*24*365).count();
+  auto one_year_in_seconds = duration_cast<seconds>(1h*24*365).count();
   wrench_msg.request.duration          = ros::Duration(one_year_in_seconds);
 
   wrench_msg.request.reference_point.x = 0.0;

--- a/ow_regolith/src/RegolithSpawner.cpp
+++ b/ow_regolith/src/RegolithSpawner.cpp
@@ -10,6 +10,10 @@
 #include <cmath>
 
 #include <gazebo_msgs/GetPhysicsProperties.h>
+#include <gazebo_msgs/SpawnModel.h>
+#include <gazebo_msgs/DeleteModel.h>
+#include <gazebo_msgs/ApplyBodyWrench.h>
+#include <gazebo_msgs/BodyRequest.h>
 
 #include <cv_bridge/cv_bridge.h>
 
@@ -108,14 +112,14 @@ bool RegolithSpawner::initialize()
   }
 
   // connect to all ROS services
-  if (!m_gz_spawn_model.connect(m_node_handle, SRV_SPAWN_MODEL,
-                                SERVICE_CONNECT_TIMEOUT, true)    ||
-      !m_gz_delete_model.connect(m_node_handle, SRV_DELETE_MODEL,
-                                 SERVICE_CONNECT_TIMEOUT, true)   ||
-      !m_gz_apply_wrench.connect(m_node_handle, SRV_APPLY_WRENCH,
-                                 SERVICE_CONNECT_TIMEOUT, true)   ||
-      !m_gz_clear_wrench.connect(m_node_handle, SRV_CLEAR_WRENCH,
-                                 SERVICE_CONNECT_TIMEOUT, true))
+  if (!m_gz_spawn_model.connect<SpawnModel>(
+        m_node_handle, SRV_SPAWN_MODEL, SERVICE_CONNECT_TIMEOUT, true)  ||
+      !m_gz_delete_model.connect<DeleteModel>(
+        m_node_handle, SRV_DELETE_MODEL, SERVICE_CONNECT_TIMEOUT, true) ||
+      !m_gz_apply_wrench.connect<ApplyBodyWrench>(
+        m_node_handle, SRV_APPLY_WRENCH, SERVICE_CONNECT_TIMEOUT, true) ||
+      !m_gz_clear_wrench.connect<BodyRequest>(
+        m_node_handle, SRV_CLEAR_WRENCH, SERVICE_CONNECT_TIMEOUT, true) )
   {
     ROS_ERROR("Failed to connect to all required ROS services");
     return false;
@@ -147,10 +151,10 @@ bool RegolithSpawner::initialize()
   constexpr auto MAX_SCOOP_INCLINATION_RAD = MAX_SCOOP_INCLINATION_DEG * M_PI / 180.0f; // radians
   constexpr auto PSUEDO_FORCE_WEIGHT_FACTOR = 1.0f / cos(MAX_SCOOP_INCLINATION_RAD);
   // query gazebo for the gravity vector
-  ServiceClientFacade<GetPhysicsProperties> gz_get_phys_props;
+  ServiceClientFacade gz_get_phys_props;
   GetPhysicsProperties phys_prop_msg;
-  if (!gz_get_phys_props.connect(m_node_handle, SRV_GET_PHYS_PROPS,
-                                 SERVICE_CONNECT_TIMEOUT, false)    ||
+  if (!gz_get_phys_props.connect<GetPhysicsProperties>(
+        m_node_handle, SRV_GET_PHYS_PROPS, SERVICE_CONNECT_TIMEOUT, false) ||
       !gz_get_phys_props.call(phys_prop_msg)) {
     ROS_ERROR("Failed to connect Gazebo for gravity vector");
     return false;

--- a/ow_regolith/src/RegolithSpawner.cpp
+++ b/ow_regolith/src/RegolithSpawner.cpp
@@ -74,7 +74,7 @@ const static Vector3 WORLD_DOWNWARD = Vector3(0.0, 0.0, -1.0);
 
 const static ros::Duration SERVICE_CONNECT_TIMEOUT = ros::Duration(5.0);
 
-RegolithSpawner::RegolithSpawner(string node_name)
+RegolithSpawner::RegolithSpawner(const string &node_name)
   : m_node_handle(new ros::NodeHandle(node_name)),
     m_volume_displaced(0.0)
 {

--- a/ow_regolith/src/regolith_node.cpp
+++ b/ow_regolith/src/regolith_node.cpp
@@ -2,23 +2,22 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-// TODO:
-//   1. Suppress or prevent "ODE Message 3: LCP internal error, s <= 0 (s=0.0000e+00)"
-//   2. Have a service for regolith_node that allows spawning of regolith
+#include <string>
 
-#include <ros/ros.h> 
+#include <ros/ros.h>
 
 #include "RegolithSpawner.h"
 
 using namespace ow_regolith;
 
+const static std::string NODE_NAME = "regolith_node";
+
 int main(int argc, char* argv[]) 
 {
   // initialize ROS
-  ros::init(argc, argv, "regolith_node");
-  ros::NodeHandle nh("regolith_node");
+  ros::init(argc, argv, NODE_NAME);
 
-  RegolithSpawner rs(&nh);
+  RegolithSpawner rs(NODE_NAME);
   
   if (!rs.initialize()) {
     ROS_ERROR("Failed to initialize regolith node");

--- a/ow_regolith/src/regolith_node.cpp
+++ b/ow_regolith/src/regolith_node.cpp
@@ -10,6 +10,8 @@
 
 #include "RegolithSpawner.h"
 
+using namespace ow_regolith;
+
 int main(int argc, char* argv[]) 
 {
   // initialize ROS

--- a/ow_regolith/src/regolith_node.cpp
+++ b/ow_regolith/src/regolith_node.cpp
@@ -6,7 +6,7 @@
 
 #include <ros/ros.h>
 
-#include "RegolithSpawner.h"
+#include <RegolithSpawner.h>
 
 using namespace ow_regolith;
 

--- a/ow_regolith/src/sdf_utility.cpp
+++ b/ow_regolith/src/sdf_utility.cpp
@@ -2,13 +2,13 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-#include "sdf_utility.h"
-
 #include <fstream>
 #include <sstream>
 
 #include <ros/ros.h>
 #include <gazebo/common/common.hh>
+
+#include <sdf_utility.h>
 
 using namespace sdf;
 


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-680](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-680) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-843](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-843) |
| Github :octocat:  | # |


## Summary of Changes
* Persistent service clients are implemented as a facade pattern that encapsulates auto-reconnect logic.
  * Results in improved performance when calling commonly called services.
* Addressed a miss-use of `std::unique_ptr`. Now using `std::shared_ptr` to support the new persistent service clients.
* Numerous code clean-ups, including:
  * ALL_CAPS constant names
  * Node parameters now grabbed in `initialize()` function allowing handling of parameter errors.

## Test
Similar to past tests of this node. Everything should work the same.
1. Launch `atacama_y1a` world.
2. Call `/ow_lander/scripts/grind_action_client.py`
3. Call `/ow_lander/scripts/dig_linear_action_client.py`
    Look for particles falling into and staying in the scoop
4. Call `/ow_lander/scripts/deliver_action_client.py` or `/ow_lander/scripts/discard_action_client.py`
    Look for particles vanishing upon completion of either action