### PR TITLE
Oceanwater 935 - LightSetIntensity action

### DIFF
--- a/ow_lander/CMakeLists.txt
+++ b/ow_lander/CMakeLists.txt
@@ -40,6 +40,7 @@ add_action_files(
   FILES Stop.action
   FILES ArmMoveJoint.action
   FILES ArmMoveJoints.action
+  FILES LightSetIntensity.action
 )
 
 add_message_files(

--- a/ow_lander/action/LightSetIntensity.action
+++ b/ow_lander/action/LightSetIntensity.action
@@ -1,0 +1,9 @@
+# goal definition
+string name        # "left" or "right" corresponding to the two mast lights
+float32 intensity  # in the range [0..1], 0 is off and 1 is max intensity
+---
+# result
+bool success
+string message
+---
+# feedback

--- a/ow_lander/launch/spawn.launch
+++ b/ow_lander/launch/spawn.launch
@@ -90,8 +90,8 @@
   </include>
 
   <!-- == launch the services servers ============== -->
-  <node pkg="ow_lander" name="path_planning_commander" type="path_planning_commander.py" output="screen" ></node>
-  <node pkg="ow_lander" name="lander_service_server" type="lander_service_server.py" output="screen" ></node>
+  <node pkg="ow_lander" name="path_planning_commander" type="path_planning_commander.py" output="screen"/>
+  <node pkg="ow_lander" name="lander_service_server" type="lander_service_server.py" output="screen"/>
   
   <!-- == launch the action servers ============== -->
   <arg name="node_start_delay" default="10.0" />  
@@ -103,6 +103,10 @@
     launch-prefix="bash -c 'sleep $(arg node_start_delay); $0 $@' "/>
   <node pkg="ow_lander" name="DockIngestSampleAction"
     type="dock_ingest_sample_action_server.py"
+    launch-prefix="bash -c 'sleep $(arg node_start_delay); $0 $@' "
+    output="screen"/>
+  <node pkg="ow_lander" name="LightSetIntensity"
+    type="light_set_intensity_action_server.py"
     launch-prefix="bash -c 'sleep $(arg node_start_delay); $0 $@' "
     output="screen"/>
 </launch>

--- a/ow_lander/scripts/light_set_intensity_action_client.py
+++ b/ow_lander/scripts/light_set_intensity_action_client.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import argparse
+
+import rospy
+import actionlib
+
+import ow_lander.msg
+from guarded_move_action_client import print_arguments
+
+def LightSetIntensity_client():
+    parser = argparse.ArgumentParser(
+        description="Set the intensity of each lander mast spotlight " \
+                    "individually.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument('name', type=str, nargs='?', default='left',
+        choices=['left', 'right'],
+        help="Light identifier."
+    )
+    parser.add_argument('intensity', type=float, nargs='?', default=1.0,
+        help="Intensity to set the light at. In the range [0.0, 1.0]. " \
+             "0 is entirely off, and 1 is max intensity."
+    )
+    args = parser.parse_args()
+    print_arguments(args)
+
+    client = actionlib.SimpleActionClient(
+        'LightSetIntensity', ow_lander.msg.LightSetIntensityAction
+    )
+
+    client.wait_for_server()
+
+    goal = ow_lander.msg.LightSetIntensityGoal(
+        name = args.name,
+        intensity = args.intensity
+    )
+
+    # Sends the goal to the action server.
+    client.send_goal(goal)
+
+    # Waits for the server to finish performing the action.
+    client.wait_for_result()
+
+    return client.get_result()
+
+if __name__ == '__main__':
+    try:
+        rospy.init_node('light_set_intensity_action_client_py')
+        result = LightSetIntensity_client()
+        rospy.loginfo("Result: %s", result)
+    except rospy.ROSInterruptException:
+        rospy.logerror("program interrupted before completion")

--- a/ow_lander/scripts/light_set_intensity_action_client.py
+++ b/ow_lander/scripts/light_set_intensity_action_client.py
@@ -13,45 +13,45 @@ import ow_lander.msg
 from guarded_move_action_client import print_arguments
 
 def LightSetIntensity_client():
-    parser = argparse.ArgumentParser(
-        description="Set the intensity of each lander mast spotlight " \
-                    "individually.",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
-    )
-    parser.add_argument('name', type=str, nargs='?', default='left',
-        choices=['left', 'right'],
-        help="Light identifier."
-    )
-    parser.add_argument('intensity', type=float, nargs='?', default=1.0,
-        help="Intensity to set the light at. In the range [0.0, 1.0]. " \
-             "0 is entirely off, and 1 is max intensity."
-    )
-    args = parser.parse_args()
-    print_arguments(args)
+  parser = argparse.ArgumentParser(
+    description="Set the intensity of each lander mast spotlight " \
+                "individually.",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter
+  )
+  parser.add_argument('name', type=str, nargs='?', default='left',
+    choices=['left', 'right'],
+    help="Light identifier."
+  )
+  parser.add_argument('intensity', type=float, nargs='?', default=1.0,
+    help="Intensity to set the light at. In the range [0.0, 1.0]. " \
+         "0 is entirely off, and 1 is max intensity."
+  )
+  args = parser.parse_args()
+  print_arguments(args)
 
-    client = actionlib.SimpleActionClient(
-        'LightSetIntensity', ow_lander.msg.LightSetIntensityAction
-    )
+  client = actionlib.SimpleActionClient(
+    'LightSetIntensity', ow_lander.msg.LightSetIntensityAction
+  )
 
-    client.wait_for_server()
+  client.wait_for_server()
 
-    goal = ow_lander.msg.LightSetIntensityGoal(
-        name = args.name,
-        intensity = args.intensity
-    )
+  goal = ow_lander.msg.LightSetIntensityGoal(
+    name = args.name,
+    intensity = args.intensity
+  )
 
-    # Sends the goal to the action server.
-    client.send_goal(goal)
+  # Sends the goal to the action server.
+  client.send_goal(goal)
 
-    # Waits for the server to finish performing the action.
-    client.wait_for_result()
+  # Waits for the server to finish performing the action.
+  client.wait_for_result()
 
-    return client.get_result()
+  return client.get_result()
 
 if __name__ == '__main__':
-    try:
-        rospy.init_node('light_set_intensity_action_client_py')
-        result = LightSetIntensity_client()
-        rospy.loginfo("Result: %s", result)
-    except rospy.ROSInterruptException:
-        rospy.logerror("program interrupted before completion")
+  try:
+    rospy.init_node('light_set_intensity_action_client_py')
+    result = LightSetIntensity_client()
+    rospy.loginfo("Result: %s", result)
+  except rospy.ROSInterruptException:
+    rospy.logerror("program interrupted before completion")

--- a/ow_lander/scripts/light_set_intensity_action_server.py
+++ b/ow_lander/scripts/light_set_intensity_action_server.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import rospy
+import actionlib
+
+import ow_lander.msg
+from irg_gazebo_plugins.msg import ShaderParamUpdate
+
+class LightSetIntensityActionServer(object):
+
+    def __init__(self, name):
+        # light shader interface setup
+        self.light_pub = rospy.Publisher(
+            "/gazebo/global_shader_param",
+            ShaderParamUpdate,
+            queue_size=1
+        )
+        self.light_msg = ShaderParamUpdate()
+        self.light_msg.shaderType = ShaderParamUpdate.SHADER_TYPE_FRAGMENT
+        # action server setup
+        self._action_name = name
+        self._fdbk = ow_lander.msg.LightSetIntensityFeedback()
+        self._result = ow_lander.msg.LightSetIntensityResult()
+        self._server = actionlib.SimpleActionServer(
+            self._action_name,
+            ow_lander.msg.LightSetIntensityAction,
+            execute_cb=self.on_light_set_intensity_action,
+            auto_start=False
+        )
+        self._server.start()
+
+    def _set_light_intensity(self, goal):
+        name = goal.name.lower() # make case insentive
+        intensity = goal.intensity
+        # check intensity range
+        if intensity < 0.0 or intensity > 1.0:
+            return False, "Light intensity setting failed. " \
+                          "Intensity = %f is out of range." % intensity
+        if name == 'left':
+            self.light_msg.paramName = 'spotlightIntensityScale[0]'
+        elif name == 'right':
+            self.light_msg.paramName = 'spotlightIntensityScale[1]'
+        else:
+            return False, 'Light intensity setting failed. ' \
+                          '\'%s\' is not a light indentifier.' % name
+        self.light_msg.paramValue = str(intensity)
+        self.light_pub.publish(self.light_msg)
+        return True, '%s light intensity setting succeeded.' % name
+
+    def on_light_set_intensity_action(self, goal):
+        self._result.success, self._result.message = self._set_light_intensity(goal)
+        if self._result.success:
+            rospy.loginfo('%s: Succeeded' % self._action_name)
+            self._server.set_succeeded(self._result)
+        else:
+            rospy.loginfo('%s: Failed' % self._action_name)
+            self._server.set_aborted(self._result)
+
+if __name__ == '__main__':
+    SERVER_NAME = 'LightSetIntensity'
+    rospy.init_node(SERVER_NAME)
+    server = LightSetIntensityActionServer(SERVER_NAME)
+    rospy.spin()

--- a/ow_lander/scripts/light_set_intensity_action_server.py
+++ b/ow_lander/scripts/light_set_intensity_action_server.py
@@ -12,56 +12,56 @@ from irg_gazebo_plugins.msg import ShaderParamUpdate
 
 class LightSetIntensityActionServer(object):
 
-    def __init__(self, name):
-        # light shader interface setup
-        self.light_pub = rospy.Publisher(
-            "/gazebo/global_shader_param",
-            ShaderParamUpdate,
-            queue_size=1
-        )
-        self.light_msg = ShaderParamUpdate()
-        self.light_msg.shaderType = ShaderParamUpdate.SHADER_TYPE_FRAGMENT
-        # action server setup
-        self._action_name = name
-        self._fdbk = ow_lander.msg.LightSetIntensityFeedback()
-        self._result = ow_lander.msg.LightSetIntensityResult()
-        self._server = actionlib.SimpleActionServer(
-            self._action_name,
-            ow_lander.msg.LightSetIntensityAction,
-            execute_cb=self.on_light_set_intensity_action,
-            auto_start=False
-        )
-        self._server.start()
+  def __init__(self, name):
+    # light shader interface setup
+    self.light_pub = rospy.Publisher(
+      "/gazebo/global_shader_param",
+      ShaderParamUpdate,
+      queue_size=1
+    )
+    self.light_msg = ShaderParamUpdate()
+    self.light_msg.shaderType = ShaderParamUpdate.SHADER_TYPE_FRAGMENT
+    # action server setup
+    self._action_name = name
+    self._fdbk = ow_lander.msg.LightSetIntensityFeedback()
+    self._result = ow_lander.msg.LightSetIntensityResult()
+    self._server = actionlib.SimpleActionServer(
+      self._action_name,
+      ow_lander.msg.LightSetIntensityAction,
+      execute_cb=self.on_light_set_intensity_action,
+      auto_start=False
+    )
+    self._server.start()
 
-    def _set_light_intensity(self, goal):
-        name = goal.name.lower() # make case insentive
-        intensity = goal.intensity
-        # check intensity range
-        if intensity < 0.0 or intensity > 1.0:
-            return False, "Light intensity setting failed. " \
-                          "Intensity = %f is out of range." % intensity
-        if name == 'left':
-            self.light_msg.paramName = 'spotlightIntensityScale[0]'
-        elif name == 'right':
-            self.light_msg.paramName = 'spotlightIntensityScale[1]'
-        else:
-            return False, 'Light intensity setting failed. ' \
-                          '\'%s\' is not a light indentifier.' % name
-        self.light_msg.paramValue = str(intensity)
-        self.light_pub.publish(self.light_msg)
-        return True, '%s light intensity setting succeeded.' % name
+  def _set_light_intensity(self, goal):
+    name = goal.name.lower() # make case insentive
+    intensity = goal.intensity
+    # check intensity range
+    if intensity < 0.0 or intensity > 1.0:
+      return False, "Light intensity setting failed. " \
+                    "Intensity = %f is out of range." % intensity
+    if name == 'left':
+      self.light_msg.paramName = 'spotlightIntensityScale[0]'
+    elif name == 'right':
+      self.light_msg.paramName = 'spotlightIntensityScale[1]'
+    else:
+      return False, 'Light intensity setting failed. ' \
+                    '\'%s\' is not a light indentifier.' % name
+    self.light_msg.paramValue = str(intensity)
+    self.light_pub.publish(self.light_msg)
+    return True, '%s light intensity setting succeeded.' % name
 
-    def on_light_set_intensity_action(self, goal):
-        self._result.success, self._result.message = self._set_light_intensity(goal)
-        if self._result.success:
-            rospy.loginfo('%s: Succeeded' % self._action_name)
-            self._server.set_succeeded(self._result)
-        else:
-            rospy.loginfo('%s: Failed' % self._action_name)
-            self._server.set_aborted(self._result)
+  def on_light_set_intensity_action(self, goal):
+    self._result.success, self._result.message = self._set_light_intensity(goal)
+    if self._result.success:
+      rospy.loginfo('%s: Succeeded' % self._action_name)
+      self._server.set_succeeded(self._result)
+    else:
+      rospy.loginfo('%s: Failed' % self._action_name)
+      self._server.set_aborted(self._result)
 
 if __name__ == '__main__':
-    SERVER_NAME = 'LightSetIntensity'
-    rospy.init_node(SERVER_NAME)
-    server = LightSetIntensityActionServer(SERVER_NAME)
-    rospy.spin()
+  SERVER_NAME = 'LightSetIntensity'
+  rospy.init_node(SERVER_NAME)
+  server = LightSetIntensityActionServer(SERVER_NAME)
+  rospy.spin()


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-933](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-933) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-935](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-935) |
| Github :octocat:  | # |


