### PR TITLE
Remove obsolete light transform bug workaround

### DIFF
--- a/ow_lander/urdf/lander_lights.xacro
+++ b/ow_lander/urdf/lander_lights.xacro
@@ -73,8 +73,6 @@
         </plugin>
       </visual>
       <light name="lander_light_light${suffix}" type="spot">
-        <!-- Light is not transformed by the joint above, so we transform it here. -->
-        <pose>0 ${y} 0 ${roll} ${pitch} 0</pose>
         <diffuse>1 1 1 1</diffuse>
         <attenuation>
           <range>100</range>


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️ | [OCEANWATER-1089](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1089) |


## Test
* Launch OceanWATERS without this branch and observe that the wireframe light frusta are not connected to the light model cylinders on the antenna.
* Check out this branch and observe that the light frusta are no in the right place.
* Tilt the light and see that the light beams are projected in the right place: `rostopic pub -1 /ant_tilt_position_controller/command std_msgs/Float64 1.4`