### PR TITLE
Oceanwater 949 - ArmFindSurface

### DIFF
--- a/ow_lander/action/GuardedMove.action
+++ b/ow_lander/action/GuardedMove.action
@@ -1,3 +1,4 @@
+### DEPRECATED: ArmFindSurface should be used in place of GuardedMove
 # goal
 geometry_msgs/Point start     # arm start position
 geometry_msgs/Point normal    # vector normal to direction of approach

--- a/ow_lander/scripts/arm_find_surface.py
+++ b/ow_lander/scripts/arm_find_surface.py
@@ -34,7 +34,7 @@ parser.add_argument('--normal', '-n', type=float, nargs=3,
   help="Normal vector in which arm will move a distance + overdrive in until "
        "either the force or torque thresholds are breached. This will always "
        "be interpreted in the base_link frame.")
-parser.add_argument('--distance', '-d', type=float, default=0.1,
+parser.add_argument('--distance', '-d', type=float, default=0.2,
   help="Distance away from the estimated surface position that the "
        "end-effector starts its trajectory.")
 parser.add_argument('--overdrive', '-o', type=float, default=0.05,

--- a/ow_lander/scripts/arm_find_surface.py
+++ b/ow_lander/scripts/arm_find_surface.py
@@ -36,7 +36,7 @@ parser.add_argument('--normal', '-n', type=float, nargs=3,
        "be interpreted in the base_link frame.")
 parser.add_argument('--distance', '-d', type=float, default=0.1,
   help="Distance away from the estimated surface position that the "
-       "end-effector start its trajectory.")
+       "end-effector starts its trajectory.")
 parser.add_argument('--overdrive', '-o', type=float, default=0.05,
   help="Distance beyond the estimated surface position through which the "
        "end-effector will keep pushing.")

--- a/ow_lander/scripts/arm_find_surface.py
+++ b/ow_lander/scripts/arm_find_surface.py
@@ -31,8 +31,9 @@ parser.add_argument('-z', type=float, default=0,
   help="Z-coordinate or the change in the Z-coordinate")
 parser.add_argument('--normal', '-n', type=float, nargs=3,
   default=[0, 0, -1], metavar=('Nx', 'Ny', 'Nz'),
-  help="Normal vector in which arm will move a distance + overdrive in until" \
-       "either the force or torque thresholds are breached")
+  help="Normal vector in which arm will move a distance + overdrive in until " \
+       "either the force or torque thresholds are breached. This will always " \
+       "be interpreted in the base_link frame.")
 parser.add_argument('--distance', '-d', type=float, default=0.1,
   help="Distance away from the estimated surface position that the " \
        "end-effector start its trajectory.")

--- a/ow_lander/scripts/arm_find_surface.py
+++ b/ow_lander/scripts/arm_find_surface.py
@@ -14,12 +14,12 @@ from geometry_msgs.msg import Point, Vector3
 
 parser = argparse.ArgumentParser(
   formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-  description="Determine the position of a surface by moving the arm's " \
-              "end-effector towards surface until sufficient resistance is " \
+  description="Determine the position of a surface by moving the arm's "
+              "end-effector towards surface until sufficient resistance is "
               "encountered.")
 parser.add_argument('--frame', '-f', type=int, default=0,
   choices=constants.FRAME_ID_MAP.keys(),
-  help="The frame index corresponding to the frame that orientation and "\
+  help="The frame index corresponding to the frame that orientation and "
        "position are relative to. " + str(constants.FRAME_ID_MAP))
 parser.add_argument('--relative', '-r', action='store_true', default=False,
   help="If True, pose will be interpreted as relative to the current pose.")
@@ -31,20 +31,20 @@ parser.add_argument('-z', type=float, default=0,
   help="Z-coordinate or the change in the Z-coordinate")
 parser.add_argument('--normal', '-n', type=float, nargs=3,
   default=[0, 0, -1], metavar=('Nx', 'Ny', 'Nz'),
-  help="Normal vector in which arm will move a distance + overdrive in until " \
-       "either the force or torque thresholds are breached. This will always " \
+  help="Normal vector in which arm will move a distance + overdrive in until "
+       "either the force or torque thresholds are breached. This will always "
        "be interpreted in the base_link frame.")
 parser.add_argument('--distance', '-d', type=float, default=0.1,
-  help="Distance away from the estimated surface position that the " \
+  help="Distance away from the estimated surface position that the "
        "end-effector start its trajectory.")
 parser.add_argument('--overdrive', '-o', type=float, default=0.05,
-  help="Distance beyond the estimated surface position through which the "\
+  help="Distance beyond the estimated surface position through which the "
        "end-effector will keep pushing.")
 parser.add_argument('--force', type=float, default=200,
-  help="Arm will stop when F/T sensor encounters a force above this value in " \
+  help="Arm will stop when F/T sensor encounters a force above this value in "
        "Newtons")
 parser.add_argument('--torque', type=float, default=100,
-  help="Arm will stop when F/T sensor encounters a torque above this value " \
+  help="Arm will stop when F/T sensor encounters a torque above this value "
        "in Newton*meters")
 
 args = parser.parse_args()

--- a/ow_lander/scripts/guarded_move_action_client.py
+++ b/ow_lander/scripts/guarded_move_action_client.py
@@ -13,7 +13,9 @@ import argparse
 
 parser = argparse.ArgumentParser(
   formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-  description="Move arm slowly in a direction until a surface is detected.")
