### PR TITLE
limit camera fault detection to timer

### DIFF
--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -143,8 +143,12 @@ private:
   bool m_tilt_fault;
   
   // Camera
-  ros::Time m_cam_raw_time;
-  ros::Time m_cam_trigger_time;
+  bool m_camera_data_pending = false;
+  // Camera faults are currently defined by subsequent trigger topics received 
+  //  without an expected raw topic. A possible fault case could be if the 
+  //  topics arrive after a threshold, recording topic timestamps with the following.
+  // ros::Time m_cam_raw_time;
+  // ros::Time m_cam_trigger_time;
   
   // Power
   float m_last_SOC = std::numeric_limits<float>::quiet_NaN();

--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -125,6 +125,7 @@ private:
   ros::Subscriber m_joint_states_sub;
 
   // Camera
+  const ros::Duration CAMERA_RESPONSE_THRESHOLD = ros::Duration(2);
   ros::Timer m_camera_trigger_timer;
   ros::Subscriber m_camera_original_trigger_sub;
   ros::Subscriber m_camera_raw_sub;

--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -125,7 +125,6 @@ private:
   ros::Subscriber m_joint_states_sub;
 
   // Camera
-  const ros::Duration CAMERA_RESPONSE_THRESHOLD = ros::Duration(2);
   ros::Timer m_camera_trigger_timer;
   ros::Subscriber m_camera_original_trigger_sub;
   ros::Subscriber m_camera_raw_sub;

--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -144,11 +144,6 @@ private:
   
   // Camera
   bool m_camera_data_pending = false;
-  // Camera faults are currently defined by subsequent trigger topics received 
-  //  without an expected raw topic. A possible fault case could be if the 
-  //  topics arrive after a threshold, recording topic timestamps with the following.
-  // ros::Time m_cam_raw_time;
-  // ros::Time m_cam_trigger_time;
   
   // Power
   float m_last_SOC = std::numeric_limits<float>::quiet_NaN();

--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -95,7 +95,7 @@ private:
   // Camera
   void camerTriggerCb(const std_msgs::Empty& msg);
   void cameraRawCb(const sensor_msgs::Image& msg);
-  void cameraTriggerPublishCb(const ros::TimerEvent& t);
+  void cameraPublishFaultMessages(bool isFault);
 
   // Power
   void publishPowerSystemFault();
@@ -125,7 +125,6 @@ private:
   ros::Subscriber m_joint_states_sub;
 
   // Camera
-  ros::Timer m_camera_trigger_timer;
   ros::Subscriber m_camera_original_trigger_sub;
   ros::Subscriber m_camera_raw_sub;
 

--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -95,7 +95,7 @@ private:
   // Camera
   void camerTriggerCb(const std_msgs::Empty& msg);
   void cameraRawCb(const sensor_msgs::Image& msg);
-  void cameraPublishFaultMessages(bool isFault);
+  void cameraPublishFaultMessages(bool is_fault);
 
   // Power
   void publishPowerSystemFault();

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -21,9 +21,6 @@ constexpr bitset<3> FaultDetector::islowVoltageError;
 constexpr bitset<3> FaultDetector::isCapLossError;
 constexpr bitset<3> FaultDetector::isThermalError;
 
