### PR TITLE
Bugfix/oceanwater 966 fix compile error in ow regolith

### DIFF
--- a/ow_dynamic_terrain/CMakeLists.txt
+++ b/ow_dynamic_terrain/CMakeLists.txt
@@ -93,10 +93,10 @@ add_message_files(
 )
 
 generate_messages(
-    DEPENDENCIES
-    std_msgs
-    geometry_msgs
-    sensor_msgs
+  DEPENDENCIES
+  std_msgs
+  geometry_msgs
+  sensor_msgs
 )
 
 ################################################
@@ -131,8 +131,12 @@ generate_messages(
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES ow_dynamic_terrain
-  CATKIN_DEPENDS message_runtime
 #  DEPENDS system_lib
+  CATKIN_DEPENDS
+  message_runtime
+  std_msgs
+  geometry_msgs
+  sensor_msgs
 )
 
 catkin_add_env_hooks(
@@ -188,7 +192,8 @@ add_library(${PROJECT_NAME}_model
 
 add_dependencies(${PROJECT_NAME}_model
   ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS})
+  ${catkin_EXPORTED_TARGETS}
+)
 
 target_link_libraries(${PROJECT_NAME}_model
   ${PROJECT_NAME}_shared
@@ -202,7 +207,8 @@ add_library(${PROJECT_NAME}_visual
 
 add_dependencies(${PROJECT_NAME}_visual
   ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  ${catkin_EXPORTED_TARGETS})
+  ${catkin_EXPORTED_TARGETS}
+)
 
 target_link_libraries(${PROJECT_NAME}_visual
   ${PROJECT_NAME}_shared

--- a/ow_dynamic_terrain/package.xml
+++ b/ow_dynamic_terrain/package.xml
@@ -25,12 +25,13 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
-  <build_depend>message_generation</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>sensor_msgs</build_depend>
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
 
-  <exec_depend>roscpp</exec_depend>
+  <build_depend>message_generation</build_depend>
+
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>cv_bridge</exec_depend>
 

--- a/ow_faults_detection/CMakeLists.txt
+++ b/ow_faults_detection/CMakeLists.txt
@@ -111,7 +111,9 @@ catkin_package(
 #  LIBRARIES ow_faults
 #  CATKIN_DEPENDS dynamic_reconfigure roscpp rospy
 #  DEPENDS system_lib
-  CATKIN_DEPENDS message_runtime
+  CATKIN_DEPENDS
+  message_runtime
+  std_msgs
 )
 
 ###########
@@ -141,10 +143,11 @@ include_directories(
 add_executable(${EXEC_NAME} src/main.cpp src/FaultDetector.cpp)
 
 # make sure configure headers are built before any node using them
-add_dependencies (
-  ${EXEC_NAME} ${PROJECT_NAME}_gencfg
+add_dependencies(${EXEC_NAME}
+  ${PROJECT_NAME}_gencfg
   ${${PROJECT_NAME}_EXPORTED_TARGETS}
-  )
+  ${catkin_EXPORTED_TARGETS}
+)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -158,7 +161,7 @@ add_dependencies (
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(${EXEC_NAME}
-   ${catkin_LIBRARIES}
+  ${catkin_LIBRARIES}
 )
 
 #############

--- a/ow_faults_detection/package.xml
+++ b/ow_faults_detection/package.xml
@@ -56,6 +56,7 @@
   <build_depend>ow_lander</build_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
+  <depend>std_msgs</depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>

--- a/ow_lander/CMakeLists.txt
+++ b/ow_lander/CMakeLists.txt
@@ -4,14 +4,12 @@ project(ow_lander)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   rospy
-  std_msgs
+  roslaunch
   message_generation
+  std_msgs
   geometry_msgs
+  actionlib_msgs
 )
-
-find_package(roslaunch)
-
-find_package(catkin REQUIRED COMPONENTS actionlib_msgs)
 
 add_service_files(
   FILES
@@ -41,30 +39,21 @@ add_action_files(
   FILES Stop.action
 )
 
-
 add_message_files(
   FILES
   GuardedMoveFinalResult.msg
 )
-
-
 
 generate_messages(
   DEPENDENCIES
   std_msgs
   geometry_msgs
   actionlib_msgs
-  
-)
-
-
-catkin_package(
-  CATKIN_DEPENDS actionlib_msgs
 )
 
 catkin_package(
   INCLUDE_DIRS include
-  CATKIN_DEPENDS message_runtime
+  CATKIN_DEPENDS message_runtime std_msgs geometry_msgs actionlib_msgs
 )
 
 catkin_add_env_hooks(
@@ -85,4 +74,5 @@ endforeach(dir)
 install(
   DIRECTORY launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-  PATTERN "setup_assistant.launch" EXCLUDE)
+  PATTERN "setup_assistant.launch" EXCLUDE
+)

--- a/ow_lander/package.xml
+++ b/ow_lander/package.xml
@@ -18,8 +18,11 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roslaunch</build_depend>
   <build_depend>message_generation</build_depend>
-  <build_depend>actionlib_msgs</build_depend>
-    
+
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>actionlib_msgs</depend>
+
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>gazebo</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
@@ -45,8 +48,6 @@
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
-  <exec_depend>message_generation</exec_depend>
-  <exec_depend>actionlib_msgs</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
   <export>
     <architecture_independent />

--- a/ow_regolith/CMakeLists.txt
+++ b/ow_regolith/CMakeLists.txt
@@ -15,6 +15,8 @@ find_package(catkin REQUIRED COMPONENTS
   gazebo_ros
   cv_bridge
   ow_dynamic_terrain
+  std_msgs
+  geometry_msgs
   message_generation
 )
 
@@ -93,6 +95,8 @@ catkin_package(
    CATKIN_DEPENDS
    ow_dynamic_terrain
    message_runtime
+   std_msgs
+   geometry_msgs
 )
 
 catkin_add_env_hooks(

--- a/ow_regolith/package.xml
+++ b/ow_regolith/package.xml
@@ -26,6 +26,7 @@
   <depend>gazebo_ros</depend>
   <depend>ow_dynamic_terrain</depend>
   <depend>cv_bridge</depend>
+  <depend>std_msgs</depend>
   <depend>geometry_msgs</depend>
 
   <build_depend>message_generation</build_depend>


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️ | [OCEANWATER-966](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-966) |


## Summary of Changes
* Fixed bug
* Update package.xml and CMakeLists.txt files to build messages, services, and actions in a consistent and compliant way, primarily following these instructions: https://docs.ros.org/en/melodic/api/catkin/html/howto/format2/building_msgs.html

## Test
* Compile OceanWATERS noetic-devel branches from scratch. The bug was intermittent, so you might not see it broken every time.
