### PR TITLE
HOTFIX/OCEANWATER-897: Replace deprecated sat427 with sat441

### DIFF
--- a/ow_ephemeris/CMakeLists.txt
+++ b/ow_ephemeris/CMakeLists.txt
@@ -60,8 +60,8 @@ download_file(
   9dcee11a333945310db8b76eb695fc9c
 )
 download_file(
-  https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/satellites/sat427.bsp
-  f09fb34fc9ec04af4971e4ea097628e5
+  https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/satellites/sat441.bsp
+  0d081d7e58504450cf2aa0b151a36b41
 )
 
 ################################################


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | N/A |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-897 / Replace deprecated sat427 with sat441](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-897) |
| Github :octocat:  | # |


## Summary of Changes
* Replace deprecated sat427 with sat441

## Test
* Launch the simulation before applying the hotfix take a screenshot of where Jupiter planet appears relative to the lander
* Checkout the hotfix branch
* Delete the `sat427.bsp` file from `src/ow_simulator/ow_ephemeris/data/`
* Verify that the workspace compiles successfully
* Launch the simulation and verify that Jupiter  appears in the same position relatives to the lander