### PR TITLE
 making planner rrt star for guarded move for consistant planning

### DIFF
--- a/ow_lander/scripts/action_trajectories.py
+++ b/ow_lander/scripts/action_trajectories.py
@@ -800,6 +800,7 @@ class ActionTrajectories:
 
         robot_state = robot.get_current_state()
         move_arm.set_start_state(robot_state)
+        move_arm.set_planner_id("RRTstar")
 
         ### pre-guarded move starts here ###
 
@@ -882,7 +883,7 @@ class ActionTrajectories:
         goal_pose.position.z -= direction_z*search_distance
 
         move_arm.set_pose_target(goal_pose)
-        move_arm.set_goal_tolerance(0.05)
+        #move_arm.set_goal_tolerance(0.05)
 
         if self.check_for_stop("guarded_move", server_stop):
             return False, False
@@ -890,7 +891,7 @@ class ActionTrajectories:
         _, plan_c, _, _ = move_arm.plan()
 
         guarded_move_traj = self.cascade_plans(pre_guarded_move_traj, plan_c)
-
+        move_arm.set_planner_id("RRTconnect")
         '''
         estimated time ratio is the ratio between the time to complete first two parts of the plan 
         to the the entire plan. It is used for ground detection only during the last part of the plan.


### PR DESCRIPTION
## Linked Issues:
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1046](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1046) |
| Github :octocat:  | # |


## Summary of Changes
* changing guarded move planner to rrt star for consistent paths 

## Test
* roslaunch ow atacama_y1a.launch

Tests: 

cd ow_simulator/ow_lander/scripts

./guarded_move_action_client.py 1.7 0.3 0.5 0 0 1 0.7
./guarded_move_action_client.py 1.7 -0.3 0.5 0 0 1 0.7
./guarded_move_action_client.py 1.9 -0.4 0.5 0 0 1 0.7
./guarded_move_action_client.py 1.9 0.5 0.5 0 0 1 0.7
./guarded_move_action_client.py 1.7 0.0 0.5 1 1 1 0.7
./guarded_move_action_client.py 1.7 0.0 0.5 0.5 -0.5 1 0.8 
./guarded_move_action_client.py 1.78 -0.20 -0.12 0.00 0.00 1.00 0.50
./guarded_move_action_client.py 1.5 -0.20 -0.12 0.00 0.00 1.00 0.50
--