## Summary of Changes
* Lander light set intensity ROS Action added. 

## Test
1. Launch the world of your choice.
`roslaunch ow atacama_y1a.launch`
2. Tilt mast down so that lander lights are easily visible against the lander body.
`./antenna_pan_tilt_action_client.py 0.0 1.5`
3. Test action client's help message. You should see a brief description of the client, and its arguments.
`./light_set_intensity_action_client.py --help`
4. Test changing the values of both lights as you'd like, i.e. 
```
./light_set_intensity_action_client.py left 0.6
./light_set_intensity_action_client.py right 0.2
```
![default_gzclient_camera(1)-2022-09-27T13_26_54 125583](https://user-images.githubusercontent.com/17039973/192617874-0dc37e36-b82c-4c3c-aec4-01d1a1b30319.jpg)
5. Test providing action client with incorrect values. 
`./light_set_intensity_action_client.py up 0.2`
should result in 
```
usage: light_set_intensity_action_client.py [-h]
                                            [{left,right}]
                                            [intensity]
light_set_intensity_action_client.py: error: argument name: invalid choice: 'up' (choose from 'left', 'right')
```
and `./light_set_intensity_action_client.py left 1.1`
should result in 
```
[INFO] [1664306976.072555, 0.000000]: Requested name value: left
[INFO] [1664306976.073066, 0.000000]: Requested intensity value: 1.1
[INFO] [1664306976.128867, 1916525007.625000]: Result: success: False
message: "Light intensity setting failed. Intensity = 1.100000 is out of range."
```