+  description="Move arm slowly in a direction until a surface is detected. " \
+              "DEPRECATED: ArmFindSurface should be used in place of " \
+              "GuardedMove")
 parser.add_argument('x_start', type=float, nargs='?', default=2.0,
   help='x-coordinates of guarded move starting point')
 parser.add_argument('y_start', type=float, nargs='?', default=0.0,

--- a/ow_lander/scripts/lander_action_servers.py
+++ b/ow_lander/scripts/lander_action_servers.py
@@ -24,6 +24,7 @@ server_move_joint     = actions.ArmMoveJointServer()
 server_move_joints    = actions.ArmMoveJointsServer()
 server_move_cartesian = actions.ArmMoveCartesianServer()
 server_move_cartesian_guarded = actions.ArmMoveCartesianGuardedServer()
+server_find_surface   = actions.ArmFindSurfaceServer()
 
 # other non-arm lander actions
 server_light_set_intensity = actions.LightSetIntensityServer()

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -18,8 +18,7 @@ from geometry_msgs.msg import Point
 # required for ArmMoveCartesianGuarded
 from ow_lander.ground_detector import FTSensorThresholdMonitor
 # required for ArmFindSurface
-from geometry_msgs.msg import (Vector3, Quaternion, QuaternionStamped,
-                               PoseStamped, Pose)
+from geometry_msgs.msg import Vector3, PoseStamped, Pose
 from ow_lander import math3d
 from ow_lander.frame_transformer import FrameTransformer
 
@@ -75,6 +74,7 @@ class StopServer(ArmActionMixin, ActionServerBase):
       self._set_aborted("No arm trajectory to stop",
         final=self._arm_tip_monitor.get_link_position())
 
+### DEPRECATED: ArmFindSurface should be used in place of GuardedMove
 class GuardedMoveServer(ArmActionMixin, ActionServerBase):
 
   # NOTE: The "final" in GuardedMove's result is not in the same frame as the

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -18,8 +18,10 @@ from geometry_msgs.msg import Point
 # required for ArmMoveCartesianGuarded
 from ow_lander.ground_detector import FTSensorThresholdMonitor
 # required for ArmFindSurface
-from geometry_msgs.msg import Vector3, Quaternion, PoseStamped, Pose
+from geometry_msgs.msg import (Vector3, Quaternion, QuaternionStamped,
+                               PoseStamped, Pose)
 from ow_lander import math3d
+from ow_lander.frame_transformer import FrameTransformer
 
 # required for LightSetIntensity
 from irg_gazebo_plugins.msg import ShaderParamUpdate
@@ -249,6 +251,7 @@ class ArmMoveCartesianServer(ModifyPoseMixin,
       if not self.pose_reached(pose):
         self._set_aborted(self.abort_message,
           final_pose=self._arm_tip_monitor.get_link_pose())
+        return
       self._set_succeeded(f"{self.name} trajectory succeeded",
         final_pose=self._arm_tip_monitor.get_link_pose())
 
@@ -308,22 +311,146 @@ class ArmMoveCartesianGuardedServer(ModifyPoseMixin,
           final_force=monitor.get_force(),
           final_torque=monitor.get_torque()
         )
+        return
+      self._set_succeeded(
+        _format_guarded_move_success_message(self.name, monitor),
+        final_pose=self._arm_tip_monitor.get_link_pose(),
+        final_force=monitor.get_force(),
+        final_torque=monitor.get_torque()
+      )
+
+
+class ArmFindSurfaceServer(ModifyPoseMixin, ArmActionMixin, ActionServerBase):
+
+  name          = 'ArmFindSurface'
+  action_type   = owl_msgs.msg.ArmFindSurfaceAction
+  goal_type     = owl_msgs.msg.ArmFindSurfaceGoal
+  feedback_type = owl_msgs.msg.ArmFindSurfaceFeedback
+  result_type   = owl_msgs.msg.ArmFindSurfaceResult
+
+  def publish_feedback_cb(self, distance=0, force=0, torque=0):
+    self._publish_feedback(
+      pose=self._planner.get_end_effector_pose(self.ARM_END_EFFECTOR).pose,
+      distance=distance,
+      force=force,
+      torque=torque
+    )
+
+  def execute_action(self, goal):
+    # the normal vector direction the scoop's bottom faces in its frame
+    SCOOP_DOWNWARD = Vector3(0, 0, 1)
+    frame_id = self.handle_frame_goal(goal)
+    if frame_id is None:
+      self._set_aborted(self.abort_message)
+      return
+    # orient scoop so that the bottom points in the opposite to the normal
+    # NOTE: regardless of frame parameter orientation is in the base_link frame
+    orientation = math3d.quaternion_rotation_between(SCOOP_DOWNWARD,
+                                                     goal.normal)
+    start = goal.position
+    if frame_id == constants.FRAME_ID_TOOL:
+      start = FrameTransformer().transform_present(start,
+        constants.FRAME_ID_TOOL, constants.FRAME_ID_BASE)
+      if start is None:
+        self._set_aborted("Failed to perform necessary frame transforms for " \
+                          "trajectory planning.")
+        return
+    max_distance = goal.distance + goal.overdrive
+    displacement = math3d.scalar_multiply(max_distance, goal.normal)
+    end = math3d.add(start, displacement)
+    # pose before end-effector is driven towards surface
+    pose1 = PoseStamped(
+      header=create_most_recent_header(constants.FRAME_ID_BASE),
+      pose=Pose(
+        position=start,
+        orientation=orientation
+      )
+    )
+    # pose after end-effector has driven its maximum distance towards surface
+    # if there is no surface, the end-effector will reach this pose
+    pose2 = PoseStamped(
+      header=create_most_recent_header(constants.FRAME_ID_BASE),
+      pose=Pose(
+        position=end,
+        orientation=orientation
+      )
+    )
+    # move to setup pose prior to surface approach
+    try:
+      self._arm.checkout_arm(self.name)
+      plan1 = self._planner.plan_arm_to_pose(pose1, self.ARM_END_EFFECTOR)
+      self._arm.execute_arm_trajectory(plan1,
+        action_feedback_cb=self.publish_feedback_cb)
+    except RuntimeError as err:
+      self._arm.checkin_arm(self.name)
+      self._set_aborted(str(err) + " - Setup trajectory failed",
+        final_pose=self._planner.get_end_effector_pose(self.ARM_END_EFFECTOR).pose,
+        final_distance=0, final_force=0, final_torque=0)
+      return
+    # TODO: pose1 should be verified here, but self.pose_reached does more than
+    #       its name lets one, and should be redesigned. Left as future work
+    # local function to compute progress of the action during surface approach
+    def compute_distance():
+      pose = self._planner.get_end_effector_pose(self.ARM_END_EFFECTOR).pose
+      d = math3d.subtract(pose.position, start)
+      return math3d.norm(d)
+    # setup F/T monitor and its callback
+    monitor = FTSensorThresholdMonitor(force_threshold=goal.force_threshold,
+                                       torque_threshold=goal.torque_threshold)
+    def guarded_cb():
+      self.publish_feedback_cb(
+        compute_distance(), monitor.get_force(), monitor.get_torque())
+      if monitor.threshold_breached():
+        self._arm.stop_trajectory_silently()
+    # move towards surface until F/T is breached or overdrive distance reached
+    try:
+      plan2 = self._planner.plan_arm_to_pose(pose2, self.ARM_END_EFFECTOR)
+      self._arm.execute_arm_trajectory(plan2, action_feedback_cb=guarded_cb)
+    except RuntimeError as err:
+      self._arm.checkin_arm(self.name)
+      self._set_aborted(str(err) + " - Surface approach trajectory failed",
+        final_pose=self._planner.get_end_effector_pose(self.ARM_END_EFFECTOR).pose,
+        final_distance=compute_distance(),
+        final_force=monitor.get_force(),
+        final_torque=monitor.get_torque()
+      )
+    else:
+      self._arm.checkin_arm(self.name)
+      if not monitor.threshold_breached() and not self.pose_reached(pose2):
+        # pose was not reached due to planning/monitor error
+        # FIXME: this does not handle case where the pose check failed, better
+        #        error handling is required
+        self._set_aborted(
+          "Arm failed to reach pose despite neither force nor torque " \
+          "thresholds being breached. Likely the thresholds were set too " \
+          "high or a planning error occurred. Try a lower threshold.",
+          final_pose=self._planner.get_end_effector_pose(self.ARM_END_EFFECTOR).pose,
+          final_distance=compute_distance(),
+          final_force=monitor.get_force(),
+          final_torque=monitor.get_torque()
+        )
       elif not monitor.threshold_breached():
         self._set_succeeded(
           "No surface was found",
-          final_pose=self._arm_tip_monitor.get_link_pose(),
+          final_pose=self._planner.get_end_effector_pose(self.ARM_END_EFFECTOR).pose,
+          final_distance=compute_distance(),
           final_force=monitor.get_force(),
           final_torque=monitor.get_torque()
         )
       else:
         msg = _format_guarded_move_success_message(self.name, monitor)
-        msg += ". Surface found."
+        pose = self._planner.get_end_effector_pose(self.ARM_END_EFFECTOR).pose
+        msg += f". Surface found at ({pose.position.x:0.3f}, "
+        msg +=                     f"{pose.position.y:0.3f}, "
+        msg +=                     f"{pose.position.z:0.3f})"
         self._set_succeeded(
           msg,
-          final_pose=self._arm_tip_monitor.get_link_pose(),
+          final_pose=pose,
+          final_distance=compute_distance(),
           final_force=monitor.get_force(),
           final_torque=monitor.get_torque()
         )
+
 
 class ArmMoveJointServer(ModifyJointValuesMixin, ActionServerBase):
 
@@ -364,98 +491,6 @@ class ArmMoveJointsServer(ModifyJointValuesMixin, ActionServerBase):
         pos[i] = goal.angles[i]
     return pos
 
-class ArmFindSurfaceServer(ModifyPoseMixin, ArmActionMixin, ActionServerBase):
-
-  name          = 'ArmFindSurface'
-  action_type   = owl_msgs.msg.ArmFindSurfaceAction
-  goal_type     = owl_msgs.msg.ArmFindSurfaceGoal
-  feedback_type = owl_msgs.msg.ArmFindSurfaceFeedback
-  result_type   = owl_msgs.msg.ArmFindSurfaceResult
-
-  def publish_feedback_cb(self):
-    self._publish_feedback(
-      pose=self._arm_tip_monitor.get_link_pose(),
-      distance=0,
-      force=0,
-      torque=0
-    )
-
-  def execute_action(self, goal):
-    # the direction the scoop's bottom faces in its frame
-    SCOOP_DOWNWARD = Vector3(0, 0, 1)
-    frame_id = self.handle_frame_goal(goal)
-    if frame_id is None:
-      self._set_aborted(self.abort_message)
-    start = goal.position
-    # orient scoop so that the bottom points in the opposite direction of the
-    # normal, and select a scoop yaw that faces radially away from the lander
-    orientation = math3d.quaternion_rotation_between(SCOOP_DOWNWARD, goal.normal)
-    pose1 = PoseStamped(
-      header=create_most_recent_header(frame_id),
-      pose=Pose(
-        position=goal.position,
-        orientation=orientation
-      )
-    )
-    max_distance = goal.distance + goal.overdrive
-    displacement = math3d.scalar_multiply(max_distance, goal.normal)
-    end = math3d.add(goal.position, displacement)
-    pose2 = PoseStamped(
-      header=create_most_recent_header(frame_id),
-      pose=Pose(
-        position=end,
-        orientation=orientation
-      )
-    )
-    def compute_distance():
-      d = math3d.subtract(self._arm_tip_monitor.get_link_position(), start)
-      return math3d.norm(d)
-
-    # perform actions
-    try:
-      self._arm.checkout_arm(self.name)
-      # setup phase
-      plan1 = self._planner.plan_arm_to_pose(pose1, self.ARM_END_EFFECTOR)
-      self._arm.execute_arm_trajectory(plan1,
-        action_feedback_cb=self.publish_feedback_cb)
-      # setup F/T monitor and its callback
-      monitor = FTSensorThresholdMonitor(force_threshold=goal.force_threshold,
-                                         torque_threshold=goal.torque_threshold)
-      def guarded_cb():
-        self.publish_feedback_cb()
-        if monitor.threshold_breached():
-          self._arm.stop_trajectory_silently()
-      # surface finding phase
-      plan2 = self._planner.plan_arm_to_pose(pose2, self.ARM_END_EFFECTOR)
-      self._arm.execute_arm_trajectory(plan2, action_feedback_cb=guarded_cb)
-    except RuntimeError as err:
-      self._arm.checkin_arm(self.name)
-      self._set_aborted(str(err),
-        pose=self._arm_tip_monitor.get_link_pose(),
-        distance=compute_distance(),
-        force=monitor.get_force(),
-        torque=monitor.get_torque()
-      )
-    else:
-      self._arm.checkin_arm(self.name)
-      if not monitor.threshold_breached() and not self.pose_reached(pose):
-        self._set_aborted(
-          "Arm failed to reach pose despite neither force nor torque " \
-          "thresholds being breached. Likely the thresholds were set too " \
-          "high or a planning error occurred. Try a lower threshold.",
-          final_pose=self._arm_tip_monitor.get_link_pose(),
-          final_distance=compute_distance(),
-          final_force=monitor.get_force(),
-          final_torque=monitor.get_torque()
-        )
-      else:
-        self._set_succeeded(
-          _format_guarded_move_success_message(self.name, monitor),
-          final_pose=self._arm_tip_monitor.get_link_pose(),
-          final_distance=compute_distance(),
-          final_force=monitor.get_force(),
-          final_torque=monitor.get_torque()
-        )
 
 #############################
 ## NON-ARM RELATED ACTIONS

--- a/ow_lander/src/ow_lander/common.py
+++ b/ow_lander/src/ow_lander/common.py
@@ -52,20 +52,5 @@ def in_closed_range(val, lo, hi, tolerance):
   """
   return val >= lo-tolerance and val <= hi+tolerance
 
-def poses_approx_equivalent(pose1, pose2, \
-    meter_tolerance=constants.ARM_POSE_METER_TOLERANCE, \
-    radian_tolerance=constants.ARM_POSE_RADIAN_TOLERANCE):
-  p1 = pose1.position
-  p2 = pose2.position
-  distance = sqrt((p1.x - p2.x)**2 + (p1.y - p2.y)**2 + (p1.z - p2.z)**2)
-  if distance <= meter_tolerance:
-    o1 = pose1.orientation
-    o2 = pose2.orientation
-    # check that the geodesic norm between the 2 quaternions is below tolerance
-    dp = o1.x * o2.x + o1.y * o2.y + o1.z * o2.z + o1.w * o2.w
-    if acos(2*dp*dp-1) <= radian_tolerance:
-      return True
-  return False
-
 def create_most_recent_header(frame_id):
   return Header(0, Time(0), frame_id)

--- a/ow_lander/src/ow_lander/common.py
+++ b/ow_lander/src/ow_lander/common.py
@@ -6,6 +6,8 @@
 
 from math import pi, tau, acos, sqrt
 from ow_lander import constants
+from std_msgs.msg import Header
+from rospy import Time
 # import roslib; roslib.load_manifest('urdfdom_py')
 from urdf_parser_py.urdf import URDF
 
@@ -64,3 +66,6 @@ def poses_approx_equivalent(pose1, pose2, \
     if acos(2*dp*dp-1) <= radian_tolerance:
       return True
   return False
+
+def create_most_recent_header(frame_id):
+  return Header(0, Time(0), frame_id)

--- a/ow_lander/src/ow_lander/constants.py
+++ b/ow_lander/src/ow_lander/constants.py
@@ -16,10 +16,12 @@ J_GRINDER = 5
 # these constants will eventually exist in a Frame message type in owl_msgs
 FRAME_BASE = 0
 FRAME_TOOL = 1
+FRAME_ID_BASE = 'base_link'
+FRAME_ID_TOOL = 'l_scoop_tip'
 # maps frame enumerate to the corresponding gazebo frame ID
 FRAME_ID_MAP = {
-  FRAME_BASE: 'base_link',
-  FRAME_TOOL: 'l_scoop_tip'
+  FRAME_BASE: FRAME_ID_BASE,
+  FRAME_TOOL: FRAME_ID_TOOL
 }
 
 # allowed deviation from commanded joint values
@@ -37,8 +39,8 @@ ARM_JOINTS = [ 'j_shou_yaw','j_shou_pitch','j_prox_pitch',
 ANTENNA_JOINTS = ['j_ant_pan', 'j_ant_tilt']
 
 # joint names mapped to their index in /joint_states (alphabetized by name)
-_all_joints = ARM_JOINTS + ANTENNA_JOINTS + ['j_grinder']
-JOINT_STATES_MAP = dict(zip(sorted(_all_joints), range(len(_all_joints))))
+ALL_JOINTS = ARM_JOINTS + ANTENNA_JOINTS + ['j_grinder']
+JOINT_STATES_MAP = dict(zip(sorted(ALL_JOINTS), range(len(ALL_JOINTS))))
 
 X_SHOU = 0.79
 Y_SHOU = 0.175

--- a/ow_lander/src/ow_lander/frame_transformer.py
+++ b/ow_lander/src/ow_lander/frame_transformer.py
@@ -5,12 +5,14 @@
 import rospy
 import tf2_ros
 
-from ow_lander.common import Singleton
+from ow_lander.common import Singleton, create_most_recent_header
 
 # NOTE: These imports are not directly used, but importing them works around a
 #       bug discussed here
 # https://answers.ros.org/question/249433/tf2_ros-buffer-transform-pointstamped/
 from tf2_geometry_msgs import *
+# needed for Stamped types unsupported by tf2_geometry_msgs
+from geometry_msgs.msg import Pose, Point, Vector3, Wrench
 
 class FrameTransformer(metaclass = Singleton):
   """Wraps the tf2_ros interface for looking up transforms and performing
@@ -20,6 +22,48 @@ class FrameTransformer(metaclass = Singleton):
   def __init__(self):
     self._buffer = tf2_ros.Buffer()
     self._listener = tf2_ros.TransformListener(self._buffer)
+
+  def transform_present(self, geometry, source_frame, target_frame, \
+      timeout=rospy.Duration(0.1)):
+    """Performs a transform on a supported geometry_msgs object. Transform is
+    performed in the present; use the transform for past transforms.
+    geometry -- A geometry_msgs object. Supported: Point, Pose, Vector3, Wrench
+    source_frame -- ROS identifier string from the frame being transformed from
+    target_frame -- ROS identifier string for the frame to be transformed into
+    returns a geometry_msgs object of the same type as provided, but transformed
+    into the target_frame. None if transform call fails
+    """
+    if source_frame == target_frame:
+      return geometry
+    # convert geometry into a stamped type
+    stamped = None
+    if isinstance(geometry, Point):
+      stamped = PointStamped(
+        header=create_most_recent_header(source_frame), point=geometry)
+    elif isinstance(geometry, Point):
+      stamped = PoseStamped(
+        header=create_most_recent_header(source_frame), pose=geometry)
+    elif isinstance(geometry, Vector3):
+      stamped = Vector3Stamped(
+        header=create_most_recent_header(source_frame), vector=geometry)
+    elif isinstance(geometry, Wrench):
+      stamped = WrenchStamped(
+        header=create_most_recent_header(source_frame), wrench=geometry)
+    else:
+      rospy.logerr(f"Unsupported geometry type {type(geometry)}")
+      return None
+    transformed = self.transform(stamped, target_frame, timeout=timeout)
+    # return the same type as was provided
+    if isinstance(transformed, PointStamped):
+      return transformed.point
+    elif isinstance(transformed, PoseStamped):
+      return transformed.pose
+    elif isinstance(transformed, Vector3Stamped):
+      return transformed.vector
+    elif isinstance(transformed, WrenchStamped):
+      return transformed.wrench
+    else:
+      return None
 
   def transform(self, stamped_type, target_frame, timeout=rospy.Duration(0.1)):
     """Performs a transform on a stamped geometry_msgs object

--- a/ow_lander/src/ow_lander/frame_transformer.py
+++ b/ow_lander/src/ow_lander/frame_transformer.py
@@ -26,7 +26,7 @@ class FrameTransformer(metaclass = Singleton):
   def transform_present(self, geometry, source_frame, target_frame, \
       timeout=rospy.Duration(0.1)):
     """Performs a transform on a supported geometry_msgs object. Transform is
-    performed in the present; use the transform for past transforms.
+    performed in the present; use the transform method for past transforms.
     geometry -- A geometry_msgs object. Supported: Point, Pose, Vector3, Wrench
     source_frame -- ROS identifier string from the frame being transformed from
     target_frame -- ROS identifier string for the frame to be transformed into
@@ -65,6 +65,10 @@ class FrameTransformer(metaclass = Singleton):
     else:
       return None
 
+  # NOTE: Calling this function can sometimes result in the following error
+  # > "world" passed to lookupTransform argument target_frame does not exist.
+  # This example occurred when transforming to the "world" frame, which should
+  # exist, but it may occur when transforming into other frames as well.
   def transform(self, stamped_type, target_frame, timeout=rospy.Duration(0.1)):
     """Performs a transform on a stamped geometry_msgs object
     stamped_type -- A stamped geometry_msgs object

--- a/ow_lander/src/ow_lander/frame_transformer.py
+++ b/ow_lander/src/ow_lander/frame_transformer.py
@@ -40,7 +40,7 @@ class FrameTransformer(metaclass = Singleton):
     if isinstance(geometry, Point):
       stamped = PointStamped(
         header=create_most_recent_header(source_frame), point=geometry)
-    elif isinstance(geometry, Point):
+    elif isinstance(geometry, Pose):
       stamped = PoseStamped(
         header=create_most_recent_header(source_frame), pose=geometry)
     elif isinstance(geometry, Vector3):

--- a/ow_lander/src/ow_lander/math3d.py
+++ b/ow_lander/src/ow_lander/math3d.py
@@ -112,8 +112,7 @@ def orthogonal(v):
   return cross(normalized, basis)
 
 def quaternion_rotation_between(a, b):
-  """Returns a quaternion that represents the rotation required to get from
-  vector a to vector b.
+  """Computes the quaternion rotation between the vectors a and b.
   a -- geometry_msgs Vector3 or Point
   b -- geometry_msgs Vector3 or Point
   returns a quaternion that represents a rotation from a to b

--- a/ow_lander/src/ow_lander/math3d.py
+++ b/ow_lander/src/ow_lander/math3d.py
@@ -2,7 +2,7 @@
 # Research and Simulation can be found in README.md in the root directory of
 # this repository.
 
-from math import sqrt
+from math import sqrt, isclose
 from geometry_msgs.msg import Quaternion
 
 def _types_match(a, b):
@@ -25,15 +25,15 @@ def dot(a, b):
     dot += a.w * b.w
   return dot
 
+def cross(a, b):
+  assert(_types_match(a, b))
+  return type(a)(a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x)
+
 def norm_squared(a):
   return dot(a,a)
 
 def norm(a):
   return sqrt(norm_squared(a))
-
-def cross(a, b):
-  assert(_types_match(a, b))
-  return type(a)(a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x)
 
 def normalize(v):
   n = norm(v)
@@ -51,7 +51,7 @@ def orthogonal(v):
   x = abs(normalized.x)
   y = abs(normalized.y)
   z = abs(normalized.z)
-  basis = None # z-axis
+  basis = None
   if x < y:
     basis = t(1, 0, 0) if x < z else t(0, 0, 1)
   else:
@@ -65,10 +65,10 @@ def quaternion_rotation_between(a, b):
   a = normalize(a)
   b = normalize(b)
   k = dot(a, b)
-  uv_norm = sqrt(norm_squared(a) * norm_squared(b))
-  if k / uv_norm == -1: # special case of a = -b
-    ortho = normalize(orthogonal(a))
-    return Quaternion(ortho.x, ortho.y, ortho.z, 0)
-  w = k + uv_norm
-  axis = cross(a, b)
-  return normalize(Quaternion(axis.x, axis.y, axis.z, w))
+  ab_norm = sqrt(norm_squared(a) * norm_squared(b))
+  if isclose(k / ab_norm, -1): # special case of a = -b
+    o = normalize(orthogonal(a))
+    return Quaternion(o.x, o.y, o.z, 0)
+  w = k + ab_norm
+  v = cross(a, b)
+  return normalize(Quaternion(v.x, v.y, v.z, w))

--- a/ow_lander/src/ow_lander/math3d.py
+++ b/ow_lander/src/ow_lander/math3d.py
@@ -1,0 +1,74 @@
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+from math import sqrt
+from geometry_msgs.msg import Quaternion
+
+def _types_match(a, b):
+  return type(a) == type(b)
+
+def add(a, b):
+  return type(a)(a.x + b.x, a.y + b.y, a.z + b.z)
+
+def subtract(a, b):
+  assert(_types_match(a, b))
+  return type(a)(a.x - b.x, a.y - b.y, a.z - b.z)
+
+def scalar_multiply(a, b):
+  return type(b)(a * b.x, a * b.y, a * b.z)
+
+def dot(a, b):
+  assert(_types_match(a, b))
+  dot = a.x * b.x + a.y * b.y + a.z * b.z
+  if hasattr(a, 'w'):
+    dot += a.w * b.w
+  return dot
+
+def norm_squared(a):
+  return dot(a,a)
+
+def norm(a):
+  return sqrt(norm_squared(a))
+
+def cross(a, b):
+  assert(_types_match(a, b))
+  return type(a)(a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x)
+
+def normalize(v):
+  n = norm(v)
+  if hasattr(v, 'w'):
+    return type(v)(v.x / n, v.y / n, v.z / n, v.w / n)
+  else:
+    return type(v)(v.x / n, v.y / n, v.z / n)
+
+def is_normalized(v):
+  return norm_squared(v) == 1.0
+
+def orthogonal(v):
+  normalized = normalize(v)
+  t = type(v)
+  x = abs(normalized.x)
+  y = abs(normalized.y)
+  z = abs(normalized.z)
+  basis = None # z-axis
+  if x < y:
+    basis = t(1, 0, 0) if x < z else t(0, 0, 1)
+  else:
+    basis = t(0, 1, 0) if y < z else t(0, 0, 1)
+  return cross(normalized, basis)
+
+def quaternion_rotation_between(a, b):
+  """Returns a quaternion that represents the rotation required to get from
+  vector a to vector b.
+  """
+  a = normalize(a)
+  b = normalize(b)
+  k = dot(a, b)
+  uv_norm = sqrt(norm_squared(a) * norm_squared(b))
+  if k / uv_norm == -1: # special case of a = -b
+    ortho = normalize(orthogonal(a))
+    return Quaternion(ortho.x, ortho.y, ortho.z, 0)
+  w = k + uv_norm
+  axis = cross(a, b)
+  return normalize(Quaternion(axis.x, axis.y, axis.z, w))

--- a/ow_lander/src/ow_lander/math3d.py
+++ b/ow_lander/src/ow_lander/math3d.py
@@ -129,6 +129,15 @@ def quaternion_rotation_between(a, b):
   return normalize(Quaternion(v.x, v.y, v.z, w))
 
 def poses_approx_equivalent(pose1, pose2, linear_tolerance, angular_tolerance):
+  """Checks if two poses are nearly the same position and orientation.
+  pose1 -- geometry_msgs Pose
+  pose2 -- geometry_msgs Pose to be checked against pose1
+  linear_tolerance  -- The maximal distance positions can differ by (meters)
+  angular_tolerance -- The maximal spherical distance orientations can differ by
+                       (radians)
+  returns True if the difference between pose1 and pose2's position and
+  orientations are below their respective tolerances. False otherwise.
+  """
   p1 = pose1.position
   p2 = pose2.position
   if distance(p1, p2) <= linear_tolerance:

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -15,9 +15,6 @@ import actionlib
 import moveit_commander
 from tf2_geometry_msgs import do_transform_pose
 
-from geometry_msgs.msg import PoseStamped
-from std_msgs.msg import Header
-
 from ow_lander.arm_interface import ArmInterface
 from ow_lander.trajectory_planner import ArmTrajectoryPlanner
 from ow_lander.subscribers import LinkStateSubscriber, JointAnglesSubscriber
@@ -141,7 +138,7 @@ class ModifyPoseMixin:
     self.abort_message = ""
     self.old_tool_transform = None
 
-  def handle_pose_goal(self, goal):
+  def handle_frame_goal(self, goal):
     self.abort_message = ""
     if goal.frame not in constants.FRAME_ID_MAP:
       self.abort_message = f"Unrecognized frame {goal.frame}"
@@ -158,8 +155,7 @@ class ModifyPoseMixin:
       if self.old_tool_transform is None:
         self.abort_message = "Failed to lookup TOOL frame transform"
         return None
-    return PoseStamped(header = Header(0, rospy.Time(0), frame_id),
-                       pose = goal.pose)
+    return frame_id
 
   def pose_reached(self, pose):
     # check if requested pose agrees with commanded pose in comparison frame

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -18,7 +18,8 @@ from tf2_geometry_msgs import do_transform_pose
 from ow_lander.arm_interface import ArmInterface
 from ow_lander.trajectory_planner import ArmTrajectoryPlanner
 from ow_lander.subscribers import LinkStateSubscriber, JointAnglesSubscriber
-from ow_lander.common import radians_equivalent, poses_approx_equivalent
+from ow_lander.common import radians_equivalent
+from ow_lander import math3d
 from ow_lander.frame_transformer import FrameTransformer
 from ow_lander import constants
 
@@ -180,7 +181,8 @@ class ModifyPoseMixin:
       self.abort_message = "Failed to perform necessary transforms to verify " \
                            "final pose"
       return False
-    if poses_approx_equivalent(expected.pose, final.pose):
+    if math3d.poses_approx_equivalent(expected.pose, final.pose,
+        constants.ARM_POSE_METER_TOLERANCE, constants.ARM_POSE_METER_TOLERANCE):
       return True
     else:
       self.abort_message = "Failed to reach commanded pose"

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -66,6 +66,10 @@ class ArmTrajectoryMixin(ArmActionMixin, ABC):
       self._arm.checkin_arm(self.name)
       self._set_succeeded("Arm trajectory succeeded")
 
+  @abstractmethod
+  def plan_trajectory(self, goal):
+    pass
+
 
 # DEPRECTATED: This version that provides current and final positions will be
 #              removed as a result of command unification. For new or
@@ -140,6 +144,7 @@ class ModifyPoseMixin:
 
   def handle_frame_goal(self, goal):
     self.abort_message = ""
+    self.old_tool_transform = None
     if goal.frame not in constants.FRAME_ID_MAP:
       self.abort_message = f"Unrecognized frame {goal.frame}"
       return None

--- a/ow_lander/src/ow_lander/trajectory_planner.py
+++ b/ow_lander/src/ow_lander/trajectory_planner.py
@@ -13,9 +13,8 @@ import moveit_commander
 from moveit_msgs.msg import PositionConstraint, RobotTrajectory
 from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
 from tf.transformations import quaternion_from_euler, euler_from_quaternion
-from geometry_msgs.msg import Quaternion, PoseStamped
+from geometry_msgs.msg import Quaternion
 from shape_msgs.msg import SolidPrimitive
-from std_msgs.msg import Header
 from moveit_msgs.srv import GetPositionFK
 
 from ow_lander import constants
@@ -129,7 +128,7 @@ class ArmTrajectoryPlanner(metaclass = Singleton):
 
     def plan_arm_to_pose(self, pose, end_effector):
         """Plan a trajectory from arm's current pose to a new pose
-        pose         -- Stamped pose plan will place end effector at
+        pose         -- Stamped pose plan will place end-effector at
         end_effector -- Name of end_effector
         """
         arm_frame = self._move_arm.get_pose_reference_frame()

--- a/ow_lander/src/ow_lander/trajectory_planner.py
+++ b/ow_lander/src/ow_lander/trajectory_planner.py
@@ -19,7 +19,8 @@ from std_msgs.msg import Header
 from moveit_msgs.srv import GetPositionFK
 
 from ow_lander import constants
-from ow_lander.common import Singleton, is_shou_yaw_goal_in_range
+from ow_lander.common import (Singleton, is_shou_yaw_goal_in_range,
+                              create_most_recent_header)
 from ow_lander.frame_transformer import FrameTransformer
 
 def _cascade_plans(plan1, plan2):
@@ -75,9 +76,6 @@ def _cascade_plans(plan1, plan2):
     new_traj.joint_trajectory = traj_msg
     return new_traj
 
-def _create_most_recent_header(frame_id):
-    return Header(0, rospy.Time(0), frame_id)
-
 class ArmTrajectoryPlanner(metaclass = Singleton):
     """Computes trajectories for arm actions and returns the result as a
     moveit_msgs.msg.RobotTrajectory
@@ -96,7 +94,7 @@ class ArmTrajectoryPlanner(metaclass = Singleton):
     def compute_forward_kinematics(self, fk_target_link, robot_state):
         # TODO: may raise ROSSerializationException
         goal_pose_stamped = self._compute_fk_srv(
-            _create_most_recent_header('base_link'),
+            create_most_recent_header('base_link'),
             [fk_target_link],
             robot_state
         )

--- a/owl_msgs/CMakeLists.txt
+++ b/owl_msgs/CMakeLists.txt
@@ -73,6 +73,7 @@ add_action_files(
   ArmUnstow.action
   ArmMoveCartesian.action
   ArmMoveCartesianGuarded.action
+  ArmFindSurface.action
 )
 
 ## Generate added messages and services with any dependencies listed here

--- a/owl_msgs/action/ArmFindSurface.action
+++ b/owl_msgs/action/ArmFindSurface.action
@@ -1,10 +1,10 @@
 # goal definition
 int32 frame
 bool relative
-geometry_msgs/Point position  # estimated position of the surface in world frame
-geometry_msgs/Vector3 normal  # normal that points out of the surface
-float64 distance
-float64 overdrive
+geometry_msgs/Point position  # estimated position of surface in requested frame
+geometry_msgs/Vector3 normal  # normal of surface in base_link frame
+float64 distance   # away from surface approach trajectory will start
+float64 overdrive  # distance past surface approach trajectory will continue
 float64 force_threshold
 float64 torque_threshold
 ---

--- a/owl_msgs/action/ArmFindSurface.action
+++ b/owl_msgs/action/ArmFindSurface.action
@@ -1,0 +1,21 @@
+# goal definition
+int32 frame
+bool relative
+geometry_msgs/Point position  # estimated position of the surface in world frame
+geometry_msgs/Vector3 normal  # normal that points out of the surface
+float64 distance
+float64 overdrive
+float64 force_threshold
+float64 torque_threshold
+---
+# result
+geometry_msgs/Pose final_pose
+float64 final_distance
+float64 final_force
+float64 final_torque
+---
+# feedback
+geometry_msgs/Pose pose
+float64 distance
+float64 force
+float64 torque


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-933](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-933) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-949](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-949) |

