### PR TITLE
Oceanwater 894 restrict power faults to one per simulation

### DIFF
--- a/ow_faults_injection/src/FaultInjector.cpp
+++ b/ow_faults_injection/src/FaultInjector.cpp
@@ -9,10 +9,6 @@ using namespace ow_lander;
 
 using std::string;
 
-// GLOBAL VAR (should implementation be changed to avoid this?)
-bool fault_activated = false;
-
-
 FaultInjector::FaultInjector(ros::NodeHandle& nh)
 { 
   string original_str = "/_original";
@@ -47,78 +43,8 @@ void FaultInjector::faultsConfigCb(ow_faults_injection::FaultsConfig& faults, ui
   // This is where we would check to see if faults is different from m_faults
   // if we wanted to change some state based on that.
 
-  // Check if any of the power faults have been injected.
-  bool low_state_of_charge_needs_deactivating = false;
-  bool instantaneous_capacity_loss_needs_deactivating = false;
-  bool thermal_needs_deactivating = false;
-  if (faults.groups.power_faults.low_state_of_charge_power_failure
-      && (faults.groups.power_faults.low_state_of_charge_power_failure 
-      != m_faults.groups.power_faults.low_state_of_charge_power_failure))
-  {
-    // low_state_of_charge_power_failure was turned on
-    if (fault_activated)
-    {
-      ROS_WARN_STREAM("Cannot activate further power faults for the remainder of simulation. Restart required to "
-                      "activate a new fault. Attempted activation will be ignored in simulation.");
-      low_state_of_charge_needs_deactivating = true;
-    }
-    else
-    {
-      fault_activated = true;
-    }
-  }
-
-  if (faults.groups.power_faults.instantaneous_capacity_loss_power_failure
-      && (faults.groups.power_faults.instantaneous_capacity_loss_power_failure
-      != m_faults.groups.power_faults.instantaneous_capacity_loss_power_failure))
-  {
-    // instantaneous_capacity_loss_power_failure was turned on
-    if (fault_activated)
-    {
-      ROS_WARN_STREAM("Cannot activate further power faults for the remainder of simulation. Restart required to "
-                      "activate a new fault. Attempted activation will be ignored in simulation.");
-      instantaneous_capacity_loss_needs_deactivating = true;
-    }
-    else
-    {
-      fault_activated = true;
-    }
-  }
-
-  if (faults.groups.power_faults.thermal_power_failure
-      && (faults.groups.power_faults.thermal_power_failure
-      != m_faults.groups.power_faults.thermal_power_failure))
-  {
-    // thermal_power_failure was turned on
-    if (fault_activated)
-    {
-      ROS_WARN_STREAM("Cannot activate further power faults for the remainder of simulation. Restart required to "
-                      "activate a new fault. Attempted activation will be ignored in simulation.");
-      thermal_needs_deactivating = true;
-    }
-    else
-    {
-      fault_activated = true;
-    }  
-  }
-
-  // Store current set of faults for later use, but modify power faults to prevent exceeding one-fault-per-simulation.
-  // NOTE: If power faults are consolidated into one type of fault (high power draw), this can be simplified to check
-  //       only one fault instead of the three.
+  // Store current set of faults for later use
   m_faults = faults;
-
-  if (low_state_of_charge_needs_deactivating)
-  {
-    m_faults.groups.power_faults.low_state_of_charge_power_failure = false;
-  }
-  if (instantaneous_capacity_loss_needs_deactivating)
-  {
-    m_faults.groups.power_faults.instantaneous_capacity_loss_power_failure = false;
-  }
-  if (thermal_needs_deactivating)
-  {
-    m_faults.groups.power_faults.thermal_power_failure = false;
-  }
 }
 
 void FaultInjector::cameraFaultRepublishCb(const sensor_msgs::Image& msg)

--- a/ow_power_system/src/power_system_node.cpp
+++ b/ow_power_system/src/power_system_node.cpp
@@ -249,7 +249,7 @@ void PowerSystemNode::injectFault (const string& fault_name,
     // Only activate the fault if no other fault has been activated in the simulation thus far.
     if (one_fault_injected)
     {
-      ROS_WARN_STREAM
+      ROS_WARN_STREAM_ONCE
         (fault_name << ": cannot activate; only one fault activation per simulation is supported.");
     }
     else 

--- a/ow_power_system/src/power_system_node.cpp
+++ b/ow_power_system/src/power_system_node.cpp
@@ -250,7 +250,9 @@ void PowerSystemNode::injectFault (const string& fault_name,
     if (one_fault_injected)
     {
       ROS_WARN_STREAM_ONCE
-        (fault_name << ": cannot activate; only one fault activation per simulation is supported.");
+        (fault_name << ": cannot activate; only one fault activation per simulation is supported."
+         << " Any additional faults for the remainder of this simulation will not be injected,"
+         << " even if they are shown as being activated.");
     }
     else 
     {

--- a/ow_power_system/src/power_system_node.cpp
+++ b/ow_power_system/src/power_system_node.cpp
@@ -24,9 +24,9 @@ const string FAULT_NAME_THERMAL = "thermal_power_failure";
 //
 static constexpr int TEMPERATURE_INDEX = 1;
 
-// GLOBAL VARS (should implementation be changed to avoid this?)
-bool one_fault_injected = false;
-string one_fault_name = "";
+// Vars used to handle preventing more than one fault activation.
+static bool OneFaultInjected = false;
+static string SelectedFaultName = "";
 
 PowerSystemNode::PowerSystemNode()
 { }
@@ -247,12 +247,11 @@ void PowerSystemNode::injectFault (const string& fault_name,
   if (!fault_activated && fault_enabled)
   {
     // Only activate the fault if no other fault has been activated in the simulation thus far.
-    if (one_fault_injected)
+    if (OneFaultInjected)
     {
       ROS_WARN_STREAM_ONCE
-        (fault_name << ": cannot activate; only one fault activation per simulation is supported."
-         << " Any additional faults for the remainder of this simulation will not be injected,"
-         << " even if they are shown as being activated.");
+        ("'" << fault_name << "' and future faults are being ignored. Only one power fault activation allowed"
+         << " per simulation; '" << SelectedFaultName << "' has already been activated.");
     }
     else 
     {
@@ -260,9 +259,8 @@ void PowerSystemNode::injectFault (const string& fault_name,
       index = 0;
       fault_activated = true;
 
-      // TEST
-      one_fault_injected = true;
-      one_fault_name = fault_name;
+      OneFaultInjected = true;
+      SelectedFaultName = fault_name;
     }
   }
   else if (fault_activated && !fault_enabled)
@@ -275,7 +273,7 @@ void PowerSystemNode::injectFault (const string& fault_name,
   {
     // Check and ensure the fault is the original one injected.
     // Any additional faults are to be ignored due to one-fault-per-simulation.
-    if (fault_name != one_fault_name) 
+    if (fault_name != SelectedFaultName) 
     {
       return;
     }


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-894](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-894) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-894](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-894) |
| Github :octocat:  | # |


## Summary of Changes
* Power fault activation is limited to one per simulation run. Additional activation attempts should be ignored and a warning displayed.

## Test
* roslaunch ow europa_terminator_workspace.launch
* In another terminal, navigate to the same directory and activate one of the three power faults:
* rosrun dynamic_reconfigure dynparam set /faults low_state_of_charge_power_failure True
* rosrun dynamic_reconfigure dynparam set /faults instantaneous_capacity_loss_power_failure True
* rosrun dynamic_reconfigure dynparam set /faults thermal_power_failure True
* The first fault activated should apply normally, however any additional faults should output a warning to the original terminal instead. This includes if you deactivate the first fault and then try to reactivate it again in the same simulation
* Faults can still be deactivated by using the same command to set them to False. This should prevent them from outputting future warnings

Note that the checkboxes in the dynamic reconfigure window will still show as checked off if you attempt to activate a fault, even if the fault is not applied.

I am unsure as to if the changes to FaultInjector.cpp are actually necessary; it seems like the primary change was done in power_system_node.cpp. I'm also unsure if the changes I made actually prevent the fault from affecting the simulation; to my understanding, they should, but I can't guarantee that.