### PR TITLE
Oceanwater 1039 Regolith less likely to be flung out of sample dock

### DIFF
--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -21,7 +21,7 @@
 
   <xacro:include filename="$(find ow_lander)/urdf/lander_sample_dock.xacro" />
   <xacro:lander_sample_dock lander_sample_dock_parent_link="base_link"
-                     off_x="0.5226" off_y="-0.35" off_z="0.32" off_R="-${pi/2.0}" off_P="0.0" off_Y="-${pi/2.0}"
+                     off_x="0.5476" off_y="-0.35" off_z="0.32" off_R="-${pi/2.0}" off_P="0.0" off_Y="-${pi/2.0}"
                      vis_mask="${vis_mask}" />
 
   <xacro:arg name="freeze_base_link" default="false"/>

--- a/ow_lander/urdf/lander_sample_dock.xacro
+++ b/ow_lander/urdf/lander_sample_dock.xacro
@@ -30,14 +30,15 @@
 
   <xacro:macro name="lander_sample_dock_link" params="suffix roll pitch y">
     <link name="lander_sample_dock${suffix}">
+
       <collision>
-        <origin rpy="0 0 0" xyz="0 0 0.025"/>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
         <geometry>
           <mesh filename="package://ow_lander/meshes/sample_dock.stl" />
         </geometry>
       </collision>
       <visual>
-        <origin rpy="0 0 0" xyz="0 0 0.025"/>
+        <origin rpy="0 0 0" xyz="0 0 0.0"/>
         <geometry>
           <mesh filename="package://ow_lander/meshes/sample_dock.stl" />
         </geometry>
@@ -46,7 +47,7 @@
         </material>
       </visual>
       <inertial>
-        <origin rpy="0 0 0" xyz="0 0 0.05"/>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
         <mass value="0.01"/>
         <inertia
             ixx="${sample_dock_mass * 0.000001}" ixy="0.0" ixz="0.0"

--- a/ow_lander/urdf/lander_sample_dock.xacro
+++ b/ow_lander/urdf/lander_sample_dock.xacro
@@ -31,12 +31,59 @@
   <xacro:macro name="lander_sample_dock_link" params="suffix roll pitch y">
     <link name="lander_sample_dock${suffix}">
 
-      <collision>
+      <!-- <collision>
         <origin rpy="0 0 0" xyz="0 0 0"/>
         <geometry>
           <mesh filename="package://ow_lander/meshes/sample_dock.stl" />
         </geometry>
+      </collision> -->
+
+      <!-- dock bottom -->
+      <collision>
+        <origin
+          xyz="0 0.0197015 0"
+          rpy="0 0 0" />
+        <geometry>
+          <box size="0.3 0.010597 0.095"/>
+        </geometry>
       </collision>
+      <!-- dock +z wall -->
+      <collision>
+        <origin
+          xyz="0 0 0.04275"
+          rpy="0 0 0" />
+        <geometry>
+          <box size="0.3 0.05 0.0095"/>
+        </geometry>
+      </collision>
+      <!-- dock -z wall -->
+      <collision>
+        <origin
+          xyz="0 0 -0.04275"
+          rpy="0 0 0" />
+        <geometry>
+          <box size="0.3 0.05 0.0095"/>
+        </geometry>
+      </collision>
+      <!-- dock +x wall -->
+      <collision>
+        <origin
+          xyz="0.1425 0 0"
+          rpy="0 0 0" />
+        <geometry>
+          <box size="0.015 0.05 0.095"/>
+        </geometry>
+      </collision>
+      <!-- dock -x wall -->
+      <collision>
+        <origin
+          xyz="-0.1425 0 0"
+          rpy="0 0 0" />
+        <geometry>
+          <box size="0.015 0.05 0.095"/>
+        </geometry>
+      </collision>
+
       <visual>
         <origin rpy="0 0 0" xyz="0 0 0.0"/>
         <geometry>

--- a/ow_lander/urdf/lander_sample_dock.xacro
+++ b/ow_lander/urdf/lander_sample_dock.xacro
@@ -31,13 +31,6 @@
   <xacro:macro name="lander_sample_dock_link" params="suffix roll pitch y">
     <link name="lander_sample_dock${suffix}">
 
-      <!-- <collision>
-        <origin rpy="0 0 0" xyz="0 0 0"/>
-        <geometry>
-          <mesh filename="package://ow_lander/meshes/sample_dock.stl" />
-        </geometry>
-      </collision> -->
-
       <!-- dock bottom -->
       <collision>
         <origin
@@ -108,7 +101,6 @@
       <parent link="lander_sample_dock_link"/>
       <child link="lander_sample_dock${suffix}"/>
     </joint>
-    
     
     <gazebo reference="lander_sample_dock${suffix}">
       <visual>

--- a/ow_regolith/models/sphere_2cm/model.sdf
+++ b/ow_regolith/models/sphere_2cm/model.sdf
@@ -19,9 +19,10 @@
 
       <collision name="collision">
         <geometry>
-          <sphere>
-            <radius>0.01</radius>
-          </sphere>
+          <box>
+            <!-- a cube with a diagonal equal to the visual sphere's radius -->
+            <size>0.011547 0.011547 0.011547</size>
+          </box>
         </geometry>
         <surface>
           <contact>

--- a/ow_sim_tests/test/sample_collection.py
+++ b/ow_sim_tests/test/sample_collection.py
@@ -341,7 +341,6 @@ class SampleCollection(unittest.TestCase):
   the final portion when it is dumped into the sample dock. Upon completion of
   the operation it also asserts that regolith models are deleted.
   """
-  @unittest.expectedFailure
   def test_07_deliver(self):
     deliver_result = test_arm_action(self,
       'Deliver', ow_lander.msg.DeliverAction,
@@ -380,7 +379,6 @@ class SampleCollection(unittest.TestCase):
   Test the ingest sample action. Upon completion, ensure no sample remains in
   the simulation.
   """
-  @unittest.expectedFailure
   def test_10_ingest_sample(self):
     ingest_result = test_action(self,
       'DockIngestSampleAction', ow_lander.msg.DockIngestSampleAction,


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | n/a |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1039](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1039) |

This change reduces the likelihood, but I suspect does not entirely solve the problem because there was one instance during testing when I saw the scoop rapidly change orientation for only a single frame when no sample was in it. It's not clear why it does this since it is on a fixed mount attached to the lander. 

## Summary of Changes
* Sample dock's implementation in the lander.xacro simplified
* `expectedFailure` decorator removed from some unit tests in **sample collection**
* Greatly reduced likelihood of sample getting flung out of sample dock by
  * Switching the collision model of regolith to that of a cube
  * Switching the collision model of the sample dock from a mesh to a collection of boxes
_These two changes together were required to reduce sample flinging. They were also tested individually, but those tests did not reduce the likelihood of sample being flung._

## Test
Run the **sample collection** test a minimum of 3 times. 
```
rostest ow_sim_tests sample_collection.test
``` 
It is fine to increase speed during these tests in the GUI or from a second terminal
```
gz physics -u 1200
```
Any failures you see should only arise from the deliver step, when all of the regolith fails to fall into the dock, which may cause either **Test 7** or **Test 10** to fail. This problem is out of scope for this PR.

## Caveat
The box collision model allows the visual sphere mesh of regolith to poke through the bottom of the scoop.
![default_gzclient_camera(1)-2022-11-14T17_23_26 717565](https://user-images.githubusercontent.com/17039973/201796010-1d64d3d2-e772-49ea-945d-4e339e1c9452.jpg)

