### PR TITLE
Update fault directory error msg

### DIFF
--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -21,7 +21,7 @@ public:
 
 private:
   bool loadSystemConfig();
-  PrognoserVector loadPowerProfile(const std::string& filename, std::string custom_file);
+  PrognoserVector loadPowerProfile(const std::string& path_name, std::string custom_file);
   bool loadCustomFaultPowerProfile(std::string path, std::string custom_file);
   bool initPrognoser();
   bool initTopics();

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -78,14 +78,14 @@ bool PowerSystemNode::loadSystemConfig()
   return true;
 }
 
-PrognoserVector PowerSystemNode::loadPowerProfile(const string& filename, string custom_file)
+PrognoserVector PowerSystemNode::loadPowerProfile(const string& path_name, string custom_file)
 {
-  ifstream file(filename);
+  ifstream file(path_name);
 
   if (file.fail())
   {
-    ROS_WARN_STREAM("Could not find a custom file in the 'profiles' directory with name '"
-                          << custom_file << "'. Deactivate fault and try again.");
+    ROS_WARN_STREAM("Could not find a custom file using the path '"
+                          << path_name << "'. Deactivate fault and try again.");
     return PrognoserVector();
   }
 


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | N/A |
| :----------- | :----------- |
| Jira Ticket 🎟️ | N/A |
| Github :octocat:  | # |


## Summary of Changes
* Very small change, simply updated a variable name as well as the error message when a custom fault file fails to open. It now displays the path attempted to reach the file rather than just the file name, making it easier to pinpoint possible problems in the code.

## Test
* roslaunch ow europa_terminator_workspace.launch
* In the RQT window, navigate to the Dynamic Reconfigure tab, then to the faults section. Scroll down to the custom faults section.
* Input an invalid file name to the `custom_fault_profile` text box, then check the `activate_custom_fault` box and observe the terminal.
* The terminal should output an error message that includes the full path to the file that was attempted to open.
