### PR TITLE
Oceanwater 945 ArmMoveCartesianGuarded added

### DIFF
--- a/ow_lander/scripts/arm_move_cartesian_guarded.py
+++ b/ow_lander/scripts/arm_move_cartesian_guarded.py
@@ -37,7 +37,7 @@ rot_parse.add_argument('--quaternion', '-q', type=float, nargs=4,
   default=[0, 0, 0, 1], metavar=('X', 'Y', 'Z', 'W'),
   help="Orientation in quaternion form. Takes 4 scalars, the first 3 are the" \
        " imaginary parts, and the 4th is the real part.")
-parser.add_argument('--force', type=float, default=100,
+parser.add_argument('--force', type=float, default=200,
   help="Arm will stop when F/T sensor encounters a force above this value in " \
        " Newtons")
 parser.add_argument('--torque', type=float, default=100,

--- a/ow_lander/scripts/arm_move_cartesian_guarded.py
+++ b/ow_lander/scripts/arm_move_cartesian_guarded.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+from ow_lander import actions
+from ow_lander import node_helper
+from ow_lander import constants
+
+import argparse
+
+from geometry_msgs.msg import Pose, Point, Quaternion
+from tf.transformations import quaternion_from_euler
+
+parser = argparse.ArgumentParser(
+  formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+  description="Move end-effector by Cartesian coordinates/translation.")
+parser.add_argument('--frame', '-f', type=int, default=0,
+  choices=constants.FRAME_ID_MAP.keys(),
+  help="The frame index corresponding to the frame that orientation and "\
+       " position are relative to. " + str(constants.FRAME_ID_MAP))
+parser.add_argument('--relative', '-r', action='store_true', default=False,
+  help="If True, pose will be interpreted as relative to the current pose.")
+parser.add_argument('-x', type=float, default=0,
+  help="X-coordinate or the change in the X-coordinate")
+parser.add_argument('-y', type=float, default=0,
+  help="Y-coordinate or the change in the Y-coordinate")
+parser.add_argument('-z', type=float, default=0,
+  help="Z-coordinate or the change in the Z-coordinate")
+# accept either Euler angles or quaternions as input for orientation
+rot_parse = parser.add_mutually_exclusive_group()
+rot_parse.add_argument('--euler', '-e', type=float, nargs=3,
+  default=[0, 0, 0], metavar=('X', 'Y', 'Z'),
+  help="Orientation in Euler angle form. Takes 3 radian values.")
+rot_parse.add_argument('--quaternion', '-q', type=float, nargs=4,
+  default=[0, 0, 0, 1], metavar=('X', 'Y', 'Z', 'W'),
+  help="Orientation in quaternion form. Takes 4 scalars, the first 3 are the" \
+       " imaginary parts, and the 4th is the real part.")
+parser.add_argument('--force', type=float, default=100,
+  help="Arm will stop when F/T sensor encounters a force above this value in " \
+       " Newtons")
+parser.add_argument('--torque', type=float, default=100,
+  help="Arm will stop when F/T sensor encounters a torque above this value " \
+       " in Newton*meters")
+
+args = parser.parse_args()
+
+quat = quaternion_from_euler(*args.euler) if args.euler != [0, 0, 0] \
+       else args.quaternion
+
+pose_arg = Pose(
+  position=Point(args.x, args.y, args.z),
+  orientation=Quaternion(*quat)
+)
+
+node_helper.call_single_use_action_client(actions.ArmMoveCartesianGuardedServer,
+  frame=args.frame, relative=args.relative, pose=pose_arg,
+  force_threshold=args.force, torque_threshold=args.torque)

--- a/ow_lander/scripts/lander_action_servers.py
+++ b/ow_lander/scripts/lander_action_servers.py
@@ -23,6 +23,7 @@ server_deliver        = actions.DeliverServer()
 server_move_joint     = actions.ArmMoveJointServer()
 server_move_joints    = actions.ArmMoveJointsServer()
 server_move_cartesian = actions.ArmMoveCartesianServer()
+server_move_cartesian_guarded = actions.ArmMoveCartesianGuardedServer()
 
 # other non-arm lander actions
 server_light_set_intensity = actions.LightSetIntensityServer()

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -38,6 +38,36 @@ from ow_lander.common import in_closed_range, radians_equivalent
 from sensor_msgs.msg import JointState
 
 #####################
+## ACTION HELPERS
+#####################
+
+def _resolve_frame(goal):
+  """Determines the correct frame_id and whether the provided frame makes this
+  movement relative.
+  """
+  if goal.frame not in constants.FRAME_ID_MAP:
+    return None, None
+  # selecting relative is the same as selecting the Tool frame and vice versa
+  relative = goal.relative or goal.frame == constants.FRAME_TOOL
+  frame_id = constants.FRAME_ID_MAP[constants.FRAME_TOOL] if relative \
+             else constants.FRAME_ID_MAP[goal.frame]
+  return relative, frame_id
+
+def _format_guarded_movement_message(action_name, monitor):
+  if monitor.threshold_breached():
+    msg = f"{action_name} trajectory stopped by "
+    if monitor.force_threshold_breached():
+      msg += f"a force of {monitor.get_force()} N"
+    if monitor.torque_threshold_breached():
+      msg += " and " if monitor.force_threshold_breached() else ""
+      msg += f"a torque of {monitor.get_torque()} Nm"
+    return msg
+  else:
+    return f"{action_name} trajectory completed without breaking force or " \
+           f"torque thresholds."
+
+
+#####################
 ## ARM ACTIONS
 #####################
 
@@ -199,7 +229,7 @@ class DeliverServer(ArmTrajectoryMixin, ActionServerBase):
     return self._planner.deliver_sample()
 
 
-class ArmMoveCartesianServer(ArmCartesianMoveMixin, ActionServerBase):
+class ArmMoveCartesianServer(ArmActionMixin, ActionServerBase):
 
   name          = 'ArmMoveCartesian'
   action_type   = owl_msgs.msg.ArmMoveCartesianAction
@@ -211,13 +241,28 @@ class ArmMoveCartesianServer(ArmCartesianMoveMixin, ActionServerBase):
     self._publish_feedback(pose=self._arm_tip_monitor.get_link_pose())
 
   def execute_action(self, goal):
-    frame_id, relative = self.interpret_frame(goal)
+    ARM_END_EFFECTOR = 'l_scoop_tip'
+    COMPARISON_FRAME = 'world'
+    # handle goal parameters
+    # NOTE: this all processes fast enough that there is no need to check-out
+    #       the arm first
+    relative, frame_id = _resolve_frame(goal)
+    if frame_id is None:
+      self._set_aborted(f"Unrecognized frame {goal.frame}")
+      return
     pose = goal.pose
+    # save tool transform now so the old transform can be used for comparison
+    old_tool_transform = None
+    if relative:
+      old_tool_transform = FrameTransformer().lookup_transform(COMPARISON_FRAME,
+                                                               frame_id)
+      if old_tool_transform is None:
+        self._set_aborted("Failed to lookup frame transform")
+        return
     # perform action
     try:
       self._arm.checkout_arm(self.name)
-      plan = self._planner.plan_arm_to_pose(pose, frame_id,
-        self.ARM_END_EFFECTOR)
+      plan = self._planner.plan_arm_to_pose(pose, frame_id, ARM_END_EFFECTOR)
       self._arm.execute_arm_trajectory(plan,
         action_feedback_cb=self.publish_feedback_cb)
     except RuntimeError as err:
@@ -225,24 +270,20 @@ class ArmMoveCartesianServer(ArmCartesianMoveMixin, ActionServerBase):
       self._set_aborted(str(err),
         final_pose=self._arm_tip_monitor.get_link_pose())
     else:
-      # FIXME: follow trajectory action sometimes returns an early result; this
-      #        sleep provides a buffer in time in case that happens (OW-1097)
-      rospy.sleep(2.0)
       self._arm.checkin_arm(self.name)
       # check if requested pose agrees with commanded pose in comparison frame
-      final = self._planner.get_end_effector_pose(self.ARM_END_EFFECTOR,
-        frame_id=self.COMPARISON_FRAME)
+      final = self._planner.get_end_effector_pose(ARM_END_EFFECTOR,
+        frame_id=COMPARISON_FRAME)
       # the transform before tool movement must be used because the Tool frame
       # moves with the tool
       expected = None
       if relative:
         # this function ignores the header
-        expected = do_transform_pose(PoseStamped(pose=pose),
-          self.premovement_tool_transform)
+        expected = do_transform_pose(PoseStamped(pose=pose), old_tool_transform)
       else:
         expected = FrameTransformer().transform(
           PoseStamped(header=Header(0, rospy.Time(0), frame_id), pose=pose),
-          self.COMPARISON_FRAME
+          COMPARISON_FRAME
         )
       if final is None or expected is None:
         self._set_aborted(
@@ -257,7 +298,8 @@ class ArmMoveCartesianServer(ArmCartesianMoveMixin, ActionServerBase):
       self._set_succeeded(f"{self.name} trajectory succeeded",
         final_pose=self._arm_tip_monitor.get_link_pose())
 
-class ArmMoveCartesianGuardedServer(ArmCartesianMoveMixin, ActionServerBase):
+
+class ArmMoveCartesianGuardedServer(ArmActionMixin, ActionServerBase):
 
   name          = 'ArmMoveCartesianGuarded'
   action_type   = owl_msgs.msg.ArmMoveCartesianGuardedAction
@@ -265,14 +307,14 @@ class ArmMoveCartesianGuardedServer(ArmCartesianMoveMixin, ActionServerBase):
   feedback_type = owl_msgs.msg.ArmMoveCartesianGuardedFeedback
   result_type   = owl_msgs.msg.ArmMoveCartesianGuardedResult
 
-  def __init__(self, *args, **kwargs):
-    super().__init__(*args, **kwargs)
-
   def execute_action(self, goal):
+    ARM_END_EFFECTOR = 'l_scoop_tip'
     pose = goal.pose
-    frame_id, relative = self.interpret_frame(goal)
+    _, frame_id = _resolve_frame(goal)
     if frame_id is None:
+      self._set_aborted(f"Unrecognized frame {goal.frame}")
       return
+    # monitor F/T sensor and define a callback to check its status
     monitor = FTSensorThresholdMonitor(goal.force_threshold,
                                        goal.torque_threshold)
     def guarded_cb():
@@ -281,44 +323,28 @@ class ArmMoveCartesianGuardedServer(ArmCartesianMoveMixin, ActionServerBase):
         force=monitor.get_force(),
         torque=monitor.get_torque()
       )
-      if monitor.threshold_reached():
+      if monitor.threshold_breached():
         self._arm.stop_trajectory_silently()
 
     # perform action
     try:
       self._arm.checkout_arm(self.name)
-      plan = self._planner.plan_arm_to_pose(pose, frame_id,
-        self.ARM_END_EFFECTOR)
-      self._arm.execute_arm_trajectory(plan,
-        action_feedback_cb=guarded_cb)
+      plan = self._planner.plan_arm_to_pose(pose, frame_id, ARM_END_EFFECTOR)
+      self._arm.execute_arm_trajectory(plan, action_feedback_cb=guarded_cb)
     except RuntimeError as err:
       self._arm.checkin_arm(self.name)
       self._set_aborted(str(err),
-        final_pose=self._arm_tip_monitor.get_link_pose())
+        final_pose=self._arm_tip_monitor.get_link_pose(),
+        final_force=monitor.get_force(),
+        final_torque=monitor.get_torque())
     else:
-      # FIXME: follow trajectory action sometimes returns an early result; this
-      #        sleep provides a buffer in time in case that happens (OW-1097)
-      rospy.sleep(2.0)
       self._arm.checkin_arm(self.name)
-      if monitor.threshold_reached():
-        msg = f"{self.name} trajectory stopped by "
-        if monitor.force_threshold_reached():
-          msg += f"a force of {monitor.get_force()} N"
-        if monitor.torque_threshold_reached():
-          msg += " and " if monitor.force_threshold_reached() else ""
-          msg += f"a torque of {monitor.get_torque()} Nm"
-        self._set_succeeded(msg,
-          final_pose=self._arm_tip_monitor.get_link_pose(),
-          final_force=monitor.get_force(),
-          final_torque=monitor.get_torque())
-      else:
-        self._set_succeeded(
-          f"{self.name} trajectory completed without breaking force or torque" \
-          f"thresholds.",
-          final_pose=self._arm_tip_monitor.get_link_pose(),
-          final_force=monitor.get_force(),
-          final_torque=monitor.get_torque()
-        )
+      self._set_succeeded(_format_guarded_movement_message(self.name, monitor),
+        final_pose=self._arm_tip_monitor.get_link_pose(),
+        final_force=monitor.get_force(),
+        final_torque=monitor.get_torque()
+      )
+
 
 class ArmMoveJointServer(ModifyJointValuesMixin, ActionServerBase):
 

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -15,12 +15,6 @@ from ow_lander.mixins import *
 # required for GuardedMove
 from ow_lander.ground_detector import GroundDetector
 from geometry_msgs.msg import Point
-# required for ArmMoveCartesian
-from geometry_msgs.msg import PoseStamped
-from std_msgs.msg import Header
-from ow_lander.common import poses_approx_equivalent
-from ow_lander.frame_transformer import FrameTransformer
-from tf2_geometry_msgs import do_transform_pose
 # require for ArmMoveCartesianGuarded
 from ow_lander.ground_detector import FTSensorThresholdMonitor
 
@@ -41,30 +35,18 @@ from sensor_msgs.msg import JointState
 ## ACTION HELPERS
 #####################
 
-def _resolve_frame(goal):
-  """Determines the correct frame_id and whether the provided frame makes this
-  movement relative.
-  """
-  if goal.frame not in constants.FRAME_ID_MAP:
-    return None, None
-  # selecting relative is the same as selecting the Tool frame and vice versa
-  relative = goal.relative or goal.frame == constants.FRAME_TOOL
-  frame_id = constants.FRAME_ID_MAP[constants.FRAME_TOOL] if relative \
-             else constants.FRAME_ID_MAP[goal.frame]
-  return relative, frame_id
-
-def _format_guarded_movement_message(action_name, monitor):
+def _format_guarded_move_success_message(action_name, monitor):
   if monitor.threshold_breached():
     msg = f"{action_name} trajectory stopped by "
     if monitor.force_threshold_breached():
-      msg += f"a force of {monitor.get_force()} N"
+      msg += f"a force of {monitor.get_force():.2f} N"
     if monitor.torque_threshold_breached():
       msg += " and " if monitor.force_threshold_breached() else ""
-      msg += f"a torque of {monitor.get_torque()} Nm"
+      msg += f"a torque of {monitor.get_torque():.2f} Nm"
     return msg
   else:
-    return f"{action_name} trajectory completed without breaking force or " \
-           f"torque thresholds."
+    return f"{action_name} trajectory completed without breaching force or " \
+           f"torque thresholds"
 
 
 #####################
@@ -229,7 +211,9 @@ class DeliverServer(ArmTrajectoryMixin, ActionServerBase):
     return self._planner.deliver_sample()
 
 
-class ArmMoveCartesianServer(ArmActionMixin, ActionServerBase):
+class ArmMoveCartesianServer(ModifyPoseMixin,
+                             ArmActionMixin,
+                             ActionServerBase):
 
   name          = 'ArmMoveCartesian'
   action_type   = owl_msgs.msg.ArmMoveCartesianAction
@@ -241,28 +225,13 @@ class ArmMoveCartesianServer(ArmActionMixin, ActionServerBase):
     self._publish_feedback(pose=self._arm_tip_monitor.get_link_pose())
 
   def execute_action(self, goal):
-    ARM_END_EFFECTOR = 'l_scoop_tip'
-    COMPARISON_FRAME = 'world'
-    # handle goal parameters
-    # NOTE: this all processes fast enough that there is no need to check-out
-    #       the arm first
-    relative, frame_id = _resolve_frame(goal)
-    if frame_id is None:
-      self._set_aborted(f"Unrecognized frame {goal.frame}")
-      return
-    pose = goal.pose
-    # save tool transform now so the old transform can be used for comparison
-    old_tool_transform = None
-    if relative:
-      old_tool_transform = FrameTransformer().lookup_transform(COMPARISON_FRAME,
-                                                               frame_id)
-      if old_tool_transform is None:
-        self._set_aborted("Failed to lookup frame transform")
-        return
+    pose = self.handle_pose_goal(goal)
+    if pose is None:
+      self._set_aborted(self.abort_message)
     # perform action
     try:
       self._arm.checkout_arm(self.name)
-      plan = self._planner.plan_arm_to_pose(pose, frame_id, ARM_END_EFFECTOR)
+      plan = self._planner.plan_arm_to_pose(pose, self.ARM_END_EFFECTOR)
       self._arm.execute_arm_trajectory(plan,
         action_feedback_cb=self.publish_feedback_cb)
     except RuntimeError as err:
@@ -271,35 +240,16 @@ class ArmMoveCartesianServer(ArmActionMixin, ActionServerBase):
         final_pose=self._arm_tip_monitor.get_link_pose())
     else:
       self._arm.checkin_arm(self.name)
