### PR TITLE
Oceanwater 1023-1025 battery telemetry unification

### DIFF
--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -13,11 +13,13 @@
 #include <std_msgs/Float64.h>
 #include <std_msgs/Empty.h>
 #include <ow_faults_detection/JointStatesFlag.h>
-#include <owl_msgs/SystemFaultsStatus.h>
 #include <owl_msgs/ArmFaultsStatus.h>
-#include <owl_msgs/PowerFaultsStatus.h>
-#include <owl_msgs/PanTiltFaultsStatus.h>
+#include <owl_msgs/BatteryTemperature.h>
 #include <owl_msgs/CameraFaultsStatus.h>
+#include <owl_msgs/PanTiltFaultsStatus.h>
+#include <owl_msgs/PowerFaultsStatus.h>
+#include <owl_msgs/StateOfCharge.h>
+#include <owl_msgs/SystemFaultsStatus.h>
 #include <ow_lander/lander_joints.h>
 #include <sensor_msgs/JointState.h>
 #include <geometry_msgs/WrenchStamped.h>
@@ -66,8 +68,8 @@ private:
 
   // Power
   void publishPowerSystemFault();
-  void powerSOCListener(const std_msgs::Float64& msg);
-  void powerTemperatureListener(const std_msgs::Float64& msg);
+  void powerSOCListener(const owl_msgs::StateOfCharge& msg);
+  void powerTemperatureListener(const owl_msgs::BatteryTemperature& msg);
 
   // OWLAT MESSAGE FUNCTIONS AND PUBLISHERS
   void publishSystemFaultsMessage();

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -220,10 +220,10 @@ void FaultDetector::cameraRawCb(const sensor_msgs::Image& msg)
 }
 
 //// Power Topic Listeners