## Summary of Changes
* **ArmFindSurface** action added
* Fixed some potential bugs in mixins.py
* tf2 for Python appears to be missing 3D math operations for geometry_msgs types that are otherwise available in C++. A math3d module has been created to handle these kind of operations.
* Deprecated GuardedMove. 
  * _Should it also print a deprecated warning when used?_

## Related Branches
Your **ow_autonomy** repo should be on the epic branch, `OCEANWATER-933-command-unification-epic`, when testing.

## Tests
### Help Message
Try it out and make sure the language makes sense.
```
rosrun ow_lander arm_find_surface.py --help
```

### Poke Terrain with Absolute Commands
Launch atacama_y1a and perform the following 
#### 1. Unstow the arm. This is good to do before any operation that poses the arm anywhere near the terrian.
`rosrun ow_lander arm_unstow.py`
Testing will focus on this reddish mound near the lander.
![default_gzclient_camera(1)-2023-01-18T12_32_15 610637](https://user-images.githubusercontent.com/17039973/213276982-92a92e0f-d7e7-41b0-8fdf-28abd306234d.jpg)

#### 2. Fail to find the mound from above
`rosrun ow_lander arm_find_surface.py -x 1.45 -y -0.4 -z 0.15`
Scoop will stop just above it and you will see 
```
ArmFindSurface action started
ArmFindSurface: Succeded - No surface was found
ArmFindSurface action complete
```
![default_gzclient_camera(1)-2023-01-18T13_14_57 884971](https://user-images.githubusercontent.com/17039973/213285203-326e05d5-5a06-4f18-b675-e5d66924b1d8.jpg)

#### 3. Find the mound from above
`rosrun ow_lander arm_find_surface.py -x 1.45 -y -0.4`
You will see the following 
```
ArmFindSurface action started
ArmFindSurface: Succeded - ArmFindSurface trajectory stopped by a force of 379.18 N. Surface found at (1.460, -0.402, -0.051)
ArmFindSurface action complete
```
![default_gzclient_camera(1)-2023-01-18T12_34_22 730745](https://user-images.githubusercontent.com/17039973/213277319-511a490a-d5f6-48b2-8b23-dd257776da41.jpg)

#### 4. Find a side slope of the mound
Retract off the surface by 8 cm to reset for another poke
`rosrun ow_lander arm_move_cartesian.py -r -z -0.2`

Attempt to find the side slope of the mound
`rosrun ow_lander arm_find_surface.py -x 1.45 -y -.36 -z -.05 -n 0 -.5 -.5`
You should see
```
ArmFindSurface action started
ArmFindSurface: Succeded - ArmFindSurface trajectory stopped by a force of 229.76 N. Surface found at (1.452, -0.377, -0.064)
ArmFindSurface action complete
```
![default_gzclient_camera(1)-2023-01-18T12_46_25 241832](https://user-images.githubusercontent.com/17039973/213279916-8a3be81c-f2d3-451c-a1d0-0d14b2d28fe0.jpg)

### Poke Terrain with Relative Commands
You can do the following in the same simulation instance
#### 1. Interrogate the flat spot in front of the lander
`rosrun ow_lander arm_find_surface.py -x 1.6 -y 0.1 -z -0.1`
```
[INFO:/lander_action_servers] ArmFindSurface action started
[INFO:/lander_action_servers] ArmFindSurface: Succeded - ArmFindSurface trajectory stopped by a force of 450.79 N. Surface found at (1.604, 0.098, -0.178)
[INFO:/lander_action_servers] ArmFindSurface action complete
```
![default_gzclient_camera(1)-2023-01-18T12_52_03 570250](https://user-images.githubusercontent.com/17039973/213280721-7d8bcb38-dc30-4266-969f-cff339618797.jpg)

#### 2. Interrogate multiple points extending out from the side of the scoop by repeating the the following 2 commands
1. Reset for next poke `rosrun ow_lander arm_move_cartesian.py -r -z -0.06`
2. Poke 10 cm to the scoop's left `rosrun ow_lander arm_find_surface.py -r -y -0.1`
3. Repeat the previous 2 steps as many times as you'd like.

The following output shows my results after performing these steps a total of 4 times
```
ArmMoveCartesian action complete
ArmFindSurface action started
ArmFindSurface: Succeded - ArmFindSurface trajectory stopped by a force of 245.79 N. Surface found at (1.613, 0.199, -0.177)
ArmFindSurface action complete
ArmMoveCartesian action started
ArmMoveCartesian: Succeded - ArmMoveCartesian trajectory succeeded
ArmMoveCartesian action complete
ArmFindSurface action started
ArmFindSurface: Succeded - ArmFindSurface trajectory stopped by a force of 283.55 N. Surface found at (1.626, 0.293, -0.200)
ArmFindSurface action complete
ArmMoveCartesian action started
ArmMoveCartesian: Succeded - ArmMoveCartesian trajectory succeeded
ArmMoveCartesian action complete
ArmFindSurface action started
ArmFindSurface: Succeded - ArmFindSurface trajectory stopped by a force of 292.45 N. Surface found at (1.639, 0.401, -0.204)
ArmFindSurface action complete
ArmMoveCartesian action started
ArmMoveCartesian: Succeded - ArmMoveCartesian trajectory succeeded
ArmMoveCartesian action complete
ArmFindSurface action started
ArmFindSurface: Succeded - ArmFindSurface trajectory stopped by a force of 270.71 N. Surface found at (1.640, 0.505, -0.175)
ArmFindSurface action complete
```
![default_gzclient_camera(1)-2023-01-18T12_57_45 015485](https://user-images.githubusercontent.com/17039973/213282086-c9759c7a-5556-4214-85e6-04c7b03605f5.jpg)
