### PR TITLE
HOTFIX/OCEANWATER-919: Remove the reset of joint values when arm fault are injected

### DIFF
--- a/ow_faults_injection/include/ow_faults_injection/FaultInjector.h
+++ b/ow_faults_injection/include/ow_faults_injection/FaultInjector.h
@@ -38,9 +38,6 @@ public:
 
   void faultsConfigCb(ow_faults_injection::FaultsConfig& faults, uint32_t level);
 
-  //arm
-  static constexpr float FAULT_ZERO_TELEMETRY = 0.0;
-
 private:
   
   ////////// functions

--- a/ow_faults_injection/src/FaultInjector.cpp
+++ b/ow_faults_injection/src/FaultInjector.cpp
@@ -72,39 +72,6 @@ void FaultInjector::jointStateCb(const sensor_msgs::JointStateConstPtr& msg)
   // checking rqt
   checkCamFaults();
 
-  //ant faults
-  if (m_faults.ant_pan_joint_locked_failure && findJointIndex(J_ANT_PAN, index)){
-    output.position[index]  = FAULT_ZERO_TELEMETRY;
-  }
-  if ( m_faults.ant_tilt_joint_locked_failure && findJointIndex(J_ANT_TILT, index)) {
-    output.position[index]  = FAULT_ZERO_TELEMETRY;
-  }
-
-  //arm faults
-  if (m_faults.shou_yaw_joint_locked_failure && findJointIndex(J_SHOU_YAW, index)) {
-    output.position[index]  = FAULT_ZERO_TELEMETRY;
-  }
-
-  if (m_faults.shou_pitch_joint_locked_failure && findJointIndex(J_SHOU_PITCH, index)) {
-    output.position[index]  = FAULT_ZERO_TELEMETRY;
-  }
-
-  if (m_faults.prox_pitch_joint_locked_failure && findJointIndex(J_PROX_PITCH, index)) {
-    output.position[index]  = FAULT_ZERO_TELEMETRY;
-  }
-
-  if (m_faults.dist_pitch_joint_locked_failure && findJointIndex(J_DIST_PITCH, index)) {
-    output.position[index]  = FAULT_ZERO_TELEMETRY;
-  }
-
-  if (m_faults.hand_yaw_joint_locked_failure && findJointIndex(J_HAND_YAW, index)) {
-    output.position[index]  = FAULT_ZERO_TELEMETRY;
-  }
-  
-  if (m_faults.scoop_yaw_joint_locked_failure && findJointIndex(J_SCOOP_YAW, index)) {
-    output.position[index]  = FAULT_ZERO_TELEMETRY;
-  }
-
   m_joint_state_remapped_pub.publish(output);
 }
 


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | N/A |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-919](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-919) |
| Github :octocat:  | closes #227, related #229 |

## Summary of Changes
* Removed the code that was setting the position of locked joints to zeros

| On Arm Fault (noetic-devel) | On Arm Fault (this branch) |
| :-----------------------------------: | :---------------------------------: |
| ![joints_fault](https://user-images.githubusercontent.com/606033/160684605-e8eb0796-7128-4832-a91f-05075da0c91e.png) | ![joint_same](https://user-images.githubusercontent.com/606033/160684746-c3586b13-693d-435d-8a2a-e0e1ff1da598.png) |

## Test
* Confirm that before this change that when a fault is applied to a specific joint it value is set to zero
  - as reported in #227
* After checking out this branch verify that this issue no longer exists. The arm will still halt execution but joint values remain intact.