-void FaultDetector::powerTemperatureListener(const std_msgs::Float64& msg)
+void FaultDetector::powerTemperatureListener(const owl_msgs::BatteryTemperature& msg)
 {
   // check for excessive battery temperature
-  if (msg.data > POWER_THERMAL_MAX) {
+  if (msg.value > POWER_THERMAL_MAX) {
     m_power_faults_flags |= PowerFaultsStatus::THERMAL_FAULT;
   } else {
     m_power_faults_flags &= ~PowerFaultsStatus::THERMAL_FAULT;
@@ -231,10 +231,10 @@ void FaultDetector::powerTemperatureListener(const std_msgs::Float64& msg)
   publishPowerSystemFault();
 }
  
-void FaultDetector::powerSOCListener(const std_msgs::Float64& msg)
+void FaultDetector::powerSOCListener(const owl_msgs::StateOfCharge& msg)
 {
   // set initial state of charge
-  float current_soc = msg.data;
+  float current_soc = msg.value;
   if (isnan(m_last_soc)){
     m_last_soc = current_soc;
   }

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -33,7 +33,7 @@ FaultDetector::FaultDetector(ros::NodeHandle& nh)
                                    this);
   
   //  power fault publishers and subs
-  m_power_soc_sub = nh.subscribe( "/state_of_charge",
+  m_power_soc_sub = nh.subscribe( "/battery_state_of_charge",
                                   10,
                                   &FaultDetector::powerSOCListener,
                                   this);

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -33,11 +33,11 @@ FaultDetector::FaultDetector(ros::NodeHandle& nh)
                                    this);
   
   //  power fault publishers and subs
-  m_power_soc_sub = nh.subscribe( "/power_system_node/state_of_charge",
+  m_power_soc_sub = nh.subscribe( "/state_of_charge",
                                   10,
                                   &FaultDetector::powerSOCListener,
                                   this);
-  m_power_temperature_sub = nh.subscribe( "/power_system_node/battery_temperature",
+  m_power_temperature_sub = nh.subscribe( "/battery_temperature",
                                           10,
                                           &FaultDetector::powerTemperatureListener,
                                           this);

--- a/ow_power_system/CMakeLists.txt
+++ b/ow_power_system/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   roslib
   ow_lander
+  owl_msgs
 )
 find_package(roslaunch)
 

--- a/ow_power_system/README.md
+++ b/ow_power_system/README.md
@@ -5,7 +5,7 @@ this repository.
 # ow_power_system
 
 It creates a node called power_system_node, which monitors power consumption
-(mainly based of mechanical power at the current time), publishes the messages 
+(mainly based off mechanical power at the current time), publishes the messages 
 from the owl_msgs package that individually describe the estimated
 _state of charge (SOC)_, estimated _remaining useful life (RUL)_ in seconds and
 also publishes the estimated _battery temperature_ in degrees Celsius. To

--- a/ow_power_system/README.md
+++ b/ow_power_system/README.md
@@ -5,15 +5,16 @@ this repository.
 # ow_power_system
 
 It creates a node called power_system_node, which monitors power consumption
-(mainly based of mechanical power at the current time), publishes the estimated
+(mainly based of mechanical power at the current time), publishes the messages 
+from the owl_msgs package that individually describe the estimated
 _state of charge (SOC)_, estimated _remaining useful life (RUL)_ in seconds and
 also publishes the estimated _battery temperature_ in degrees Celsius. To
 monitor any of these values simply subscribe to their respective topics:
 
 ```bash
-rostopic echo /power_system_node/state_of_charge
-rostopic echo /power_system_node/remaining_useful_life
-rostopic echo /power_system_node/battery_temperature
+rostopic echo /state_of_charge
+rostopic echo /remaining_useful_life
+rostopic echo /battery_temperature
 ```
 
 state_of_charge (SOC): The SOC estimate provides the amount of energy present in

--- a/ow_power_system/README.md
+++ b/ow_power_system/README.md
@@ -12,8 +12,8 @@ also publishes the estimated _battery temperature_ in degrees Celsius. To
 monitor any of these values simply subscribe to their respective topics:
 
 ```bash
-rostopic echo /state_of_charge
-rostopic echo /remaining_useful_life
+rostopic echo /battery_state_of_charge
+rostopic echo /battery_remaining_useful_life
 rostopic echo /battery_temperature
 ```
 

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -7,7 +7,11 @@
 #include <random>
 #include <ros/ros.h>
 #include <sensor_msgs/JointState.h>
+#include <owl_msgs/BatteryTemperature.h>
+#include <owl_msgs/RemainingUsefulLife.h>
+#include <owl_msgs/StateOfCharge.h>
 #include <PrognoserFactory.h>
+
 
 using PrognoserMap = std::map<PCOE::MessageId, PCOE::Datum<double>>;
 using PrognoserVector = std::vector<PrognoserMap>;
@@ -44,9 +48,9 @@ private:
                                     double voltage,
                                     double temperature);
   void parseEoD_Event(const ProgEvent& eod_event,
-                      std_msgs::Float64& soc_msg,
-                      std_msgs::Int16& rul_msg,
-                      std_msgs::Float64& battery_temperature_msg);
+                      owl_msgs::StateOfCharge& soc_msg,
+                      owl_msgs::RemainingUsefulLife& rul_msg,
+                      owl_msgs::BatteryTemperature& battery_temperature_msg);
   void runPrognoser(double electrical_power);
 
   ros::NodeHandle m_nh;                        // Node Handle Initialization

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -53,13 +53,13 @@ private:
                       owl_msgs::BatteryTemperature& battery_temperature_msg);
   void runPrognoser(double electrical_power);
 
