### PR TITLE
Oceanwater 901 bypass rviz playback arm action

### DIFF
--- a/ow_lander/config/ompl_planning.yaml
+++ b/ow_lander/config/ompl_planning.yaml
@@ -122,7 +122,7 @@ planner_configs:
     dense_delta_fraction: 0.001  # delta fraction for interface detection. default: 0.001
     max_failures: 5000  # maximum consecutive failure limit. default: 5000
 arm:
-  default_planner_config: RRTstar
+  default_planner_config: RRTConnect
   planner_configs:
     - SBL
     - EST
@@ -206,7 +206,7 @@ limbs:
   projection_evaluator: joints(j_shou_yaw,j_shou_pitch)
   longest_valid_segment_fraction: 0.005
 grinder:
-  default_planner_config: RRTstar
+  default_planner_config: RRTConnect
   planner_configs:
     - SBL
     - EST

--- a/ow_lander/launch/spawn.launch
+++ b/ow_lander/launch/spawn.launch
@@ -78,7 +78,7 @@
 
   <include file="$(find ow_lander)/launch/move_group.launch">
     <arg name="load_robot_description" value="false"/>
-    <arg name="allow_trajectory_execution" value="true"/>
+    <arg name="allow_trajectory_execution" value="false"/>
     <arg name="fake_execution" value="false"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
@@ -96,6 +96,6 @@
   
   <!-- == launch the action servers ============== -->
   <arg name="node_start_delay" default="10.0" />  
-  <node pkg="ow_lander" name="ArmActionServers" type="arm_action_servers.py" launch-prefix="bash -c 'sleep $(arg node_start_delay); $0 $@' " />
+  <node pkg="ow_lander" name="ArmActionServers" type="arm_action_servers.py" launch-prefix="bash -c 'sleep $(arg node_start_delay); $0 $@' " output="screen" />
   <node pkg="ow_lander" name="AntennaPanTiltAction" type="antenna_pan_tilt_action_server.py" launch-prefix="bash -c 'sleep $(arg node_start_delay); $0 $@' " />
 </launch>


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-901](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-XXX) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-901](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-901) |
| Github :octocat:  | # |


## Summary of Changes
* Changing Planner from RRT* to RRT-Connect. 
* With these changes rviz playback is not an issue. 

## Test
* roslaunch ow atacama_y1a.launch 
test all the action clients
./unstow_action_client.py 
./grind_action_client.py 
./dig_circular_action_client.py 
 ./dig_linear_action_client.py 
./deliver_action_client.py




