### PR TITLE
Oceanwater 538 ow dynamic terrain modifies normal maps

### DIFF
--- a/ow_dynamic_terrain/README.md
+++ b/ow_dynamic_terrain/README.md
@@ -73,6 +73,19 @@ The following excerpt shows how to apply the two plugins towards a DEM object:
 </sdf>
 ```
 
+`libow_dynamic_terrain_visual.so` can apply an Ogre-generated normal map upon
+initialization and will update that normal map each time the terrain is
+modified. If you are using a custom Ogre material script, get this normal map
+by adding the line:
+
+```
+texture_unit ow_dynamic_terrain_normal_map {}
+```
+
+You can specify a texture map file in a texture unit, but there is no reason to
+do so when using the above texture unit name as it will be overridden by the
+plugin.
+
 Once these plugins have been configured for a heightmap object, the user can then modify the terrain by composing and
 submitting an appropriate ros message to the following three topics/methods:
 - */ow_dynamic_terrain/modify_terrain_circle*

--- a/ow_dynamic_terrain/src/DynamicTerrainModel.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainModel.cpp
@@ -100,14 +100,16 @@ private:
     auto heightmap = getHeightmap(get_scene());
     if (heightmap == nullptr)
     {
-      gzerr << m_plugin_name << ": Couldn't acquire heightmap!" << endl;
+      gzerr << m_plugin_name << ": DynamicTerrainModel::onModifyTerrainMsg()"
+        " could not acquire heightmap." << endl;
       return;
     }
 
     auto heightmap_shape = getHeightmapShape();
     if (heightmap_shape == nullptr)
     {
-      gzerr << m_plugin_name << ": Couldn't acquire heightmap shape!" << endl;
+      gzerr << m_plugin_name << ": DynamicTerrainModel::onModifyTerrainMsg()"
+        " could not acquire heightmap shape." << endl;
       return;
     }
 

--- a/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
@@ -4,10 +4,12 @@
 
 #include "DynamicTerrainBase.h"
 #include "TerrainModifier.h"
+#include <gazebo/rendering/RenderingIface.hh>
 
 using namespace std;
 using namespace gazebo;
 using namespace rendering;
+using namespace Ogre;
 
 namespace ow_dynamic_terrain
 {
@@ -61,6 +63,41 @@ private:
       terrain->updateDerivedData(false, Ogre::Terrain::DERIVED_DATA_NORMALS | Ogre::Terrain::DERIVED_DATA_LIGHTMAP);
 
       m_differential_pub.publish(diff_msg);
+
+      // Override custom material normal map labeled "ow_dynamic_terrain_normal_map"
+      // with Ogre::Terrain's internal normal map.
+      // Ogre::Terrain makes a copy of a user-specified normal map and the copy
+      // is the one that is updated by Terrain::updateDerivedData(), not the
+      // original normal map specified in a custom material file.
+      // Note: If you are not using a custom material this code will have no
+      // effect, but Ogre should be using the correct normal map and a generated
+      // material and shader in that case.
+      // Caveat: The normal map copy is always resized to the terrain's DEM
+      // resolution, so using a larger texture for more detail is not possible
+      // with this plugin. It might be possible to update the original normal map
+      // by computing all necessary heights at the original resolution and then
+      // computing and uploading normals instead of relying on Ogre to do it. 
+      ResourceManager::ResourceMapIterator res_it = MaterialManager::getSingleton().getResourceIterator();
+      while (res_it.hasMoreElements())
+      {
+        ResourcePtr resource = res_it.getNext();
+        MaterialPtr material = resource.staticCast<Material>();
+        Material::TechniqueIterator tech_it = material->getTechniqueIterator();
+        while (tech_it.hasMoreElements())
+        {
+          Technique* technique = tech_it.getNext();
+          Technique::PassIterator pass_it = technique->getPassIterator();
+          while (pass_it.hasMoreElements())
+          {
+            Pass* pass = pass_it.getNext();
+            TextureUnitState* tus = pass->getTextureUnitState("ow_dynamic_terrain_normal_map");
+            if (tus != 0)
+            {
+              tus->setTexture(terrain->getTerrainNormalMap());
+            }
+          }
+        }
+      }
     }
   }
 

--- a/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
@@ -23,6 +23,13 @@ public:
   void Load(VisualPtr /*visual*/, sdf::ElementPtr /*sdf*/) override
   {
     Initialize("visual");
+
+    m_on_prerender_connection = gazebo::event::Events::ConnectPreRender([this]() {
+      // Initialize terrain with Ogre-generated normal map.
+      applyNormalMap();
+      // Disconnect so this method will not be called again.
+      m_on_prerender_connection.reset();
+    });
   }
 
 private:
@@ -45,7 +52,7 @@ private:
     auto heightmap = getHeightmap(get_scene());
     if (heightmap == nullptr)
     {
-      gzerr << m_plugin_name << ": Couldn't acquire heightmap!" << endl;
+      gzerr << m_plugin_name << ": onModifyTerrainMsg() could not acquire heightmap." << endl;
       return;
     }
 
@@ -63,41 +70,6 @@ private:
       terrain->updateDerivedData(false, Ogre::Terrain::DERIVED_DATA_NORMALS | Ogre::Terrain::DERIVED_DATA_LIGHTMAP);
 
       m_differential_pub.publish(diff_msg);
-
-      // Override custom material normal map labeled "ow_dynamic_terrain_normal_map"
-      // with Ogre::Terrain's internal normal map.
-      // Ogre::Terrain makes a copy of a user-specified normal map and the copy
-      // is the one that is updated by Terrain::updateDerivedData(), not the
-      // original normal map specified in a custom material file.
-      // Note: If you are not using a custom material this code will have no
-      // effect, but Ogre should be using the correct normal map and a generated
-      // material and shader in that case.
-      // Caveat: The normal map copy is always resized to the terrain's DEM
-      // resolution, so using a larger texture for more detail is not possible
-      // with this plugin. It might be possible to update the original normal map
-      // by computing all necessary heights at the original resolution and then
-      // computing and uploading normals instead of relying on Ogre to do it. 
-      ResourceManager::ResourceMapIterator res_it = MaterialManager::getSingleton().getResourceIterator();
-      while (res_it.hasMoreElements())
-      {
-        ResourcePtr resource = res_it.getNext();
-        MaterialPtr material = resource.staticCast<Material>();
-        Material::TechniqueIterator tech_it = material->getTechniqueIterator();
-        while (tech_it.hasMoreElements())
-        {
-          Technique* technique = tech_it.getNext();
-          Technique::PassIterator pass_it = technique->getPassIterator();
-          while (pass_it.hasMoreElements())
-          {
-            Pass* pass = pass_it.getNext();
-            TextureUnitState* tus = pass->getTextureUnitState("ow_dynamic_terrain_normal_map");
-            if (tus != 0)
-            {
-              tus->setTexture(terrain->getTerrainNormalMap());
-            }
-          }
-        }
-      }
     }
   }
 
@@ -115,6 +87,52 @@ private:
   {
     onModifyTerrainMsg(msg, TerrainModifier::modifyPatch);
   }
+
+  void applyNormalMap()
+  {
+    auto heightmap = getHeightmap(get_scene());
+    if (heightmap == nullptr)
+    {
+      gzerr << m_plugin_name << ": applyNormalMap() could not acquire heightmap." << endl;
+      return;
+    }
+    auto terrain = heightmap->OgreTerrain()->getTerrain(0, 0);
+
+    // Override custom material normal map labeled "ow_dynamic_terrain_normal_map"
+    // with Ogre::Terrain's internal normal map.
+    // Ogre::Terrain generates an internal normal map and it is updated by
+    // Terrain::updateDerivedData(). But if you use a custom material script
+    // with a custom normal map, the internal normal map will never be seen.
+    // Note: If you are not using a custom material this code will have no
+    // effect, but Ogre should be using the correct normal map and a generated
+    // material and shader in that case.
+    // Caveat: The internal normal map is always sized to the terrain's DEM
+    // resolution, so using a larger texture for more detail is not possible
+    // with this plugin.
+    ResourceManager::ResourceMapIterator res_it = MaterialManager::getSingleton().getResourceIterator();
+    while (res_it.hasMoreElements())
+    {
+      ResourcePtr resource = res_it.getNext();
+      MaterialPtr material = resource.staticCast<Material>();
+      Material::TechniqueIterator tech_it = material->getTechniqueIterator();
+      while (tech_it.hasMoreElements())
+      {
+        Technique* technique = tech_it.getNext();
+        Technique::PassIterator pass_it = technique->getPassIterator();
+        while (pass_it.hasMoreElements())
+        {
+          Pass* pass = pass_it.getNext();
+          TextureUnitState* tus = pass->getTextureUnitState("ow_dynamic_terrain_normal_map");
+          if (tus != 0)
+          {
+            tus->setTexture(terrain->getTerrainNormalMap());
+          }
+        }
+      }
+    }
+  }
+
+  gazebo::event::ConnectionPtr m_on_prerender_connection;
 };
 
 GZ_REGISTER_VISUAL_PLUGIN(DynamicTerrainVisual)

--- a/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
@@ -52,7 +52,8 @@ private:
     auto heightmap = getHeightmap(get_scene());
     if (heightmap == nullptr)
     {
-      gzerr << m_plugin_name << ": onModifyTerrainMsg() could not acquire heightmap." << endl;
+      gzerr << m_plugin_name << ": DynamicTerrainVisual::onModifyTerrainMsg()"
+        " could not acquire heightmap." << endl;
       return;
     }
 
@@ -93,7 +94,8 @@ private:
     auto heightmap = getHeightmap(get_scene());
     if (heightmap == nullptr)
     {
-      gzerr << m_plugin_name << ": applyNormalMap() could not acquire heightmap." << endl;
+      gzerr << m_plugin_name << ": DynamicTerrainVisual::applyNormalMap()"
+        " could not acquire heightmap." << endl;
       return;
     }
     auto terrain = heightmap->OgreTerrain()->getTerrain(0, 0);


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-703](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-703) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-538](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-538) |


## Summary of Changes
* Ogre's internal normal map is applied to any terrain using texture unit `ow_dynamic_terrain_normal_map`. It is updated every time the terrain is modified.

## Test
* You must also use the branch from the ow_europa sibling PR: https://github.com/nasa/ow_europa/pull/20
* Run anything that modifies the atacama or terminator_workspace terrains. You should now see the normals and, consequently, the shading being updated on the terrain. Don't confusing shading with shadows; shadows were already working.