### PR TITLE
update pan tilt artifacts to unified telemetry standard

### DIFF
--- a/ow_faults_detection/CMakeLists.txt
+++ b/ow_faults_detection/CMakeLists.txt
@@ -53,7 +53,6 @@ find_package(catkin REQUIRED COMPONENTS
 add_message_files(
   FILES
   PowerFaults.msg
-  PTFaults.msg
   JointStatesFlag.msg
 )
 

--- a/ow_faults_detection/README.md
+++ b/ow_faults_detection/README.md
@@ -24,7 +24,7 @@ include a system fault message that aggregates the states.
 
 Antenna Faults: `/faults/pt_faults_status`
 Arm Faults: `/arm_faults_status`
-Force-Torque Sensor Faults: `/faults/pt_faults_status`
+Force-Torque Sensor Faults: `/pan_tilt_faults_status`
 Power Faults: `/faults/power_faults_status`
 Camera Faults: `/camera_faults_status`
 System Faults: `/system_faults_status`

--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -16,7 +16,7 @@
 #include <owl_msgs/SystemFaultsStatus.h>
 #include <owl_msgs/ArmFaultsStatus.h>
 #include "ow_faults_detection/PowerFaults.h"
-#include "ow_faults_detection/PTFaults.h"
+#include <owl_msgs/PanTiltFaultsStatus.h>
 #include <owl_msgs/CameraFaultsStatus.h>
 #include <ow_lander/lander_joints.h>
 #include <sensor_msgs/JointState.h>

--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -86,7 +86,7 @@ private:
   
   // faults topic publishers
   ros::Publisher m_arm_faults_msg_pub;
-  ros::Publisher m_antenna_fault_msg_pub;
+  ros::Publisher m_antenna_faults_msg_pub;
   ros::Publisher m_camera_faults_msg_pub;
   ros::Publisher m_power_fault_msg_pub;
   ros::Publisher m_system_faults_msg_pub;

--- a/ow_faults_detection/msg/PTFaults.msg
+++ b/ow_faults_detection/msg/PTFaults.msg
@@ -1,4 +1,0 @@
-# The 'value' field is either 0 (no fault) or 1 (hardware error).
-
-Header header
-uint32 value

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -48,7 +48,7 @@ FaultDetector::FaultDetector(ros::NodeHandle& nh)
 
   // topics for OWLAT/JPL msgs: system fault messages, see owl_msgs/msg
   m_arm_faults_msg_pub = nh.advertise<owl_msgs::ArmFaultsStatus>("/arm_faults_status", 10);
-  m_antenna_fault_msg_pub = nh.advertise<ow_faults_detection::PTFaults>("/faults/pt_faults_status", 10);
+  m_antenna_fault_msg_pub = nh.advertise<owl_msgs::PanTiltFaultsStatus>("/pan_tilt_faults_status", 10);
   m_camera_faults_msg_pub = nh.advertise<owl_msgs::CameraFaultsStatus>("/camera_faults_status", 10);
   m_power_fault_msg_pub = nh.advertise<ow_faults_detection::PowerFaults>("/faults/power_faults_status", 10);
   m_system_faults_msg_pub = nh.advertise<owl_msgs::SystemFaultsStatus>("/system_faults_status", 10);
@@ -179,7 +179,7 @@ bool FaultDetector::findJointIndex(const unsigned int joint, unsigned int& out_i
 //// Antenna Listeners
 void FaultDetector::antPublishFaultMessages()
 {
-  ow_faults_detection::PTFaults ant_fault_msg;
+  owl_msgs::PanTiltFaultsStatus ant_fault_msg;
   if (m_pan_fault || m_tilt_fault) {
     m_system_faults_flags |= SystemFaultsStatus::PAN_TILT_EXECUTION_ERROR;
   }else {

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -48,7 +48,7 @@ FaultDetector::FaultDetector(ros::NodeHandle& nh)
 
   // topics for OWLAT/JPL msgs: system fault messages, see owl_msgs/msg
   m_arm_faults_msg_pub = nh.advertise<owl_msgs::ArmFaultsStatus>("/arm_faults_status", 10);
-  m_antenna_fault_msg_pub = nh.advertise<owl_msgs::PanTiltFaultsStatus>("/pan_tilt_faults_status", 10);
+  m_antenna_faults_msg_pub = nh.advertise<owl_msgs::PanTiltFaultsStatus>("/pan_tilt_faults_status", 10);
   m_camera_faults_msg_pub = nh.advertise<owl_msgs::CameraFaultsStatus>("/camera_faults_status", 10);
   m_power_fault_msg_pub = nh.advertise<ow_faults_detection::PowerFaults>("/faults/power_faults_status", 10);
   m_system_faults_msg_pub = nh.advertise<owl_msgs::SystemFaultsStatus>("/system_faults_status", 10);
@@ -179,14 +179,28 @@ bool FaultDetector::findJointIndex(const unsigned int joint, unsigned int& out_i
 //// Antenna Listeners
 void FaultDetector::antPublishFaultMessages()
 {
-  owl_msgs::PanTiltFaultsStatus ant_fault_msg;
+  owl_msgs::PanTiltFaultsStatus ant_faults_msg;
   if (m_pan_fault || m_tilt_fault) {
+    // assign system fault and determine/assign individual pan_tilt faults
     m_system_faults_flags |= SystemFaultsStatus::PAN_TILT_EXECUTION_ERROR;
+    if (m_pan_fault) {
+      ant_faults_msg.value |= PanTiltFaultsStatus::PAN_JOINT_LOCKED;
+    } else {
+      ant_faults_msg.value &= ~PanTiltFaultsStatus::PAN_JOINT_LOCKED;
+    }
+    if (m_tilt_fault) {
+      ant_faults_msg.value |= PanTiltFaultsStatus::TILT_JOINT_LOCKED;
+    } else {
+      ant_faults_msg.value &= ~PanTiltFaultsStatus::TILT_JOINT_LOCKED;
+    }
   }else {
+    // exonerate system and pan_tilt faults
     m_system_faults_flags &= ~SystemFaultsStatus::PAN_TILT_EXECUTION_ERROR;
+    ant_faults_msg.value = PanTiltFaultsStatus::NONE;
   }
   publishSystemFaultsMessage();
-  m_antenna_fault_msg_pub.publish(ant_fault_msg);
+  setFaultsMessageHeader(ant_faults_msg);
+  m_antenna_faults_msg_pub.publish(ant_faults_msg);
 }
 
 //// Camera listeners

--- a/owl_msgs/CMakeLists.txt
+++ b/owl_msgs/CMakeLists.txt
@@ -53,8 +53,9 @@ add_message_files(
   ArmJointPositions.msg
   ArmJointTorques.msg
   ArmJointVelocities.msg
-  PanTiltPosition.msg
   CameraFaultsStatus.msg
+  PanTiltPosition.msg
+  PanTiltFaultsStatus.msg
   SystemFaultsStatus.msg
 )
 

--- a/owl_msgs/msg/PanTiltFaultsStatus.msg
+++ b/owl_msgs/msg/PanTiltFaultsStatus.msg
@@ -1,0 +1,8 @@
+# The 'value' field is either 0 (no fault) or 1 (hardware error).
+
+Header header
+uint64 value
+
+uint64 NONE = 0
+uint64 PAN_JOINT_LOCKED = 1
+uint64 TILT_JOINT_LOCKED = 2


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-934](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-934) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1011](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1011) |
| Github :octocat:  | [OCEANWATER-1011_implement_telemetry_pan_tilt_faults_status](https://github.com/nasa/ow_simulator/tree/OCEANWATER-1011_implement_telemetry_pan_tilt_faults_status) |

Mostly artifact renaming and updating message definitions.

**This issue has a corresponding and required branch on [ow_autonomy](https://github.com/nasa/ow_autonomy/tree/OCEANWATER-1011_implement_telemetry_pan_tilt_faults_status).**

## Summary of Changes
* Renamed the `PTFaults` message to `PanTiltFaultsStatus` and updated all references in source and documentation.
* Moved `PanTiltFaultsStatus.msg` to the `owl_msgs` package.
* Removed the `/faults/` topic prefix from the `pan_tilt_faults_status` topic.
* Updated `PanTiltFaultsStatus` message semantics and defintion.
* Made Plexil-OwInterface package imports consistent with new 'owl_msgs' package.
* Renamed some variables to be consistent with message rename.

## Test
* Build according to [User Documentation](https://github.com/nasa/ow_simulator/wiki/Using-OceanWATERS).
* Run four terminals sourced with the project's `setup.bash`.
* In one terminal, run the project:
  * `roslaunch ow atacama_y1a.launch`
* In the second terminal, verify the fault messages are in the `owl_msgs` package and its contents:
  * `rosmsg package owl_msgs`
  * `rosmsg show owl_msgs/PanTiltFaultsStatus`
* In the third terminal, subscribe to the pan tilt faults status topic:
  * `rostopic echo /pan_tilt_faults_status`
* In the fourth terminal Subscribe to the system faults status topic
  * `rostopic echo /system_faults_status`
* In the second terminal, run a plan that uses pan and tilts (ie: `roslaunch ow_plexil ow_exec.launch plan:=Continuous.plx`)
* In RQT go to the Dynamic Reconfigure tab and select faults.
* Toggle any of the ant faults and observe the rostopic change with an appropriate values in both echoed rostopics, observe the reporting and exonerating of faults in the plexil output (terminal 2)

## Comments/Issues


  