### PR TITLE
Oceanwater 1092 move exposure to its own action

### DIFF
--- a/ow_lander/CMakeLists.txt
+++ b/ow_lander/CMakeLists.txt
@@ -46,6 +46,7 @@ add_action_files(
   FILES ArmMoveJoints.action
   FILES LightSetIntensity.action
   FILES CameraCapture.action
+  FILES CameraSetExposure.action
 )
 
 add_message_files(

--- a/ow_lander/action/CameraCapture.action
+++ b/ow_lander/action/CameraCapture.action
@@ -1,5 +1,4 @@
 # goal
-float64 exposure  # (seconds) Must be greater than 0 or previous exposure will be used
 ---
 # result
 ---

--- a/ow_lander/action/CameraSetExposure.action
+++ b/ow_lander/action/CameraSetExposure.action
@@ -1,0 +1,7 @@
+# goal
+bool automatic
+float64 exposure  # (seconds) Must be greater than 0 or previous exposure will be used
+---
+# result
+---
+# feedback

--- a/ow_lander/scripts/camera_capture_action_client.py
+++ b/ow_lander/scripts/camera_capture_action_client.py
@@ -15,5 +15,4 @@ parser = argparse.ArgumentParser(
 )
 args = parser.parse_args()
 
-node_helper.call_single_use_action_client(actions.CameraCaptureServer,
-  **vars(args))
+node_helper.call_single_use_action_client(actions.CameraCaptureServer)

--- a/ow_lander/scripts/camera_set_exposure_action_client.py
+++ b/ow_lander/scripts/camera_set_exposure_action_client.py
@@ -11,9 +11,11 @@ import argparse
 
 parser = argparse.ArgumentParser(
   formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-  description="Trigger both mast cameras to capture photographs."
+  description="Set exposure on both mast cameras."
 )
+parser.add_argument('exposure', type=float, nargs='?', default=-1,
+  help="Camera exposure in seconds. If <= 0 the exposure will not change.")
 args = parser.parse_args()
 
-node_helper.call_single_use_action_client(actions.CameraCaptureServer,
+node_helper.call_single_use_action_client(actions.CameraSetExposureServer,
   **vars(args))

--- a/ow_lander/scripts/deliver_action_client.py
+++ b/ow_lander/scripts/deliver_action_client.py
@@ -14,4 +14,4 @@ parser = argparse.ArgumentParser(
   description="Transfers contents of the scoop to the Sample Transfer Dock.")
 args = parser.parse_args()
 
-node_helper.call_single_use_action_client(actions.DeliverServer, **vars(args))
+node_helper.call_single_use_action_client(actions.DeliverServer)

--- a/ow_lander/scripts/dock_ingest_sample_action_client.py
+++ b/ow_lander/scripts/dock_ingest_sample_action_client.py
@@ -15,5 +15,4 @@ parser = argparse.ArgumentParser(
 )
 args = parser.parse_args()
 
-node_helper.call_single_use_action_client(actions.DockIngestSampleServer,
-  **vars(args))
+node_helper.call_single_use_action_client(actions.DockIngestSampleServer)

--- a/ow_lander/scripts/lander_action_servers.py
+++ b/ow_lander/scripts/lander_action_servers.py
@@ -27,6 +27,7 @@ server_move_cartesian = actions.ArmMoveCartesianServer()
 # other non-arm lander actions
 server_light_set_intensity = actions.LightSetIntensityServer()
 server_camera_capture      = actions.CameraCaptureServer()
+server_camera_set_exposure = actions.CameraSetExposureServer()
 server_dock_ingest_sample  = actions.DockIngestSampleServer()
 server_antenna_pan_tilt    = actions.AntennaPanTiltServer()
 

--- a/ow_lander/scripts/stop_action_client.py
+++ b/ow_lander/scripts/stop_action_client.py
@@ -15,6 +15,4 @@ parser = argparse.ArgumentParser(
               "executing a trajectory.")
 args = parser.parse_args()
 
-node_helper.call_single_use_action_client(
-  actions.StopServer, **vars(args)
-)
+node_helper.call_single_use_action_client(actions.StopServer)

--- a/ow_lander/scripts/stow_action_client.py
+++ b/ow_lander/scripts/stow_action_client.py
@@ -15,7 +15,4 @@ parser = argparse.ArgumentParser(
 )
 args = parser.parse_args()
 
-node_helper.call_single_use_action_client(
-  actions.StowServer, **vars(args)
-)
-
+node_helper.call_single_use_action_client(actions.StowServer)

--- a/ow_lander/scripts/unstow_action_client.py
+++ b/ow_lander/scripts/unstow_action_client.py
@@ -15,6 +15,4 @@ parser = argparse.ArgumentParser(
 )
 args = parser.parse_args()
 
-node_helper.call_single_use_action_client(
-  actions.UnstowServer, **vars(args)
-)
+node_helper.call_single_use_action_client(actions.UnstowServer)

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -434,7 +434,6 @@ class CameraSetExposureServer(ActionServerBase):
 
   def execute_action(self, goal):
     if goal.automatic:
-      rospy.logerr(f'{self.name} action does not support autoexposure.')
       self._set_aborted(f'{self.name} action does not support autoexposure.')
       return
 

--- a/ow_lander/src/ow_lander/server.py
+++ b/ow_lander/src/ow_lander/server.py
@@ -80,7 +80,7 @@ class ActionServerBase(ABC):
     kwargs -- Keyword arguments that match fields in result_type. Leave empty
               if result type is empty.
     """
-    rospy.loginfo(self.__format_result_msg(f"{self.name}: Succeded", msg))
+    rospy.loginfo(self.__format_result_msg(f"{self.name}: Succeeded", msg))
     result, msg = self.__create_result(msg, **kwargs)
     self._server.set_succeeded(result, msg)
 


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-933](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-933) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1092](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1092) |

This PR is accompanied by https://github.com/nasa/ow_autonomy/pull/105

## Summary of Changes
* Removed exposure from CameraCapture action and created CameraSetExposure action
