### PR TITLE
Action condition failures wait for action completion

### DIFF
--- a/ow_sim_tests/test/action_testing.py
+++ b/ow_sim_tests/test/action_testing.py
@@ -101,14 +101,9 @@ def test_action_noyaml(test_object, action_name, action, goal, max_duration,
   client.send_goal(goal)
   # monitor for failed conditions during action execution
   start = rospy.get_time()
-  elapsed = 0.0
   condition_failure = None
   while not is_action_done(client):
     rospy.sleep(condition_check_interval)
-    elapsed = rospy.get_time() - start
-    if elapsed > max_duration:
-      # TODO: preempt the action here if possible
-      break
     # catch the first failure only
     if condition_failure is None:
       try:
@@ -116,13 +111,13 @@ def test_action_noyaml(test_object, action_name, action, goal, max_duration,
       except AssertionError as failure:
         condition_failure = failure
 
+  elapsed = rospy.get_time() - start
   # only fail the test when the action has completed or timed out
   if not condition_failure is None:
     raise condition_failure
-
   test_object.assertLess(
     elapsed, max_duration,
-    "Timeout reached waiting for %s action to finish!" % action_name
+    "Action %s took longer than expected to finish!" % action_name
   )
   return client.get_result(), elapsed
 


### PR DESCRIPTION
## Summary of Changes
* A condition failure will not be raised until the action completes
* Overtime actions are now allowed to complete

## Test
Run the two action calling tests. Testing the failure conditions is unnecessary and may be difficult. Just make sure the tests execute normally. If a failure does happen to occur (i.e. regolith falls out of scoop during a dig/transfer) you should still see the action complete.
1. Run sample collection test
```
rostest ow_sim_tests sample_collection.test
```
2. Run arm check action test
```
rostest ow_sim_tests arm_check_action.test
```