-// Not currently in use, see notes with camera members in FaultDetctor.h
-// const ros::Duration CAMERA_RESPONSE_THRESHOLD = ros::Duration(2);
-
 FaultDetector::FaultDetector(ros::NodeHandle& nh)
 {
   srand (static_cast <unsigned> (time(0)));
@@ -213,9 +210,6 @@ void FaultDetector::antPublishFaultMessages()
 //// Camera listeners
 void FaultDetector::camerTriggerCb(const std_msgs::Empty& msg)
 {
-  // Not currently in use, see notes with member declaration in FaultDetctor.h
-  // m_cam_trigger_time = ros::Time::now();
-
   // fault if camera data is still pending when trigger is received
   if (m_camera_data_pending) {
     cameraPublishFaultMessages(true);
@@ -225,13 +219,7 @@ void FaultDetector::camerTriggerCb(const std_msgs::Empty& msg)
 
 void FaultDetector::cameraRawCb(const sensor_msgs::Image& msg)
 {
-  // Not currently in use, see notes with member declaration in FaultDetctor.h
-  // m_cam_raw_time = ros::Time::now();
-  
-  // fault if camera data took too long to arrive
-  // bool is_camera_data_stale 
-  //   = m_cam_raw_time - m_cam_trigger_time > CAMERA_RESPONSE_THRESHOLD;
-  // cameraPublishFaultMessages(is_camera_data_stale);
+  // exonerate fault when camera_raw data is received
   cameraPublishFaultMessages(false);
   m_camera_data_pending = false;
 }

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -93,17 +93,17 @@ void FaultDetector::publishSystemFaultsMessage()
 }
 
 //// Publish Camera Messages
-void FaultDetector::cameraPublishFaultMessages(bool isFault)
+void FaultDetector::cameraPublishFaultMessages(bool is_fault)
 {
   ow_faults_detection::CamFaults camera_faults_msg;
-  if (isFault) {
-    ROS_ERROR("Camera Fault");
+  if (is_fault) {
     m_system_faults_bitset |= isCamExecutionError;
     setComponentFaultsMessage(camera_faults_msg, ComponentFaults::Hardware);
   } else {
     m_system_faults_bitset &= ~isCamExecutionError;
   }
   publishSystemFaultsMessage();
+  m_camera_fault_msg_pub.publish(camera_faults_msg);
 }
 
 //// Publish Power Faults Messages

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -21,8 +21,8 @@ constexpr bitset<3> FaultDetector::islowVoltageError;
 constexpr bitset<3> FaultDetector::isCapLossError;
 constexpr bitset<3> FaultDetector::isThermalError;
 
-static bool camera_data_pending = false;
-const ros::Duration CAMERA_RESPONSE_THRESHOLD = ros::Duration(2);
+// Not currently in use, see notes with camera members in FaultDetctor.h
+// const ros::Duration CAMERA_RESPONSE_THRESHOLD = ros::Duration(2);
 
 FaultDetector::FaultDetector(ros::NodeHandle& nh)
 {
@@ -213,24 +213,27 @@ void FaultDetector::antPublishFaultMessages()
 //// Camera listeners
 void FaultDetector::camerTriggerCb(const std_msgs::Empty& msg)
 {
-  m_cam_trigger_time = ros::Time::now();
+  // Not currently in use, see notes with member declaration in FaultDetctor.h
+  // m_cam_trigger_time = ros::Time::now();
 
   // fault if camera data is still pending when trigger is received
-  if (camera_data_pending) {
+  if (m_camera_data_pending) {
     cameraPublishFaultMessages(true);
   }
-  camera_data_pending = true;
+  m_camera_data_pending = true;
 }
 
 void FaultDetector::cameraRawCb(const sensor_msgs::Image& msg)
 {
-  m_cam_raw_time = ros::Time::now();
+  // Not currently in use, see notes with member declaration in FaultDetctor.h
+  // m_cam_raw_time = ros::Time::now();
   
   // fault if camera data took too long to arrive
-  bool is_camera_data_stale 
-    = m_cam_raw_time - m_cam_trigger_time > CAMERA_RESPONSE_THRESHOLD;
-  cameraPublishFaultMessages(is_camera_data_stale);
-  camera_data_pending = false;
+  // bool is_camera_data_stale 
+  //   = m_cam_raw_time - m_cam_trigger_time > CAMERA_RESPONSE_THRESHOLD;
+  // cameraPublishFaultMessages(is_camera_data_stale);
+  cameraPublishFaultMessages(false);
+  m_camera_data_pending = false;
 }
 
 //// Power Topic Listeners

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -41,8 +41,8 @@ FaultDetector::FaultDetector(ros::NodeHandle& nh)
                                    this);
   
   m_camera_trigger_timer = nh.createTimer( CAMERA_RESPONSE_THRESHOLD, 
-                                           &FaultDetector::cameraTriggerPublishCb, 
-                                           this, true, false);
+                                           &FaultDetector::cameraTriggerPublishCb,this,
+                                           true, false); // oneshot, autostart
 
   //  power fault publishers and subs
   m_power_soc_sub = nh.subscribe( "/power_system_node/state_of_charge",

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -227,10 +227,8 @@ void FaultDetector::cameraRawCb(const sensor_msgs::Image& msg)
   m_cam_raw_time = ros::Time::now();
   
   // fault if camera data took too long to arrive
-  bool is_camera_data_stale = false;
-  if (m_cam_raw_time - m_cam_trigger_time > CAMERA_RESPONSE_THRESHOLD) {
-    is_camera_data_stale = true;
-  }
+  bool is_camera_data_stale 
+    = m_cam_raw_time - m_cam_trigger_time > CAMERA_RESPONSE_THRESHOLD;
   cameraPublishFaultMessages(is_camera_data_stale);
   camera_data_pending = false;
 }


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️ | [OCEANWATER-1077](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1077) |
| Jira Ticket 🎟️ | [OCEANWATER-1086](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1086) |

Bugfix for issues with camera fault detection that was causing spurious warnings and intermittent fault reports when camera faults where not injected. The issue seemed to stem from asynchronicity in the timer-triggered fault detection routine and the intervals in which camera trigger and camera raw data where being reported.

## Summary of Changes
* Defined a threshold constant for maximum allowed time delay between a camera_trigger message and camera_raw message.
* Simplified the error checking inequality to use the threshold constant.
* ~~Changed error checking callback to only run after a camera trigger, and with time enough to permit receiving a camera raw message within the threshold.~~
* Changed the error checking logic to primarily be based on subsequent image_trigger msgs received without a image_raw msg.

## Test
To test according to [OCEANWATER-1086](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1086)
* Launch 3 terminals sourced with the build.
* In terminal 1, launch the sim (ie: `roslaunch ow atacama_y1a.launch`)
* In terminal 2, launch the plexil node with `roslaunch ow_plexil ow_exec.launch`
* In terminal 3, monitor the system fault topic with `rostopic echo /faults/system_fault_status`
* After terminal 1 and 2 are finished initializing, run the **TestAntennaCamera** plan in rqt -> PlexilPlanSelection.
* Observe that the plan completes without error.
* Do not yet close the terminals and proceed to next test.

To test according to [OCEANWATER-1077](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1077)
* Inject the camera trigger failure fault in rqt -> Dynamic Reconfigure -> faults
* Trigger the camera topic in rqt -> Control and Viz -> /StereoCamera/left/image_trigger
* After a few seconds, observe the error value `32` in terminal 3
* Deactivate the camera trigger topic.
* Deactivate the camera trigger fault.
* Trigger the camera topic again.
* After a few seconds, observe the error value clearing back to `0` in terminal 3 and remaining clear.
