### PR TITLE
 OCEANWATER-923 actions report failed when stopped by stop action client

### DIFF
--- a/ow_lander/scripts/arm_action_servers.py
+++ b/ow_lander/scripts/arm_action_servers.py
@@ -6,6 +6,7 @@
 
 import rospy
 import actionlib
+from actionlib_msgs.msg import GoalStatus
 from ow_lander.msg import *
 from LanderInterface import MoveItInterface
 from LanderInterface import LinkStateSubscriber
@@ -85,7 +86,7 @@ class UnstowActionServer(object):
             self._update_feedback()
 
         success = trajectory_async_executer.success(
-        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != 2
+        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != GoalStatus.PREEMPTED
         
 
         if success:
@@ -165,7 +166,7 @@ class StowActionServer(object):
             self._update_feedback()
 
         success = trajectory_async_executer.success(
-        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != 2
+        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != GoalStatus.PREEMPTED
 
         if success:
             self._result.final.x = self._fdbk.current.x
@@ -318,7 +319,7 @@ class GrindActionServer(object):
             self._update_feedback()
 
         success = trajectory_async_executer.success(
-        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != 2
+        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != GoalStatus.PREEMPTED
 
         if success:
             self._result.final.x = self._fdbk.current.x
@@ -445,7 +446,7 @@ class GuardedMoveActionServer(object):
                 start_time)/self._timeout
 
         success = trajectory_async_executer.success(
-        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != 2
+        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != GoalStatus.PREEMPTED
 
         if success:
             self._result.final.x = self.ground_detector.ground_position.x
@@ -543,10 +544,7 @@ class DigCircularActionServer(object):
             self._update_feedback()
 
         success = trajectory_async_executer.success(
-        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != 2
-        
-        if trajectory_async_executer.get_state() == 2:
-            success = False
+        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != GoalStatus.PREEMPTED
 
         if success:
             self._result.final.x = self._fdbk.current.x
@@ -627,7 +625,7 @@ class DigLinearActionServer(object):
             self._update_feedback()
 
         success = trajectory_async_executer.success(
-        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != 2
+        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != GoalStatus.PREEMPTED
 
         if success:
             self._result.final.x = self._fdbk.current.x
@@ -704,7 +702,7 @@ class DiscardActionServer(object):
             self._update_feedback()
 
         success = trajectory_async_executer.success(
-        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != 2
+        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != GoalStatus.PREEMPTED
 
         if success:
             self._result.final.x = self._fdbk.current.x
@@ -782,7 +780,7 @@ class DeliverActionServer(object):
             self._update_feedback()
 
         success = trajectory_async_executer.success(
-        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != 2
+        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != GoalStatus.PREEMPTED
 
         if success:
             self._result.final.x = self._fdbk.current.x

--- a/ow_lander/scripts/arm_action_servers.py
+++ b/ow_lander/scripts/arm_action_servers.py
@@ -85,7 +85,8 @@ class UnstowActionServer(object):
             self._update_feedback()
 
         success = trajectory_async_executer.success(
-        ) and trajectory_async_executer.wait()
+        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != 2
+        
 
         if success:
             self._result.final.x = self._fdbk.current.x
@@ -164,7 +165,7 @@ class StowActionServer(object):
             self._update_feedback()
 
         success = trajectory_async_executer.success(
-        ) and trajectory_async_executer.wait()
+        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != 2
 
         if success:
             self._result.final.x = self._fdbk.current.x
@@ -317,7 +318,7 @@ class GrindActionServer(object):
             self._update_feedback()
 
         success = trajectory_async_executer.success(
-        ) and trajectory_async_executer.wait()
+        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != 2
 
         if success:
             self._result.final.x = self._fdbk.current.x
@@ -444,7 +445,7 @@ class GuardedMoveActionServer(object):
                 start_time)/self._timeout
 
         success = trajectory_async_executer.success(
-        ) and trajectory_async_executer.wait()
+        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != 2
 
         if success:
             self._result.final.x = self.ground_detector.ground_position.x
@@ -542,7 +543,10 @@ class DigCircularActionServer(object):
             self._update_feedback()
 
         success = trajectory_async_executer.success(
-        ) and trajectory_async_executer.wait()
+        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != 2
+        
+        if trajectory_async_executer.get_state() == 2:
+            success = False
 
         if success:
             self._result.final.x = self._fdbk.current.x
@@ -623,7 +627,7 @@ class DigLinearActionServer(object):
             self._update_feedback()
 
         success = trajectory_async_executer.success(
-        ) and trajectory_async_executer.wait()
+        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != 2
 
         if success:
             self._result.final.x = self._fdbk.current.x
@@ -700,7 +704,7 @@ class DiscardActionServer(object):
             self._update_feedback()
 
         success = trajectory_async_executer.success(
-        ) and trajectory_async_executer.wait()
+        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != 2
 
         if success:
             self._result.final.x = self._fdbk.current.x
@@ -778,7 +782,7 @@ class DeliverActionServer(object):
             self._update_feedback()
 
         success = trajectory_async_executer.success(
-        ) and trajectory_async_executer.wait()
+        ) and trajectory_async_executer.wait() and trajectory_async_executer.get_state() != 2
 
         if success:
             self._result.final.x = self._fdbk.current.x

--- a/ow_lander/scripts/deliver_action_client.py
+++ b/ow_lander/scripts/deliver_action_client.py
@@ -16,6 +16,7 @@
 
 import rospy
 import actionlib
+from actionlib_msgs.msg import GoalStatus
 import ow_lander.msg
 import argparse
 from guarded_move_action_client import print_arguments
@@ -52,7 +53,10 @@ def deliver_client():
     client.wait_for_result()
 
     # Prints out the result of executing the action
-    return client.get_result()
+    if client.get_state() == GoalStatus.ABORTED:
+        return ('failed')
+    else: 
+        return client.get_result()
 
 
 if __name__ == '__main__':

--- a/ow_lander/scripts/deliver_action_client.py
+++ b/ow_lander/scripts/deliver_action_client.py
@@ -54,7 +54,7 @@ def deliver_client():
 
     # Prints out the result of executing the action
     if client.get_state() == GoalStatus.ABORTED:
-        return ('failed')
+        return ('aborted')
     else: 
         return client.get_result()
 

--- a/ow_lander/scripts/dig_circular_action_client.py
+++ b/ow_lander/scripts/dig_circular_action_client.py
@@ -65,7 +65,7 @@ def DigCircular_client():
 
     # Prints out the result of executing the action
     if client.get_state() == GoalStatus.ABORTED:
-        return ('failed')
+        return ('aborted')
     else: 
         return client.get_result()
 

--- a/ow_lander/scripts/dig_circular_action_client.py
+++ b/ow_lander/scripts/dig_circular_action_client.py
@@ -20,6 +20,7 @@
 
 import rospy
 import actionlib
+from actionlib_msgs.msg import GoalStatus
 import ow_lander.msg
 import constants
 import argparse
@@ -63,7 +64,10 @@ def DigCircular_client():
     client.wait_for_result()
 
     # Prints out the result of executing the action
-    return client.get_result()
+    if client.get_state() == GoalStatus.ABORTED:
+        return ('failed')
+    else: 
+        return client.get_result()
 
 
 if __name__ == '__main__':

--- a/ow_lander/scripts/dig_linear_action_client.py
+++ b/ow_lander/scripts/dig_linear_action_client.py
@@ -20,6 +20,7 @@
 
 import rospy
 import actionlib
+from actionlib_msgs.msg import GoalStatus
 import ow_lander.msg
 import constants
 import argparse
@@ -63,7 +64,10 @@ def DigLinear_client():
     client.wait_for_result()
 
     # Prints out the result of executing the action
-    return client.get_result()
+    if client.get_state() == GoalStatus.ABORTED:
+        return ('failed')
+    else: 
+        return client.get_result()
 
 
 if __name__ == '__main__':

--- a/ow_lander/scripts/dig_linear_action_client.py
+++ b/ow_lander/scripts/dig_linear_action_client.py
@@ -65,7 +65,7 @@ def DigLinear_client():
 
     # Prints out the result of executing the action
     if client.get_state() == GoalStatus.ABORTED:
-        return ('failed')
+        return ('aborted')
     else: 
         return client.get_result()
 

--- a/ow_lander/scripts/discard_action_client.py
+++ b/ow_lander/scripts/discard_action_client.py
@@ -6,6 +6,7 @@
 
 import rospy
 import actionlib
+from actionlib_msgs.msg import GoalStatus
 import ow_lander.msg
 import argparse
 from guarded_move_action_client import print_arguments
@@ -42,7 +43,10 @@ def discard_client():
     client.wait_for_result()
 
     # Prints out the result of executing the action
-    return client.get_result()
+    if client.get_state() == GoalStatus.ABORTED:
+        return ('failed')
+    else: 
+        return client.get_result()
 
 
 if __name__ == '__main__':

--- a/ow_lander/scripts/discard_action_client.py
+++ b/ow_lander/scripts/discard_action_client.py
@@ -44,7 +44,7 @@ def discard_client():
 
     # Prints out the result of executing the action
     if client.get_state() == GoalStatus.ABORTED:
-        return ('failed')
+        return ('aborted')
     else: 
         return client.get_result()
 

--- a/ow_lander/scripts/grind_action_client.py
+++ b/ow_lander/scripts/grind_action_client.py
@@ -77,7 +77,7 @@ def Grind_client():
 
     # Prints out the result of executing the action
     if client.get_state() == GoalStatus.ABORTED:
-        return ('failed')
+        return ('aborted')
     else: 
         return client.get_result()
 

--- a/ow_lander/scripts/grind_action_client.py
+++ b/ow_lander/scripts/grind_action_client.py
@@ -31,6 +31,7 @@
 
 import rospy
 import actionlib
+from actionlib_msgs.msg import GoalStatus
 import ow_lander.msg
 import constants
 import argparse
@@ -75,7 +76,10 @@ def Grind_client():
     client.wait_for_result()
 
     # Prints out the result of executing the action
-    return client.get_result()
+    if client.get_state() == GoalStatus.ABORTED:
+        return ('failed')
+    else: 
+        return client.get_result()
 
 
 if __name__ == '__main__':

--- a/ow_lander/scripts/guarded_move_action_client.py
+++ b/ow_lander/scripts/guarded_move_action_client.py
@@ -6,6 +6,7 @@
 
 import rospy
 import actionlib
+from actionlib_msgs.msg import GoalStatus
 import ow_lander.msg
 import argparse
 
@@ -55,7 +56,10 @@ def guarded_move_client():
     client.wait_for_result()
 
     # Prints out the result of executing the action
-    return client.get_result()
+    if client.get_state() == GoalStatus.ABORTED:
+        return ('failed')
+    else: 
+        return client.get_result()
 
 
 if __name__ == '__main__':

--- a/ow_lander/scripts/guarded_move_action_client.py
+++ b/ow_lander/scripts/guarded_move_action_client.py
@@ -57,7 +57,7 @@ def guarded_move_client():
 
     # Prints out the result of executing the action
     if client.get_state() == GoalStatus.ABORTED:
-        return ('failed')
+        return ('aborted')
     else: 
         return client.get_result()
 

--- a/ow_lander/scripts/stow_action_client.py
+++ b/ow_lander/scripts/stow_action_client.py
@@ -33,7 +33,7 @@ def stow_client():
     # Prints out the result of executing the action
     
     if client.get_state() == GoalStatus.ABORTED:
-        return ('failed')
+        return ('aborted')
     else: 
         return client.get_result()
 

--- a/ow_lander/scripts/stow_action_client.py
+++ b/ow_lander/scripts/stow_action_client.py
@@ -6,11 +6,12 @@
 
 import rospy
 import actionlib
+from actionlib_msgs.msg import GoalStatus
 import ow_lander.msg
 import argparse
 from guarded_move_action_client import print_arguments
 
-def unstow_client():
+def stow_client():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
@@ -30,14 +31,18 @@ def unstow_client():
     client.wait_for_result()
 
     # Prints out the result of executing the action
-    return client.get_result()
+    
+    if client.get_state() == GoalStatus.ABORTED:
+        return ('failed')
+    else: 
+        return client.get_result()
 
 if __name__ == '__main__':
     try:
         # Initializes a rospy node so that the StowActionClient can
         # publish and subscribe over ROS.
         rospy.init_node('stow_client_py')
-        result = unstow_client()
+        result = stow_client()
         rospy.loginfo("Result: %s", result)
     except rospy.ROSInterruptException:
         rospy.logerror("program interrupted before completion")

--- a/ow_lander/scripts/trajectory_async_execution.py
+++ b/ow_lander/scripts/trajectory_async_execution.py
@@ -90,8 +90,8 @@ class TrajectoryAsyncExecuter:
         """
         Stops the execution of the last trajectory submitted for executoin
         """
-        goal_active = self.is_active()
-        if self._connected and goal_active == 1:
+        action_state = self.get_state()
+        if self._connected and action_state == 1:
             self._client.cancel_goal()
 
     def wait(self, timeout=0):
@@ -112,7 +112,7 @@ class TrajectoryAsyncExecuter:
             return None
         return self._client.get_result()
 
-    def is_active(self):
+    def get_state(self):
         """
         returns if the goal is active
         """

--- a/ow_lander/scripts/trajectory_async_execution.py
+++ b/ow_lander/scripts/trajectory_async_execution.py
@@ -6,6 +6,7 @@
 
 import rospy
 import actionlib
+from actionlib_msgs.msg import GoalStatus
 from control_msgs.msg import FollowJointTrajectoryAction, FollowJointTrajectoryGoal
 from ow_faults_detection.msg import SystemFaults
 
@@ -91,7 +92,7 @@ class TrajectoryAsyncExecuter:
         Stops the execution of the last trajectory submitted for executoin
         """
         action_state = self.get_state()
-        if self._connected and action_state == 1:
+        if self._connected and action_state == GoalStatus.ACTIVE:
             self._client.cancel_goal()
 
     def wait(self, timeout=0):

--- a/ow_lander/scripts/unstow_action_client.py
+++ b/ow_lander/scripts/unstow_action_client.py
@@ -32,7 +32,7 @@ def unstow_client():
 
     # Prints out the result of executing the action
     if client.get_state() == GoalStatus.ABORTED:
-        return ('failed')
+        return ('aborted')
     else: 
         return client.get_result()
 
@@ -44,4 +44,4 @@ if __name__ == '__main__':
         result = unstow_client()
         rospy.loginfo("Result: %s", result)
     except rospy.ROSInterruptException:
-        rospy.logerror("program interrupted before completion")
+        rospy.logerror("Program interrupted before completion.")

--- a/ow_lander/scripts/unstow_action_client.py
+++ b/ow_lander/scripts/unstow_action_client.py
@@ -6,6 +6,7 @@
 
 import rospy
 import actionlib
+from actionlib_msgs.msg import GoalStatus
 import ow_lander.msg
 import argparse
 from guarded_move_action_client import print_arguments
@@ -30,7 +31,10 @@ def unstow_client():
     client.wait_for_result()
 
     # Prints out the result of executing the action
-    return client.get_result()
+    if client.get_state() == GoalStatus.ABORTED:
+        return ('failed')
+    else: 
+        return client.get_result()
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
## Linked Issues:
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-923](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-923) |
| Github :octocat:  | # |


## Summary of Changes
* Detects if the arm actions have been stopped by the stop action server and reports the current actions as failed. 

## Test
In 3 seperate terminals:

1. roslaunch ow atacama_y1a.launch
2. launch any of the action files:

-   ./unstow_action_client.py
-   you can check for all other action clients like dig_circular, dig_linear etc...

3. Stop the motion during any phase of the arm movement.
        ./stop_action_client.py

The terminal should report that the action failed and was stopped. 
