### PR TITLE
Updated battery values

### DIFF
--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -66,7 +66,7 @@ public:
   static constexpr std::bitset<3> isCapLossError{    0b010 };
   static constexpr std::bitset<3> isThermalError{    0b100 };
 
-  static constexpr float THERMAL_MAX = 50;
+  static constexpr float THERMAL_MAX = 70;
   static constexpr float SOC_MIN = 0.1;
   static constexpr float SOC_MAX_DIFF = 0.05;
   

--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -7,7 +7,7 @@ initial_voltage: 4.1        # volts
 initial_temperature: 20.0   # deg. C
 
 # voltage
-base_voltage: 3.2           # volts
+base_voltage: 2.8           # volts
 voltage_range: 0.1          # volts
 
 # power


### PR DESCRIPTION
## Summary of Changes
* Changes max temperature threshold of battery from 50 C to 70 C, per advice from @chetankul 
* Changes base voltage from 3.2 to 2.8, per advice from @chetankul 
* 
## Test
* catkin build
* start any simulator world
* start ow_plexil
* run the plan Continuous.plx
* In a new terminal, `rostopic echo /power_system_node/battery_temperature`
* In a new terminal, `rostopic echo /faults/power_faults_status`
* Inject a high power draw of ~30 watts
* Watch the battery temperature and power fault status.  The former should start around 20 and the latter should be 0.  The temperature should steadily increase, and within a few minutes reach 70.  When it does, the power fault status should be 1.   (Before this fix, 50 was the threshold temperature).

NOTE: there is no test for the base voltage change.
