### PR TITLE
BUGFIX/OCEANWATER-930: parts of ros services no longer work

### DIFF
--- a/ow_lander/launch/spawn.launch
+++ b/ow_lander/launch/spawn.launch
@@ -78,7 +78,7 @@
 
   <include file="$(find ow_lander)/launch/move_group.launch">
     <arg name="load_robot_description" value="false"/>
-    <arg name="allow_trajectory_execution" value="false"/>
+    <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="false"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | N/A |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-930 / parts of ros services no longer work](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-930) |
| Github :octocat:  | #226 |


## Summary of Changes
* The PR #226 introduced an issue that hindered the execution of certain commands of the ros services interface
* This PR reset the flag _allow_trajectory_execution_ back to **true**

## Test
Run the following system tests:
* https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/CopyOfOW-TEST-009-3+Sample+Collection
* https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/CopyOfOW-TEST-009-4+ROS+Actions
