### PR TITLE
changing planner to RRT* for consistent deliver and discard behavior

### DIFF
--- a/ow_lander/scripts/action_trajectories.py
+++ b/ow_lander/scripts/action_trajectories.py
@@ -930,7 +930,7 @@ class ActionTrajectories:
         goal_pose.orientation = Quaternion(q[0], q[1], q[2], q[3])
 
         move_arm.set_pose_target(goal_pose)
-
+        move_arm.set_planner_id("RRTstar")
         if self.check_for_stop("discard_sample", server_stop):
             return False
         _, plan_a, _, _ = move_arm.plan()
@@ -965,7 +965,6 @@ class ActionTrajectories:
         goal_pose.orientation = Quaternion(q[0], q[1], q[2], q[3])
 
         move_arm.set_pose_target(goal_pose)
-
         if self.check_for_stop("discard_sample", server_stop):
             return False
         _, plan_b, _, _ = move_arm.plan()
@@ -975,7 +974,7 @@ class ActionTrajectories:
             return plan_a
 
         discard_sample_traj = self.cascade_plans(plan_a, plan_b)
-
+        move_arm.set_planner_id("RRTconnect")
         return discard_sample_traj
 
     def deliver_sample(self, move_arm, robot, moveit_fk, server_stop):
@@ -994,6 +993,7 @@ class ActionTrajectories:
                 self.calculate_joint_state_end_pose_from_plan_arm(
                     robot, total_plan, move_arm, moveit_fk)[0]
             move_arm.set_start_state(cs)
+            move_arm.set_planner_id("RRTstar")
             goal = move_arm.get_named_target_values(t)
             move_arm.set_joint_value_target(goal)
             
@@ -1005,5 +1005,5 @@ class ActionTrajectories:
                 return False
             total_plan = plan if total_plan is None else \
                 self.cascade_plans(total_plan, plan)
-
+        move_arm.set_planner_id("RRTconnect")
         return total_plan

--- a/ow_sim_tests/test/terrain_interaction.py
+++ b/ow_sim_tests/test/terrain_interaction.py
@@ -351,7 +351,10 @@ class TerrainInteraction(unittest.TestCase):
   """
   def test_04_discard(self):
 
-    DISCARD_MAX_DURATION = 50.0
+    # DISCARD_MAX_DURATION = 50.0
+    # NOTE: As long as discard and deliver use RRT*, the additional planning
+    #       time must be accounted for, so we use a large interval here
+    DISCARD_MAX_DURATION = 200.0
     DISCARD_EXPECTED_FINAL = Point(1.5024, 0.8643, -6.6408)
     REGOLITH_CLEANUP_DELAY = 5.0 # seconds
 
@@ -404,7 +407,10 @@ class TerrainInteraction(unittest.TestCase):
   """
   def test_06_deliver(self):
 
-    DELIVER_MAX_DURATION = 60.0
+    # DELIVER_MAX_DURATION = 60.0
+    # NOTE: As long as discard and deliver use RRT*, the additional planning
+    #       time must be accounted for, so we use a large interval here
+    DELIVER_MAX_DURATION = 200.0
     DELIVER_EXPECTED_FINAL = Point(0.5562, -0.2135, -6.3511)
 
     deliver_result = self._test_action(


### PR DESCRIPTION
## Linked Issues:
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-932](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-932) |
| Github :octocat:  | # |


## Summary of Changes
* Changed default planner for discard and deliver to RRT* for constant behavior

## Test
*roslaunch ow atacama_y1a.launch 

In a separate terminal :
*./grind_action_client.py 
* ./dig_circular_action_client.py  (you can also use the dig_linear service)
* ./discard_action_client.py
*  ./dig_circular_action_client.py (you can also use the dig_linear service)
* ./deliver_action_client.py 


