### PR TITLE
Oceanwater 1021 implement arm pose

### DIFF
--- a/ow_lander/CMakeLists.txt
+++ b/ow_lander/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   rospy
   roslaunch
+  tf2_ros
   message_generation
   std_msgs
   geometry_msgs

--- a/ow_lander/scripts/state_publisher.py
+++ b/ow_lander/scripts/state_publisher.py
@@ -5,8 +5,10 @@
 # this repository.
 
 import rospy
+import tf2_ros
 from sensor_msgs.msg import JointState
-from owl_msgs.msg import ArmJointAccelerations, ArmJointPositions, ArmJointTorques, ArmJointVelocities, PanTiltPosition
+from owl_msgs.msg import ArmJointAccelerations, ArmJointPositions, ArmJointTorques, \
+                         ArmJointVelocities, ArmPose, PanTiltPosition
 
 class StatePublisher(object):
 
@@ -16,9 +18,11 @@ class StatePublisher(object):
     self._joint_tor = ArmJointTorques()
     self._joint_vel = ArmJointVelocities()
     self._pan_tilt = PanTiltPosition()
+    self._arm_pose = ArmPose()
 
     self._subscriber = rospy.Subscriber(
             '/joint_states', JointState, self._handle_joint_states)
+
     self._arm_joint_accelerations_pub = rospy.Publisher(
             '/arm_joint_accelerations', ArmJointAccelerations, queue_size=10)
     self._arm_joint_positions_pub = rospy.Publisher(
@@ -29,6 +33,13 @@ class StatePublisher(object):
             '/arm_joint_velocities', ArmJointVelocities, queue_size=10)
     self._pan_tilt_pub = rospy.Publisher(
             '/pan_tilt_position', PanTiltPosition, queue_size=10)
+
+    self._tf_buffer = tf2_ros.Buffer()
+    self._tf_listener = tf2_ros.TransformListener(self._tf_buffer)
+
+    self._arm_pose_pub = rospy.Publisher(
+            '/arm_pose', ArmPose, queue_size=10)
+
 
   def _handle_joint_states(self, data):
     """
@@ -66,6 +77,24 @@ class StatePublisher(object):
     self._pan_tilt.header = data.header
     self._pan_tilt.value = data.position[0 : OFFSET]
     self._pan_tilt_pub.publish(self._pan_tilt)
+
+    # Use /joint_states as the clock for publishing /arm_pose. Alternatively,
+    # this could be refactored put publish /arm_pose at a different rate.
+    self._publish_arm_pose()
+
+
+  def _publish_arm_pose(self):
+    try:
+      trans = self._tf_buffer.lookup_transform('base_link', 'l_scoop',  rospy.Time(0))
+    except (tf2_ros.LookupException, tf2_ros.ConnectivityException, tf2_ros.ExtrapolationException) as e:
+      rospy.logwarn("StatePublisher: tf2 raised an exception: %s" % e)
+      return
+
+    self._arm_pose.header = trans.header
+    self._arm_pose.value.position = trans.transform.translation
+    self._arm_pose.value.orientation = trans.transform.rotation
+    self._arm_pose_pub.publish(self._arm_pose)
+
 
 if __name__ == '__main__':
     node_name = 'state_publisher'

--- a/ow_lander/scripts/state_publisher.py
+++ b/ow_lander/scripts/state_publisher.py
@@ -87,7 +87,7 @@ class StatePublisher(object):
     try:
       trans = self._tf_buffer.lookup_transform('base_link', 'l_scoop',  rospy.Time(0))
     except (tf2_ros.LookupException, tf2_ros.ConnectivityException, tf2_ros.ExtrapolationException) as e:
-      rospy.logwarn("StatePublisher: tf2 raised an exception: %s" % e)
+      rospy.logerr("StatePublisher: tf2 raised an exception: %s" % e)
       return
 
     self._arm_pose.header = trans.header

--- a/owl_msgs/CMakeLists.txt
+++ b/owl_msgs/CMakeLists.txt
@@ -10,6 +10,7 @@ project(owl_msgs)
 find_package(catkin REQUIRED COMPONENTS
   message_generation
   std_msgs
+  geometry_msgs
 )
 
 ## System dependencies are found with CMake's conventions
@@ -52,6 +53,7 @@ add_message_files(
   ArmJointPositions.msg
   ArmJointTorques.msg
   ArmJointVelocities.msg
+  ArmPose.msg
   PanTiltPosition.msg
   SystemFaultsStatus.msg
 )
@@ -74,6 +76,7 @@ add_message_files(
 generate_messages(
   DEPENDENCIES
   std_msgs
+  geometry_msgs
 )
 
 ################################################
@@ -108,7 +111,7 @@ generate_messages(
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES owl_msgs
- CATKIN_DEPENDS message_runtime std_msgs
+  CATKIN_DEPENDS message_runtime std_msgs geometry_msgs
 #  DEPENDS system_lib
 )
 

--- a/owl_msgs/msg/ArmPose.msg
+++ b/owl_msgs/msg/ArmPose.msg
@@ -1,0 +1,2 @@
+Header header
+geometry_msgs/Pose value

--- a/owl_msgs/package.xml
+++ b/owl_msgs/package.xml
@@ -51,10 +51,9 @@
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_export_depend>std_msgs</build_export_depend>
   <exec_depend>message_runtime</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-934](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-934) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1021](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1021) |


## Summary of Changes
* Added /arm_pose topic

## Test
* roslaunch ow atacama_y1a.launch
* rostopic echo /arm_pose
* ./guarded_move_action_client.py

Note that the final position of guarded_move is similar to the position of /arm_pose because guarded_move shows the position of l_scoop_tip while /arm_pose shows the position of l_scoop. Both positions are relative to base_link.
