### PR TITLE
OCEANWATER-1067 Naive solution to scoop pushback

### DIFF
--- a/ow_gazebo_plugins/src/BalovnevModelPlugin/BalovnevModelPlugin.cpp
+++ b/ow_gazebo_plugins/src/BalovnevModelPlugin/BalovnevModelPlugin.cpp
@@ -91,6 +91,7 @@ void BalovnevModelPlugin::Load(physics::ModelPtr model, sdf::ElementPtr sdf)
   );
 
   resetForces();
+  resetDepth();
 
   m_dig_timeout = m_node_handle->createTimer(
     DIG_TIMEOUT_INTERVAL, &BalovnevModelPlugin::onDigTimeout, this, true, false
@@ -99,14 +100,25 @@ void BalovnevModelPlugin::Load(physics::ModelPtr model, sdf::ElementPtr sdf)
   gzlog << "BavlovnevModelPlugin - successfully loaded" <<endl;
 }
 
-
 void BalovnevModelPlugin::onUpdate()
 {
+  if (!isScoopDigging())
+    return;
+
   if(!m_link) {
     gzwarn << " m_link is invalid." << endl;
     return;
   }
-  // DEBUG DISABLED
+  // check for pushback
+  const Vector3 SCOOP_FORWARD = Vector3(1.0, 0.0, 0.0);
+  auto link_vel = m_link->RelativeLinearVel();
+  if (link_vel.Dot(SCOOP_FORWARD) < 0.0) {
+    // reset force if pushback occurs
+    resetForces();
+    m_link->ResetPhysicsStates();
+  }
+  if (m_horizontal_force == 0.0 || m_vertical_force == 0.0)
+    return; // no force to apply, early return
   m_link->AddRelativeForce(
     ignition::math::Vector3d(-m_horizontal_force, 0, m_vertical_force)
   );
@@ -182,9 +194,11 @@ void BalovnevModelPlugin::resetForces()
   m_vertical_force = 0.0;
   m_horizontal_force = 0.0;
   publishForces();
+}
+
+void BalovnevModelPlugin::resetDepth() {
   // reset moving average
   m_moving_max_depth->clear();
-
   // DEBUG CODE
   static std_msgs::Float64 depth;
   depth.data = 0.0;
@@ -252,4 +266,5 @@ void BalovnevModelPlugin::onModDiffVisualMsg(
 void BalovnevModelPlugin::onDigTimeout(const TimerEvent &)
 {
   resetForces();
+  resetDepth();
 }

--- a/ow_gazebo_plugins/src/BalovnevModelPlugin/BalovnevModelPlugin.h
+++ b/ow_gazebo_plugins/src/BalovnevModelPlugin/BalovnevModelPlugin.h
@@ -42,6 +42,8 @@ private:
 
   void resetForces();
 
+  void resetDepth();
+
   bool isScoopDigging();
 
   void onModDiffVisualMsg(


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-1069](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1069) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1067](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1067) |

## Summary of Changes
* During a dig when the scoop's velocity reverses direction, the Balovnev forces will be set to zero. 

## Test
Repeat essentially the same test for [PR#277](https://github.com/nasa/ow_simulator/pull/277), only watching the `balovnev_analysis.perspective` is optional.
1. Call an unstow, grind, and a shallow dig. 
`./unstow_action_client.py && ./grind_action_client.py && ./dig_linear_action_client.py 1.46 0.0 0.01 0.1 -0.1`
The scoop should make it through the material with no trouble. 
2. Call a deeper dig 
`./dig_linear_action_client.py 1.46 0.0 0.01 0.1 -0.2`
Unlike the test for [PR#277](https://github.com/nasa/ow_simulator/pull/277), the scoop should now stall rather than move in reverse. Despite struggling, it should still complete the dig trajectory. 