-      # check if requested pose agrees with commanded pose in comparison frame
-      final = self._planner.get_end_effector_pose(ARM_END_EFFECTOR,
-        frame_id=COMPARISON_FRAME)
-      # the transform before tool movement must be used because the Tool frame
-      # moves with the tool
-      expected = None
-      if relative:
-        # this function ignores the header
-        expected = do_transform_pose(PoseStamped(pose=pose), old_tool_transform)
-      else:
-        expected = FrameTransformer().transform(
-          PoseStamped(header=Header(0, rospy.Time(0), frame_id), pose=pose),
-          COMPARISON_FRAME
-        )
-      if final is None or expected is None:
-        self._set_aborted(
-          "Failed to perform necessary transforms to verify final pose",
-          final_pose=self._arm_tip_monitor.get_link_pose()
-        )
-        return
-      if not poses_approx_equivalent(expected.pose, final.pose):
-        self._set_aborted("Failed to reach commanded pose",
+      if not self.pose_reached(pose):
+        self._set_aborted(self.abort_message,
           final_pose=self._arm_tip_monitor.get_link_pose())
-        return
       self._set_succeeded(f"{self.name} trajectory succeeded",
         final_pose=self._arm_tip_monitor.get_link_pose())
 
 
-class ArmMoveCartesianGuardedServer(ArmActionMixin, ActionServerBase):
+class ArmMoveCartesianGuardedServer(ModifyPoseMixin,
+                                    ArmActionMixin,
+                                    ActionServerBase):
 
   name          = 'ArmMoveCartesianGuarded'
   action_type   = owl_msgs.msg.ArmMoveCartesianGuardedAction
@@ -308,12 +258,9 @@ class ArmMoveCartesianGuardedServer(ArmActionMixin, ActionServerBase):
   result_type   = owl_msgs.msg.ArmMoveCartesianGuardedResult
 
   def execute_action(self, goal):
-    ARM_END_EFFECTOR = 'l_scoop_tip'
-    pose = goal.pose
-    _, frame_id = _resolve_frame(goal)
-    if frame_id is None:
-      self._set_aborted(f"Unrecognized frame {goal.frame}")
-      return
+    pose = self.handle_pose_goal(goal)
+    if pose is None:
+      self._set_aborted(self.abort_message)
     # monitor F/T sensor and define a callback to check its status
     monitor = FTSensorThresholdMonitor(force_threshold=goal.force_threshold,
                                        torque_threshold=goal.torque_threshold)
@@ -329,7 +276,7 @@ class ArmMoveCartesianGuardedServer(ArmActionMixin, ActionServerBase):
     # perform action
     try:
       self._arm.checkout_arm(self.name)
-      plan = self._planner.plan_arm_to_pose(pose, frame_id, ARM_END_EFFECTOR)
+      plan = self._planner.plan_arm_to_pose(pose, self.ARM_END_EFFECTOR)
       self._arm.execute_arm_trajectory(plan, action_feedback_cb=guarded_cb)
     except RuntimeError as err:
       self._arm.checkin_arm(self.name)
@@ -339,7 +286,21 @@ class ArmMoveCartesianGuardedServer(ArmActionMixin, ActionServerBase):
         final_torque=monitor.get_torque())
     else:
       self._arm.checkin_arm(self.name)