-  ros::NodeHandle m_nh;                        // Node Handle Initialization
-  ros::Publisher m_mechanical_power_raw_pub;   // Mechanical Power Raw
-  ros::Publisher m_mechanical_power_avg_pub;   // Mechanical Power Averaged
-  ros::Publisher m_state_of_charge_pub;        // State of Charge Publisher
-  ros::Publisher m_remaining_useful_life_pub;  // Remaining Useful Life Publisher
-  ros::Publisher m_battery_temperature_pub;    // Battery Temperature Publisher
-  ros::Subscriber m_joint_states_sub;          // Mechanical Power Subscriber
+  ros::NodeHandle m_nh;                               // Node Handle Initialization
+  ros::Publisher m_mechanical_power_raw_pub;          // Mechanical Power Raw
+  ros::Publisher m_mechanical_power_avg_pub;          // Mechanical Power Averaged
+  ros::Publisher m_battery_state_of_charge_pub;       // State of Charge Publisher
+  ros::Publisher m_battery_remaining_useful_life_pub; // Remaining Useful Life Publisher
+  ros::Publisher m_battery_temperature_pub;           // Battery Temperature Publisher
+  ros::Subscriber m_joint_states_sub;                 // Mechanical Power Subscriber
 
   int m_moving_average_window = 25;
   std::vector<double> m_power_values;

--- a/ow_power_system/package.xml
+++ b/ow_power_system/package.xml
@@ -36,6 +36,7 @@
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>owl_msgs</depend>
   <build_depend>roslaunch</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -195,9 +195,9 @@ bool PowerSystemNode::initTopics()
   // Construct the PowerSystemNode publishers
   m_mechanical_power_raw_pub = m_nh.advertise<Float64>("mechanical_power/raw", 1);
   m_mechanical_power_avg_pub = m_nh.advertise<Float64>("mechanical_power/average", 1);
-  m_state_of_charge_pub = m_nh.advertise<Float64>("owl_msgs/state_of_charge", 1);
-  m_remaining_useful_life_pub = m_nh.advertise<Int16>("owl_msgs/remaining_useful_life", 1);
-  m_battery_temperature_pub = m_nh.advertise<Float64>("owl_msgs/battery_temperature", 1);
+  m_state_of_charge_pub = m_nh.advertise<owl_msgs::StateOfCharge>("/state_of_charge", 1);
+  m_remaining_useful_life_pub = m_nh.advertise<owl_msgs::RemainingUsefulLife>("/remaining_useful_life", 1);
+  m_battery_temperature_pub = m_nh.advertise<owl_msgs::BatteryTemperature>("/battery_temperature", 1);
   // Finally subscribe to the joint_states to estimate the mechanical power
   m_joint_states_sub = m_nh.subscribe("/joint_states", 1, &PowerSystemNode::jointStatesCb, this);
   return true;

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -194,8 +194,8 @@ bool PowerSystemNode::initTopics()
   // Construct the PowerSystemNode publishers
   m_mechanical_power_raw_pub = m_nh.advertise<Float64>("mechanical_power/raw", 1);
   m_mechanical_power_avg_pub = m_nh.advertise<Float64>("mechanical_power/average", 1);
-  m_state_of_charge_pub = m_nh.advertise<owl_msgs::StateOfCharge>("/state_of_charge", 1);
-  m_remaining_useful_life_pub = m_nh.advertise<owl_msgs::RemainingUsefulLife>("/remaining_useful_life", 1);
+  m_battery_state_of_charge_pub = m_nh.advertise<owl_msgs::StateOfCharge>("/battery_state_of_charge", 1);
+  m_battery_remaining_useful_life_pub = m_nh.advertise<owl_msgs::RemainingUsefulLife>("/battery_remaining_useful_life", 1);
   m_battery_temperature_pub = m_nh.advertise<owl_msgs::BatteryTemperature>("/battery_temperature", 1);
   // Finally subscribe to the joint_states to estimate the mechanical power
   m_joint_states_sub = m_nh.subscribe("/joint_states", 1, &PowerSystemNode::jointStatesCb, this);
@@ -498,8 +498,8 @@ void PowerSystemNode::runPrognoser(double electrical_power)
   }
 
   // publish current SOC, RUL, and battery temperature
-  m_state_of_charge_pub.publish(soc_msg);
-  m_remaining_useful_life_pub.publish(rul_msg);
+  m_battery_state_of_charge_pub.publish(soc_msg);
+  m_battery_remaining_useful_life_pub.publish(rul_msg);
   m_battery_temperature_pub.publish(battery_temperature_msg);
 }
 

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -8,7 +8,6 @@
 #include <algorithm>
 #include <ros/package.h>
 #include <std_msgs/Float64.h>
