### PR TITLE
OceanWATERS 981 Updated all CMakesLists.txt files to required cmake v3.0.2 and other fixes

### DIFF
--- a/ow/CMakeLists.txt
+++ b/ow/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(os_simulator)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ow_bag_recorder/CMakeLists.txt
+++ b/ow_bag_recorder/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(ow_bag_recorder)
 

--- a/ow_dynamic_terrain/CMakeLists.txt
+++ b/ow_dynamic_terrain/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ow_dynamic_terrain)
 
 ## libiginition-math6-dev which is a dependency of this module seem to require

--- a/ow_ephemeris/CMakeLists.txt
+++ b/ow_ephemeris/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ow_ephemeris)
 
 ## Find catkin macros and libraries

--- a/ow_faults_detection/CMakeLists.txt
+++ b/ow_faults_detection/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ow_faults_detection)
 
 set(EXEC_NAME faults_detection)
@@ -144,7 +144,6 @@ add_executable(${EXEC_NAME} src/main.cpp src/FaultDetector.cpp)
 
 # make sure configure headers are built before any node using them
 add_dependencies(${EXEC_NAME}
-  ${PROJECT_NAME}_gencfg
   ${${PROJECT_NAME}_EXPORTED_TARGETS}
   ${catkin_EXPORTED_TARGETS}
 )

--- a/ow_faults_injection/CMakeLists.txt
+++ b/ow_faults_injection/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ow_faults_injection)
 
 ## libiginition-math6-dev which is a dependency of this module seem to require

--- a/ow_gazebo_plugins/CMakeLists.txt
+++ b/ow_gazebo_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ow_gazebo_plugins)
 
 ## Find catkin macros and libraries

--- a/ow_lander/CMakeLists.txt
+++ b/ow_lander/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ow_lander)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/ow_lander/launch/planning.launch
+++ b/ow_lander/launch/planning.launch
@@ -23,7 +23,7 @@
     </include>
 
     <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-      <param name="use_gui" value="$(arg use_gui)"/>
+      <param name="use_gui" value="$(arg use_gui)"/> <!-- deprecated param -->
       <param name="zeros/j_shou_yaw" value="$(arg stowed_shou_yaw)"/>
       <param name="zeros/j_shou_pitch" value="$(arg stowed_shou_pitch)"/>
       <param name="zeros/j_prox_pitch" value="$(arg stowed_prox_pitch)"/>

--- a/ow_lander/launch/spawn.launch
+++ b/ow_lander/launch/spawn.launch
@@ -2,7 +2,6 @@
 <launch>
 
   <arg name="debug" default="false" />
-  <arg name="use_gui" default="false" />
   <arg name="use_rviz" default="true" />
 
   <!-- Initial lander pose arguments -->

--- a/ow_power_system/CMakeLists.txt
+++ b/ow_power_system/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ow_power_system)
 
 if(DEFINED ENV{GSAP_HOME})

--- a/ow_regolith/CMakeLists.txt
+++ b/ow_regolith/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ow_regolith)
 
 ## libiginition-math6-dev which is a dependency of this module seem to require

--- a/ow_sim_tests/CMakeLists.txt
+++ b/ow_sim_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ow_sim_tests)
 
 ## libiginition-math6-dev which is a dependency of this module seem to require

--- a/ow_testbed/CMakeLists.txt
+++ b/ow_testbed/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(ow_testbed)
 

--- a/ow_testbed/launch/rviz.launch
+++ b/ow_testbed/launch/rviz.launch
@@ -3,7 +3,7 @@
   <param name="robot_description" textfile="$(find ow_testbed)/urdf/testbed.xacro" />
 
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-    <param name="use_gui" value="true" />
+    <param name="use_gui" value="true" /> <!-- deprecated param -->
   </node>
 
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | N/A |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-981](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-981) |
| Github :octocat:  | # |

## Related PRs
[ow_autonomy #82](https://github.com/nasa/ow_autonomy/pull/82)
[ow_europa #19](https://github.com/nasa/ow_europa/pull/19)
[irg_open #12](https://github.com/nasa/irg_open/pull/12)

## Summary of Changes
* Updated all CMakesLists.txt following [this ROS Noetic migration step](http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning), which has eliminated the following cmake warning.
```
Warnings   << ow_plexil:check /usr/local/home/tstucky/ow/workspace/logs/ow_plexil/build.check.002.log                                          
CMake Warning (dev) at CMakeLists.txt:2 (project): 
 Policy CMP0048 is not set: project() command manages VERSION variables. 
 Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy 
 command to set the policy and suppress this warning.
 The following variable(s) would be set to empty:
   CMAKE_PROJECT_VERSION 
   CMAKE_PROJECT_VERSION_MAJOR 
   CMAKE_PROJECT_VERSION_MINOR 
   CMAKE_PROJECT_VERSION_PATCH 
This warning is for project developers.  Use -Wno-dev to suppress it.
```
* Removed a dependency in **ow_faults_detection** which fixes this warning
```
CMake Warning (dev) at CMakeLists.txt:146 (add_dependencies):
  Policy CMP0046 is not set: Error on non-existent dependency in
  add_dependencies.  Run "cmake --help-policy CMP0046" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.

  The dependency target "ow_faults_detection_gencfg" of target
  "faults_detection" does not exist.
This warning is for project developers.  Use -Wno-dev to suppress it.
```
* Removed an unsued launch file argument. 
* Marked a param as deprecated in unused launch files. 
   * Held off on updating the launch files as described in [this migration step](http://wiki.ros.org/noetic/Migration#Joint_State_Publisher_GUI) because the launch files appear to not be used/included by anything, so I wasn't sure how to test the change. 

## Test
1. Change all 4 repositories to `OCEANWATER-981_cleanup_cmake_warnings`
2. Compile and look for errors or warnings. **NOTE** The irg_open warning that starts off `backspace.c: In function 'f_back':` is not fixed by this PR.