-      self._set_succeeded(_format_guarded_movement_message(self.name, monitor),
+      if not monitor.threshold_breached() and not self.pose_reached(pose):
+        # pose was not reached due to planning/monitor error
+        # FIXME: this does not handle case where the pose check failed, better
+        #        error handling is required
+        self._set_aborted(
+          "Arm failed to reach pose despite neither force nor torque " \
+          "thresholds being breached. Likely the thresholds were set too " \
+          "high or a planning error occurred. Try a lower threshold.",
+          final_pose=self._arm_tip_monitor.get_link_pose(),
+          final_force=monitor.get_force(),
+          final_torque=monitor.get_torque()
+        )
+        return
+      self._set_succeeded(
+        _format_guarded_move_success_message(self.name, monitor),
         final_pose=self._arm_tip_monitor.get_link_pose(),
         final_force=monitor.get_force(),
         final_torque=monitor.get_torque()

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -21,6 +21,8 @@ from std_msgs.msg import Header
 from ow_lander.common import poses_approx_equivalent
 from ow_lander.frame_transformer import FrameTransformer
 from tf2_geometry_msgs import do_transform_pose
+# require for ArmMoveCartesianGuarded
+from ow_lander.ground_detector import FTSensorThresholdMonitor
 
 # required for LightSetIntensity
 from irg_gazebo_plugins.msg import ShaderParamUpdate
@@ -197,7 +199,7 @@ class DeliverServer(ArmTrajectoryMixin, ActionServerBase):
     return self._planner.deliver_sample()
 
 
-class ArmMoveCartesianServer(ArmActionMixin, ActionServerBase):
+class ArmMoveCartesianServer(ArmCartesianMoveMixin, ActionServerBase):
 
   name          = 'ArmMoveCartesian'
   action_type   = owl_msgs.msg.ArmMoveCartesianAction
@@ -209,35 +211,13 @@ class ArmMoveCartesianServer(ArmActionMixin, ActionServerBase):
     self._publish_feedback(pose=self._arm_tip_monitor.get_link_pose())
 
   def execute_action(self, goal):
-    ARM_END_EFFECTOR = 'l_scoop_tip'
-    # select a stationary frame for the final pose to be verified in
-    COMPARISON_FRAME = 'world'
-
-    # handle goal parameters
-    # NOTE: this all processes fast enough that there is no need to check-out
-    #       the arm first
-    if goal.frame not in constants.FRAME_ID_MAP:
-      self._set_aborted(f"Unrecognized frame {goal.frame}")
-      return
+    frame_id, relative = self.interpret_frame(goal)
     pose = goal.pose
-    # selecting relative is the same as selecting the Tool frame and vice versa
-    relative = goal.relative or goal.frame == constants.FRAME_TOOL
-    frame_id = constants.FRAME_ID_MAP[constants.FRAME_TOOL] if relative \
-               else constants.FRAME_ID_MAP[goal.frame]
-
-    # save tool transform now so the old transform can be used for comparison
-    old_tool_transform = None
-    if relative:
-      old_tool_transform = FrameTransformer().lookup_transform(COMPARISON_FRAME,
-                                                               frame_id)
-      if old_tool_transform is None:
-        self._set_aborted("Failed to lookup frame transform")
-        return
-
     # perform action
     try:
       self._arm.checkout_arm(self.name)
-      plan = self._planner.plan_arm_to_pose(pose, frame_id, ARM_END_EFFECTOR)
+      plan = self._planner.plan_arm_to_pose(pose, frame_id,
+        self.ARM_END_EFFECTOR)
       self._arm.execute_arm_trajectory(plan,
         action_feedback_cb=self.publish_feedback_cb)
     except RuntimeError as err:
@@ -250,18 +230,19 @@ class ArmMoveCartesianServer(ArmActionMixin, ActionServerBase):
       rospy.sleep(2.0)
       self._arm.checkin_arm(self.name)
       # check if requested pose agrees with commanded pose in comparison frame
-      final = self._planner.get_end_effector_pose(ARM_END_EFFECTOR,
-        frame_id=COMPARISON_FRAME)
+      final = self._planner.get_end_effector_pose(self.ARM_END_EFFECTOR,
+        frame_id=self.COMPARISON_FRAME)
       # the transform before tool movement must be used because the Tool frame
       # moves with the tool
       expected = None
       if relative:
         # this function ignores the header
-        expected = do_transform_pose(PoseStamped(pose=pose), old_tool_transform)
+        expected = do_transform_pose(PoseStamped(pose=pose),
+          self.premovement_tool_transform)
       else:
         expected = FrameTransformer().transform(
           PoseStamped(header=Header(0, rospy.Time(0), frame_id), pose=pose),
-          COMPARISON_FRAME
+          self.COMPARISON_FRAME
         )
       if final is None or expected is None:
         self._set_aborted(
@@ -276,6 +257,68 @@ class ArmMoveCartesianServer(ArmActionMixin, ActionServerBase):
       self._set_succeeded(f"{self.name} trajectory succeeded",
         final_pose=self._arm_tip_monitor.get_link_pose())
 
+class ArmMoveCartesianGuardedServer(ArmCartesianMoveMixin, ActionServerBase):
+
+  name          = 'ArmMoveCartesianGuarded'
+  action_type   = owl_msgs.msg.ArmMoveCartesianGuardedAction
+  goal_type     = owl_msgs.msg.ArmMoveCartesianGuardedGoal
+  feedback_type = owl_msgs.msg.ArmMoveCartesianGuardedFeedback
+  result_type   = owl_msgs.msg.ArmMoveCartesianGuardedResult
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+
+  def execute_action(self, goal):
+    pose = goal.pose
+    frame_id, relative = self.interpret_frame(goal)
+    if frame_id is None:
+      return
+    monitor = FTSensorThresholdMonitor(goal.force_threshold,
+                                       goal.torque_threshold)
+    def guarded_cb():
+      self._publish_feedback(
+        pose=self._arm_tip_monitor.get_link_pose(),
+        force=monitor.get_force(),
+        torque=monitor.get_torque()
+      )
+      if monitor.threshold_reached():
+        self._arm.stop_trajectory_silently()
+
+    # perform action
+    try:
+      self._arm.checkout_arm(self.name)
+      plan = self._planner.plan_arm_to_pose(pose, frame_id,
+        self.ARM_END_EFFECTOR)
+      self._arm.execute_arm_trajectory(plan,
+        action_feedback_cb=guarded_cb)
+    except RuntimeError as err:
+      self._arm.checkin_arm(self.name)
+      self._set_aborted(str(err),
+        final_pose=self._arm_tip_monitor.get_link_pose())
+    else:
+      # FIXME: follow trajectory action sometimes returns an early result; this
+      #        sleep provides a buffer in time in case that happens (OW-1097)
+      rospy.sleep(2.0)
+      self._arm.checkin_arm(self.name)
+      if monitor.threshold_reached():
+        msg = f"{self.name} trajectory stopped by "
+        if monitor.force_threshold_reached():
+          msg += f"a force of {monitor.get_force()} N"
+        if monitor.torque_threshold_reached():
+          msg += " and " if monitor.force_threshold_reached() else ""
+          msg += f"a torque of {monitor.get_torque()} Nm"
+        self._set_succeeded(msg,
+          final_pose=self._arm_tip_monitor.get_link_pose(),
+          final_force=monitor.get_force(),
+          final_torque=monitor.get_torque())
+      else:
+        self._set_succeeded(
+          f"{self.name} trajectory completed without breaking force or torque" \
+          f"thresholds.",
+          final_pose=self._arm_tip_monitor.get_link_pose(),
+          final_force=monitor.get_force(),
+          final_torque=monitor.get_torque()
+        )
 
 class ArmMoveJointServer(ModifyJointValuesMixin, ActionServerBase):
 

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -315,8 +315,8 @@ class ArmMoveCartesianGuardedServer(ArmActionMixin, ActionServerBase):
       self._set_aborted(f"Unrecognized frame {goal.frame}")
       return
     # monitor F/T sensor and define a callback to check its status
-    monitor = FTSensorThresholdMonitor(goal.force_threshold,
-                                       goal.torque_threshold)
+    monitor = FTSensorThresholdMonitor(force_threshold=goal.force_threshold,
+                                       torque_threshold=goal.torque_threshold)
     def guarded_cb():
       self._publish_feedback(
         pose=self._arm_tip_monitor.get_link_pose(),

--- a/ow_lander/src/ow_lander/arm_interface.py
+++ b/ow_lander/src/ow_lander/arm_interface.py
@@ -152,6 +152,10 @@ class ArmInterface:
     # wait for action to complete in case it takes longer than the timeout
     self._executor.wait()
 
+    # FIXME: follow trajectory action sometimes returns an early result; this
+    #        sleep provides a buffer in time in case that happens (OW-1097)
+    rospy.sleep(2.0)
+
 class ArmFaultMonitor(metaclass=Singleton):
     """Checks whether the arm has faulted."""
 

--- a/ow_lander/src/ow_lander/constants.py
+++ b/ow_lander/src/ow_lander/constants.py
@@ -29,6 +29,17 @@ ARM_JOINT_TOLERANCE = 0.05 # radians
 ARM_POSE_METER_TOLERANCE = 0.01
 ARM_POSE_RADIAN_TOLERANCE = 0.05
 
+# all arm joint names
+ARM_JOINTS = [ 'j_shou_yaw','j_shou_pitch','j_prox_pitch',
+               'j_dist_pitch','j_hand_yaw', 'j_scoop_yaw' ]
+
+# all antenna joints
+ANTENNA_JOINTS = ['j_ant_pan', 'j_ant_tilt']
+
+# joint names mapped to their index in /joint_states (alphabetized by name)
+_all_joints = ARM_JOINTS + ANTENNA_JOINTS + ['j_grinder']
+JOINT_STATES_MAP = dict(zip(sorted(_all_joints), range(len(_all_joints))))
+
 X_SHOU = 0.79
 Y_SHOU = 0.175
 HAND_Y_OFFSET = 0.0249979319838

--- a/ow_lander/src/ow_lander/ground_detector.py
+++ b/ow_lander/src/ow_lander/ground_detector.py
@@ -13,7 +13,7 @@ def _magnitude(vec):
 
 class FTSensorThresholdMonitor:
 
-  def __init__(self, force_threshold, torque_threshold):
+  def __init__(self, force_threshold=None, torque_threshold=None):
     self._ft_sensor_sub = rospy.Subscriber('/ft_sensor_dist_pitch',
                                            WrenchStamped,
                                            self._ft_sensor_cb)
@@ -24,25 +24,31 @@ class FTSensorThresholdMonitor:
 
   def _ft_sensor_cb(self, msg):
     wrench = msg.wrench
-    self._force = _magnitude(wrench.force)
-    self._torque = _magnitude(wrench.torque)
+    if self.is_force_monitor(): self._force = _magnitude(wrench.force)
+    if self.is_torque_monitor(): self._torque = _magnitude(wrench.torque)
     if self.threshold_breached():
       self._ft_sensor_sub.unregister()
 
+  def is_force_monitor(self):
+    return self._force_threshold is not None
+
+  def is_torque_monitor(self):
+    return self._torque_threshold is not None
+
   def force_threshold_breached(self):
-    return self._force >= self._force_threshold
+    return self.is_force_monitor() and self._force >= self._force_threshold
 
   def torque_threshold_breached(self):
-    return self._torque >= self._torque_threshold
+    return self.is_torque_monitor() and self._torque >= self._torque_threshold
 
   def threshold_breached(self):
     return self.force_threshold_breached() or self.torque_threshold_breached()
 
   def get_force(self):
-    return self._force
+    return self._force if self.is_force_monitor() else None
 
   def get_torque(self):
-    return self._torque
+    return self._torque if self.is_torque_monitor() else None
 
 
 # DEPRECATED: Only supports GuardedMove, which is itself deprecated

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -73,7 +73,6 @@ class ArmTrajectoryMixin(ArmActionMixin, ABC):
   def plan_trajectory(self, goal):
     pass
 
-
 class GrinderTrajectoryMixin(ArmActionMixin, ABC):
 
   def __init__(self, *args, **kwargs):
@@ -103,44 +102,12 @@ class GrinderTrajectoryMixin(ArmActionMixin, ABC):
   def plan_trajectory(self, goal):
     pass
 
-class ArmCartesianMoveMixin(ArmActionMixin, ABC):
-
-  # name of the end-effector that is posed
-  ARM_END_EFFECTOR = 'l_scoop_tip'
-  # a stationary frame for the final pose to be verified in
-  COMPARISON_FRAME = 'world'
-
-  def interpret_frame(self, goal):
-    # handle goal parameters
-    # NOTE: this all processes fast enough that there is no need to check-out
-    #       the arm first
-    if goal.frame not in constants.FRAME_ID_MAP:
-      self._set_aborted(f"Unrecognized frame {goal.frame}")
-      return None, None
-    # selecting relative is the same as selecting the Tool frame and vice versa
-    relative = goal.relative or goal.frame == constants.FRAME_TOOL
-    frame_id = constants.FRAME_ID_MAP[constants.FRAME_TOOL] if relative \
-               else constants.FRAME_ID_MAP[goal.frame]
-
-    # save tool transform now so the old transform can be used for comparison
-    self.premovement_tool_transform = None
-    if relative:
-      self.premovement_tool_transform = FrameTransformer().lookup_transform(
-        self.COMPARISON_FRAME, frame_id)
-      if self.premovement_tool_transform is None:
-        self._set_aborted("Failed to lookup frame transform")
-        return None, None
-    return frame_id, relative
 
 class ModifyJointValuesMixin(ArmActionMixin, ABC):
 
   def __init__(self, *args, **kwargs):
-    ARM_JOINTS = [
-      'j_shou_yaw','j_shou_pitch','j_prox_pitch',
-      'j_dist_pitch','j_hand_yaw', 'j_scoop_yaw'
-    ]
     super().__init__(*args, **kwargs)
-    self._arm_joints_monitor = JointAnglesSubscriber(ARM_JOINTS)
+    self._arm_joints_monitor = JointAnglesSubscriber(constants.ARM_JOINTS)
 
   # NOTE: these two helper functions are hacky work-arounds necessary because
   #       ArmMoveJoints.action uses wrong names in feedback and result (OW-1096)

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -9,18 +9,21 @@ define non-arm mixins.
 """
 
 import sys
+from abc import ABC, abstractmethod
 import rospy
 import actionlib
 import moveit_commander
+from tf2_geometry_msgs import do_transform_pose
+
+from geometry_msgs.msg import PoseStamped
+from std_msgs.msg import Header
 
 from ow_lander.arm_interface import ArmInterface
 from ow_lander.trajectory_planner import ArmTrajectoryPlanner
 from ow_lander.subscribers import LinkStateSubscriber, JointAnglesSubscriber
-from ow_lander.common import radians_equivalent
+from ow_lander.common import radians_equivalent, poses_approx_equivalent
 from ow_lander.frame_transformer import FrameTransformer
 from ow_lander import constants
-
-from abc import ABC, abstractmethod
 
 class ArmActionMixin:
   """Enables an action server to control the OceanWATERS arm. This or one of its
@@ -102,6 +105,62 @@ class GrinderTrajectoryMixin(ArmActionMixin, ABC):
   def plan_trajectory(self, goal):
     pass
 
+class ModifyPoseMixin:
+  """Can be inherited by ArmMoveActions that modify pose. DOES NOT implement an
+  arm interface, and so must be inherited along with ArmActionMixin or one of
+  its children.
+  """
+
+  ARM_END_EFFECTOR = 'l_scoop_tip'
+  COMPARISON_FRAME = 'world'
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self.abort_message = ""
+    self.old_tool_transform = None
+
+  def handle_pose_goal(self, goal):
+    self.abort_message = ""
+    if goal.frame not in constants.FRAME_ID_MAP:
+      self.abort_message = f"Unrecognized frame {goal.frame}"
+      return None
+    # selecting relative is the same as selecting the Tool frame and vice versa
+    relative = goal.relative or goal.frame == constants.FRAME_TOOL
+    frame_id = constants.FRAME_ID_MAP[constants.FRAME_TOOL] if relative \
+               else constants.FRAME_ID_MAP[goal.frame]
+
+    # save tool transform now so the old transform can be used for comparison
+    if relative:
+      self.old_tool_transform = FrameTransformer() \
+        .lookup_transform(self.COMPARISON_FRAME, frame_id)
+      if self.old_tool_transform is None:
+        self.abort_message = "Failed to lookup TOOL frame transform"
+        return None
+    return PoseStamped(header = Header(0, rospy.Time(0), frame_id),
+                       pose = goal.pose)
+
+  def pose_reached(self, pose):
+    # check if requested pose agrees with commanded pose in comparison frame
+    final = self._planner.get_end_effector_pose(self.ARM_END_EFFECTOR,
+      frame_id=self.COMPARISON_FRAME)
+    # the transform before tool movement must be used because the Tool frame
+    # moves with the tool
+    expected = None
+    if self.old_tool_transform is not None: # if movement was relative
+      # this function ignores the header
+      expected = do_transform_pose(pose,
+        self.old_tool_transform)
+      self.old_tool_transform = None
+    else:
+      expected = FrameTransformer().transform(pose, self.COMPARISON_FRAME)
+    if final is None or expected is None:
+      self.abort_message = "Failed to perform necessary transforms to verify " \
+                           "final pose"
+      return False
+    if poses_approx_equivalent(expected.pose, final.pose):
+      return True
+    else:
+      self.abort_message = "Failed to reach commanded pose"
 
 class ModifyJointValuesMixin(ArmActionMixin, ABC):
 

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -17,7 +17,8 @@ from ow_lander.arm_interface import ArmInterface
 from ow_lander.trajectory_planner import ArmTrajectoryPlanner
 from ow_lander.subscribers import LinkStateSubscriber, JointAnglesSubscriber
 from ow_lander.common import radians_equivalent
-from ow_lander.constants import ARM_JOINT_TOLERANCE
+from ow_lander.frame_transformer import FrameTransformer
+from ow_lander import constants
 
 from abc import ABC, abstractmethod
 
@@ -102,6 +103,34 @@ class GrinderTrajectoryMixin(ArmActionMixin, ABC):
   def plan_trajectory(self, goal):
     pass
 
+class ArmCartesianMoveMixin(ArmActionMixin, ABC):
+
+  # name of the end-effector that is posed
+  ARM_END_EFFECTOR = 'l_scoop_tip'
+  # a stationary frame for the final pose to be verified in
+  COMPARISON_FRAME = 'world'
+
+  def interpret_frame(self, goal):
+    # handle goal parameters
+    # NOTE: this all processes fast enough that there is no need to check-out
+    #       the arm first
+    if goal.frame not in constants.FRAME_ID_MAP:
+      self._set_aborted(f"Unrecognized frame {goal.frame}")
+      return None, None
+    # selecting relative is the same as selecting the Tool frame and vice versa
+    relative = goal.relative or goal.frame == constants.FRAME_TOOL
+    frame_id = constants.FRAME_ID_MAP[constants.FRAME_TOOL] if relative \
+               else constants.FRAME_ID_MAP[goal.frame]
+
+    # save tool transform now so the old transform can be used for comparison
+    self.premovement_tool_transform = None
+    if relative:
+      self.premovement_tool_transform = FrameTransformer().lookup_transform(
+        self.COMPARISON_FRAME, frame_id)
+      if self.premovement_tool_transform is None:
+        self._set_aborted("Failed to lookup frame transform")
+        return None, None
+    return frame_id, relative
 
 class ModifyJointValuesMixin(ArmActionMixin, ABC):
 
@@ -124,7 +153,7 @@ class ModifyJointValuesMixin(ArmActionMixin, ABC):
     actual = self._arm_joints_monitor.get_joint_positions()
     success = all(
       [
-        radians_equivalent(a, b, ARM_JOINT_TOLERANCE)
+        radians_equivalent(a, b, constants.ARM_JOINT_TOLERANCE)
           for a, b in zip(actual, target)
       ]
     )

--- a/ow_lander/src/ow_lander/trajectory_planner.py
+++ b/ow_lander/src/ow_lander/trajectory_planner.py
@@ -129,14 +129,13 @@ class ArmTrajectoryPlanner(metaclass = Singleton):
         _, plan, _, _ = self._move_arm.plan()
         return plan
 
-    def plan_arm_to_pose(self, pose, frame_id, end_effector):
-        # transform desired pose from user's desired frame to arm's pose frame
-        stamped = PoseStamped(
-            header = _create_most_recent_header(frame_id),
-            pose = pose
-        )
+    def plan_arm_to_pose(self, pose, end_effector):
+        """Plan a trajectory from arm's current pose to a new pose
+        pose         -- Stamped pose plan will place end effector at
+        end_effector -- Name of end_effector
+        """
         arm_frame = self._move_arm.get_pose_reference_frame()
-        pose_t = FrameTransformer().transform(stamped, arm_frame)
+        pose_t = FrameTransformer().transform(pose, arm_frame)
         if pose_t is None:
             return False
         # plan trajectory to pose in the arm's pose frame

--- a/owl_msgs/CMakeLists.txt
+++ b/owl_msgs/CMakeLists.txt
@@ -70,6 +70,7 @@ add_message_files(
 add_action_files(
   FILES
   ArmMoveCartesian.action
+  ArmMoveCartesianGuarded.action
 )
 
 ## Generate added messages and services with any dependencies listed here

--- a/owl_msgs/action/ArmMoveCartesianGuarded.action
+++ b/owl_msgs/action/ArmMoveCartesianGuarded.action
@@ -1,0 +1,16 @@
+# goal definition
+int32 frame
+bool relative
+geometry_msgs/Pose pose
+float64 force_threshold
+float64 torque_threshold
+---
+# result
+geometry_msgs/Pose final_pose
+float64 final_force
+float64 final_torque
+---
+# feedback
+geometry_msgs/Pose pose
+float64 force
+float64 torque


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-933](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-933) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-945](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-945) |
| Github :octocat:  | # |

## Summary of Changes
* Added ArmMoveCartesianGuarded
* There is now a mixin for arm actions that modify pose. 
* Reduced code repetition where possible between ArmMoveCartesian and actions not yet added (this will likely be on-going). 

## Reviewer Assignments
@anthonykoutroulis To save your own time, please only perform a review of the code.
@kmdalal Perform the following tests, and review the code at your discretion.

## Test Help Message
Test help message and proof-read
```
$ rosrun ow_lander arm_move_cartesian_guarded.py --help  
usage: arm_move_cartesian_guarded.py [-h] [--frame {0,1}] [--relative] [-x X] [-y Y] [-z Z]
                                     [--euler X Y Z | --quaternion X Y Z W] [--force FORCE]
                                     [--torque TORQUE]

Move end-effector by Cartesian coordinates/translation.

optional arguments:
  -h, --help            show this help message and exit
  --frame {0,1}, -f {0,1}
                        The frame index corresponding to the frame that orientation and position are
                        relative to. {0: 'base_link', 1: 'l_scoop_tip'} (default: 0)
  --relative, -r        If True, pose will be interpreted as relative to the current pose. (default: False)
  -x X                  X-coordinate or the change in the X-coordinate (default: 0)
  -y Y                  Y-coordinate or the change in the Y-coordinate (default: 0)
  -z Z                  Z-coordinate or the change in the Z-coordinate (default: 0)
  --euler X Y Z, -e X Y Z
                        Orientation in Euler angle form. Takes 3 radian values. (default: [0, 0, 0])
  --quaternion X Y Z W, -q X Y Z W
                        Orientation in quaternion form. Takes 4 scalars, the first 3 are the imaginary
                        parts, and the 4th is the real part. (default: [0, 0, 0, 1])
  --force FORCE         Arm will stop when F/T sensor encounters a force above this value in Newtons
                        (default: 200)
  --torque TORQUE       Arm will stop when F/T sensor encounters a torque above this value in Newton*meters
                        (default: 100)
```

## Test Action
1. Start simulation in atacama_y1a so that terrain is consistent across tests.
2. Prime scoop to poke ground with 
`rosrun ow_lander arm_move_cartesian.py  -x 1.7 -e 3.14 0 0`. 
The scoop should now be just above the ground.
3. Perform a guarded relative move of the scoop down and into the ground with 
`rosrun ow_lander arm_move_cartesian_guarded.py -r -z 0.6` 
The following output should result. Force value will vary, but should be above 200 N.
```
ArmMoveCartesianGuarded: Succeded - ArmMoveCartesianGuarded trajectory stopped by a force of 309.77 N
```
4. Lift scoop off the ground and up high
`rosrun ow_lander arm_move_cartesian.py  -x 1.7 -z 0.5 -e 3.14 0 0`
5. Call the same relative guarded move command as before 
`rosrun ow_lander arm_move_cartesian_guarded.py -r -z 0.6` 
Scoop should stop just above the ground. The following output should result
```
ArmMoveCartesianGuarded: Succeded - ArmMoveCartesianGuarded trajectory completed without breaching force or torque thresholds
```
6. Call the same relative guarded move command but now increasing the force tolerance to something unreachable
`rosrun ow_lander arm_move_cartesian_guarded.py -r -z 0.6 --force 600` 
Scoop will hit the terrain and the following error output result
```
ArmMoveCartesianGuarded: Aborted - Arm failed to reach pose despite neither force nor torque thresholds being breached. Likely the thresholds were set too high or a planning error occurred. Try a lower threshold.
```
7. While scoop is still planted on the ground, cause a torque and force threshold breach by sliding it horizontally and setting a low torque threshold.
`rosrun ow_lander arm_move_cartesian_guarded.py -r -y 0.1 --torque 10`
Note that force threshold is should now be breached because we used the default of 200 N. Output should be
```
ArmMoveCartesianGuarded: Succeded - ArmMoveCartesianGuarded trajectory stopped by a force of 368.85 N and a torque of 31.97 Nm
```
8. Finally try and get only a torque threshold breach by doing the same maneuver but making the force threshold unreachable. 
`rosrun ow_lander arm_move_cartesian_guarded.py -r -y 0.1 --force 600 --torque 10`
```
ArmMoveCartesianGuarded: Succeded - ArmMoveCartesianGuarded trajectory stopped by a torque of 56.07 Nm
```