-#include <std_msgs/Int16.h>
 #include <ow_lander/lander_joints.h>
 #include "PowerSystemNode.h"
 

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -195,9 +195,9 @@ bool PowerSystemNode::initTopics()
   // Construct the PowerSystemNode publishers
   m_mechanical_power_raw_pub = m_nh.advertise<Float64>("mechanical_power/raw", 1);
   m_mechanical_power_avg_pub = m_nh.advertise<Float64>("mechanical_power/average", 1);
-  m_state_of_charge_pub = m_nh.advertise<Float64>("power_system_node/state_of_charge", 1);
-  m_remaining_useful_life_pub = m_nh.advertise<Int16>("power_system_node/remaining_useful_life", 1);
-  m_battery_temperature_pub = m_nh.advertise<Float64>("power_system_node/battery_temperature", 1);
+  m_state_of_charge_pub = m_nh.advertise<Float64>("owl_msgs/state_of_charge", 1);
+  m_remaining_useful_life_pub = m_nh.advertise<Int16>("owl_msgs/remaining_useful_life", 1);
+  m_battery_temperature_pub = m_nh.advertise<Float64>("owl_msgs/battery_temperature", 1);
   // Finally subscribe to the joint_states to estimate the mechanical power
   m_joint_states_sub = m_nh.subscribe("/joint_states", 1, &PowerSystemNode::jointStatesCb, this);
   return true;
