### PR TITLE
Oceanwater 1017 arm antenna telemetry unification

### DIFF
--- a/ow_lander/launch/spawn.launch
+++ b/ow_lander/launch/spawn.launch
@@ -114,4 +114,7 @@
     type="camera_capture_action_server.py"
     launch-prefix="bash -c 'sleep $(arg node_start_delay); $0 $@' "
     output="screen"/>
+
+  <!-- == launch the state repackaging node ============== -->
+  <node pkg="ow_lander" name="state_publisher" type="state_publisher.py" output="screen"/>
 </launch>

--- a/ow_lander/scripts/state_publisher.py
+++ b/ow_lander/scripts/state_publisher.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import rospy
+from sensor_msgs.msg import JointState
+from owl_msgs.msg import ArmJointPositions, ArmJointTorques, ArmJointVelocities, PanTiltPosition
+
+class StatePublisher(object):
+
+  def __init__(self, name):
+    self._joint_pos = ArmJointPositions()
+    self._joint_tor = ArmJointTorques()
+    self._joint_vel = ArmJointVelocities()
+    self._pan_tilt = PanTiltPosition()
+
+    self._subscriber = rospy.Subscriber(
+            '/joint_states', JointState, self._handle_joint_states)
+    self._arm_joint_positions_pub = rospy.Publisher(
+            '/arm_joint_positions', ArmJointPositions, queue_size=10)
+    self._arm_joint_torques_pub = rospy.Publisher(
+            '/arm_joint_torques', ArmJointTorques, queue_size=10)
+    self._arm_joint_velocities_pub = rospy.Publisher(
+            '/arm_joint_velocities', ArmJointVelocities, queue_size=10)
+    self._pan_tilt_pub = rospy.Publisher(
+            '/pan_tilt_position', PanTiltPosition, queue_size=10)
+
+  def _handle_joint_states(self, data):
+    """
+    :type data: sensor_msgs.msg.JointState
+    """
+    # Check for compatible input and output array sizes
+    if len(data.position) != len(self._joint_pos.value) + len(self._pan_tilt.value) :
+      rospy.logerr_throttle(1, 'StatePublisher: Array size mismatch')
+      return
+
+    self._joint_pos.header = data.header
+    self._joint_pos.value = data.position[2 : len(data.position)]
+    self._arm_joint_positions_pub.publish(self._joint_pos)
+
+    self._joint_tor.header = data.header
+    self._joint_tor.value = data.effort[2 : len(data.effort)]
+    self._arm_joint_torques_pub.publish(self._joint_tor)
+
+    self._joint_vel.header = data.header
+    self._joint_vel.value = data.velocity[2 : len(data.velocity)]
+    self._arm_joint_velocities_pub.publish(self._joint_vel)
+
+    self._pan_tilt.header = data.header
+    self._pan_tilt.value = data.position[0 : 2]
+    self._pan_tilt_pub.publish(self._pan_tilt)
+
+if __name__ == '__main__':
+    node_name = 'state_publisher'
+    rospy.init_node(node_name)
+    state_publisher = StatePublisher(node_name)
+    rospy.spin()

--- a/owl_msgs/CMakeLists.txt
+++ b/owl_msgs/CMakeLists.txt
@@ -48,6 +48,10 @@ find_package(catkin REQUIRED COMPONENTS
 ## Generate messages in the 'msg' folder
 add_message_files(
   FILES
+  ArmJointPositions.msg
+  ArmJointTorques.msg
+  ArmJointVelocities.msg
+  PanTiltPosition.msg
   SystemFaultsStatus.msg
 )
 

--- a/owl_msgs/msg/ArmJointPositions.msg
+++ b/owl_msgs/msg/ArmJointPositions.msg
@@ -1,0 +1,2 @@
+Header header
+float64[7] value

--- a/owl_msgs/msg/ArmJointTorques.msg
+++ b/owl_msgs/msg/ArmJointTorques.msg
@@ -1,0 +1,2 @@
+Header header
+float64[7] value

--- a/owl_msgs/msg/ArmJointVelocities.msg
+++ b/owl_msgs/msg/ArmJointVelocities.msg
@@ -1,0 +1,2 @@
+Header header
+float64[7] value

--- a/owl_msgs/msg/PanTiltPosition.msg
+++ b/owl_msgs/msg/PanTiltPosition.msg
@@ -1,0 +1,2 @@
+Header header
+float64[2] value


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-934](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-934) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1017](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1017) |


## Summary of Changes
* Publish specific arm and antenna state messages to unify with OWLAT interface

## Test
* Launch OceanWATERS sim and `rostopic echo` the following topics:
  * /arm_joint_positions
  * /arm_joint_torques
  * /arm_joint_velocities
  * /pan_tilt_position