@@ -422,9 +422,9 @@ PowerSystemNode::composePrognoserData(double power,
 }
 
 void PowerSystemNode::parseEoD_Event(const ProgEvent& eod_event,
-				     Float64& soc_msg,
-				     Int16& rul_msg,
-				     Float64& battery_temperature_msg)
+				     owl_msgs::StateOfCharge& soc_msg,
+				     owl_msgs::RemainingUsefulLife& rul_msg,
+				     owl_msgs::BatteryTemperature& battery_temperature_msg)
 {
   // The time of event is a `UData` structure, which represents a data
   // point while maintaining uncertainty. For the MonteCarlo predictor
@@ -446,14 +446,14 @@ void PowerSystemNode::parseEoD_Event(const ProgEvent& eod_event,
   auto now = MessageClock::now();
   auto now_s = duration_cast<chrono::seconds>(now.time_since_epoch());
   double rul_median = eod_median - now_s.count();
-  rul_msg.data = rul_median;
+  rul_msg.value = rul_median;
 
   // Determine the median SOC.
   UData currentSOC = eod_event.getState()[0];
   auto samplesSOC = currentSOC.getVec();
   sort(samplesSOC.begin(), samplesSOC.end());
   double soc_median = samplesSOC.at(samplesSOC.size() / 2);
-  soc_msg.data = soc_median;
+  soc_msg.value = soc_median;
 
   // Determine the Battery Temperature
   auto stateSamples = eod_event.getSystemState()[0];
@@ -463,7 +463,7 @@ void PowerSystemNode::parseEoD_Event(const ProgEvent& eod_event,
 
   auto& model = dynamic_cast<ModelBasedPrognoser*>(m_prognoser.get())->getModel();
   auto model_output = model.outputEqn(now_s.count(), static_cast<PrognosticsModel::state_type>(state));
-  battery_temperature_msg.data = model_output[TEMPERATURE_INDEX];
+  battery_temperature_msg.value = model_output[TEMPERATURE_INDEX];
 }
 
 void PowerSystemNode::runPrognoser(double electrical_power)
@@ -487,9 +487,9 @@ void PowerSystemNode::runPrognoser(double electrical_power)
   auto prediction = m_prognoser->step(current_data);
 
   // Individual msgs to be published
-  Float64 soc_msg;
-  Int16 rul_msg;
-  Float64 battery_temperature_msg;
+  owl_msgs::StateOfCharge soc_msg;
+  owl_msgs::RemainingUsefulLife rul_msg;
+  owl_msgs::BatteryTemperature battery_temperature_msg;
 
   auto& eod_events = prediction.getEvents();
   if (!eod_events.empty())

--- a/owl_msgs/CMakeLists.txt
+++ b/owl_msgs/CMakeLists.txt
@@ -55,11 +55,14 @@ add_message_files(
   ArmJointTorques.msg
   ArmJointVelocities.msg
   ArmPose.msg
+  BatteryTemperature.msg
   CameraFaultsStatus.msg
   PanTiltFaultsStatus.msg
   PanTiltPosition.msg
-  SystemFaultsStatus.msg
   PowerFaultsStatus.msg
+  RemainingUsefulLife.msg
+  StateOfCharge.msg
+  SystemFaultsStatus.msg
 )
 
 ## Generate services in the 'srv' folder
@@ -81,6 +84,7 @@ generate_messages(
   DEPENDENCIES
   std_msgs
   geometry_msgs
+  owl_msgs
 )
 
 ################################################
@@ -115,7 +119,7 @@ generate_messages(
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES owl_msgs
-  CATKIN_DEPENDS message_runtime std_msgs geometry_msgs
+  CATKIN_DEPENDS message_runtime std_msgs geometry_msgs owl_msgs
 #  DEPENDS system_lib
 )
 

--- a/owl_msgs/CMakeLists.txt
+++ b/owl_msgs/CMakeLists.txt
@@ -84,7 +84,6 @@ generate_messages(
   DEPENDENCIES
   std_msgs
   geometry_msgs
-  owl_msgs
 )
 
 ################################################
@@ -119,7 +118,7 @@ generate_messages(
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES owl_msgs
-  CATKIN_DEPENDS message_runtime std_msgs geometry_msgs owl_msgs
+  CATKIN_DEPENDS message_runtime std_msgs geometry_msgs
 #  DEPENDS system_lib
 )
 

--- a/owl_msgs/msg/BatteryTemperature.msg
+++ b/owl_msgs/msg/BatteryTemperature.msg
@@ -1,0 +1,4 @@
+# Battery temperature message
+
+Header header
+float64 value # temperature (Celsius)

--- a/owl_msgs/msg/RemainingUsefulLife.msg
+++ b/owl_msgs/msg/RemainingUsefulLife.msg
@@ -1,0 +1,4 @@
+# Battery remaining useful life message
+
+Header header
+int32 value # remaining life (Seconds)

--- a/owl_msgs/msg/StateOfCharge.msg
+++ b/owl_msgs/msg/StateOfCharge.msg
@@ -1,0 +1,4 @@
+# Battery state of charge message
+
+Header header
+float64 value # 0.0 - 1.0 indicating percentage


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-934](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-934) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1023](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1023) |
| Jira Ticket 🎟️ | [OCEANWATER-1024](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1024) |
| Jira Ticket 🎟️ | [OCEANWATER-1025](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1025) |

**This issue has a corresponding and required branch on [ow_autonomy](https://github.com/nasa/ow_autonomy/pull/104).**

## Summary of Changes
* Create messages for BatteryTemperature, RemainingUsefulLife, and StateOfCharge in the `owl_msgs` package according to the Telemetry Unification Doc.
* Change existing power_system_node messages to publish without the `/power_system_node` prefix.
* Update references in ow_power_system_node, ow_faults_detection, and ow_plexil to use new types and prefixes.

## Test
* After building and sourcing, show the new messages in owl_msgs with: 
  * `rosmsg package owl_msgs`
  * `rosmsg show owl_msgs/BatteryTemperature`
  *  `rosmsg show owl_msgs/RemainingUsefulLife`
  *  `rosmsg show owl_msgs/StateOfCharge`
* Since FaultDetection is dependent on BatteryTemperature and StateOfCharge, their continued functionality can be verified using the testing procedure in [OCEANWATER-1014_implement_telemetry_power_faults_status](https://github.com/nasa/ow_simulator/pull/299), while also echoing the updated topics `/battery_temperature` and `/state_of_charge` (without the `/power_system_node` prefix).
  * Note: `remaining_useful_life` has no current dependent module, but it can be observed with `echo /remaining_useful_life` during tests.
