### PR TITLE
Oceanwater 879 PanTiltMoveCartesian

### DIFF
--- a/ow_lander/scripts/lander_action_servers.py
+++ b/ow_lander/scripts/lander_action_servers.py
@@ -31,5 +31,6 @@ server_light_set_intensity = actions.LightSetIntensityServer()
 server_camera_capture      = actions.CameraCaptureServer()
 server_dock_ingest_sample  = actions.DockIngestSampleServer()
 server_antenna_pan_tilt    = actions.AntennaPanTiltServer()
+server_pan_tilt_move_cartesian = actions.PanTiltMoveCartesianServer()
 
 rospy.spin()

--- a/ow_lander/scripts/pan_tilt_move_cartesian.py
+++ b/ow_lander/scripts/pan_tilt_move_cartesian.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+from ow_lander import actions
+from ow_lander import node_helper
+from ow_lander import constants
+
+import argparse
+
+from geometry_msgs.msg import Point
+
+parser = argparse.ArgumentParser(
+  formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+  description="Moves the antenna mast to look at the provided position.")
+parser.add_argument('--frame', '-f', type=int, default=0,
+  choices=constants.FRAME_ID_MAP.keys(),
+  help="The frame index of the provided Point. " + str(constants.FRAME_ID_MAP))
+parser.add_argument('-x', type=float, default=0,
+  help="X-coordinate of the point looked at")
+parser.add_argument('-y', type=float, default=0,
+  help="Y-coordinate of the point looked at")
+parser.add_argument('-z', type=float, default=0,
+  help="Z-coordinate of the point looked at")
+args = parser.parse_args()
+
+point_arg = Point(args.x, args.y, args.z)
+
+node_helper.call_single_use_action_client(actions.PanTiltMoveCartesianServer,
+  frame=args.frame, point=point_arg)

--- a/ow_lander/scripts/pan_tilt_move_cartesian.py
+++ b/ow_lander/scripts/pan_tilt_move_cartesian.py
@@ -14,7 +14,7 @@ from geometry_msgs.msg import Point
 
 parser = argparse.ArgumentParser(
   formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-  description="Moves the antenna mast to look position in space.")
+  description="Moves the antenna mast to look at a position in space.")
 parser.add_argument('--frame', '-f', type=int, default=0,
   choices=constants.FRAME_ID_MAP.keys(),
   help="The frame index of the position. " + str(constants.FRAME_ID_MAP))

--- a/ow_lander/scripts/pan_tilt_move_cartesian.py
+++ b/ow_lander/scripts/pan_tilt_move_cartesian.py
@@ -14,16 +14,16 @@ from geometry_msgs.msg import Point
 
 parser = argparse.ArgumentParser(
   formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-  description="Moves the antenna mast to look at the provided position.")
+  description="Moves the antenna mast to look position in space.")
 parser.add_argument('--frame', '-f', type=int, default=0,
   choices=constants.FRAME_ID_MAP.keys(),
-  help="The frame index of the provided Point. " + str(constants.FRAME_ID_MAP))
+  help="The frame index of the position. " + str(constants.FRAME_ID_MAP))
 parser.add_argument('-x', type=float, default=0,
-  help="X-coordinate of the point looked at")
+  help="X-coordinate of the position looked at")
 parser.add_argument('-y', type=float, default=0,
-  help="Y-coordinate of the point looked at")
+  help="Y-coordinate of the position looked at")
 parser.add_argument('-z', type=float, default=0,
-  help="Z-coordinate of the point looked at")
+  help="Z-coordinate of the position looked at")
 args = parser.parse_args()
 
 point_arg = Point(args.x, args.y, args.z)

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -782,7 +782,7 @@ class PanTiltMoveCartesianServer(PanTiltMoveMixin, ActionServerBase):
     # The sum of a and b gives the angle between the desired camera lever arm
     # vector and the x-y plane.
     # Antenna tilt is measured from the +z axis, so a pi/2 is subtracted.
-    # Finally, tilt rotates in reverse of the unit circle, so we multiple the
+    # Finally, tilt rotates in reverse of the unit circle, so we multiply the
     # the result by -1.
     tilt_raw = -(a + b - (math.pi / 2))
     tilt = normalize_radians(tilt_raw)

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -17,6 +17,7 @@ from ow_lander.ground_detector import GroundDetector
 from geometry_msgs.msg import Point
 # required for ArmMoveCartesianGuarded
 from ow_lander.ground_detector import FTSensorThresholdMonitor
+from ow_lander.common import create_most_recent_header
 # required for ArmFindSurface
 from geometry_msgs.msg import Vector3, PoseStamped, Pose
 from ow_lander import math3d
@@ -32,9 +33,6 @@ from ow_regolith.srv import RemoveRegolith
 from ow_regolith.msg import Contacts
 # required for AntennaPanTilt
 from ow_lander import constants
-from ow_lander.common import (in_closed_range, radians_equivalent,
-                              create_most_recent_header)
-from sensor_msgs.msg import JointState
 
 #####################
 ## ACTION HELPERS
@@ -683,7 +681,7 @@ class DockIngestSampleServer(ActionServerBase):
       self._set_succeeded(message, sample_ingested=self._sample_was_ingested)
 
 
-class AntennaPanTiltServer(ActionServerBase):
+class AntennaPanTiltServer(PanTiltMoveMixin, ActionServerBase):
 
   name          = 'AntennaPanTiltAction'
   action_type   = ow_lander.msg.AntennaPanTiltAction
@@ -691,91 +689,50 @@ class AntennaPanTiltServer(ActionServerBase):
   feedback_type = ow_lander.msg.AntennaPanTiltFeedback
   result_type   = ow_lander.msg.AntennaPanTiltResult
 
-  JOINT_STATES_TOPIC = "/joint_states"
-
-  def __init__(self):
-    super(AntennaPanTiltServer, self).__init__()
-    ANTENNA_PAN_POS_TOPIC  = '/ant_pan_position_controller/command'
-    ANTENNA_TILT_POS_TOPIC = '/ant_tilt_position_controller/command'
-    self._pan_pub = rospy.Publisher(
-      ANTENNA_PAN_POS_TOPIC, Float64, queue_size=1)
-    self._tilt_pub = rospy.Publisher(
-      ANTENNA_TILT_POS_TOPIC, Float64, queue_size=1)
-    self._subscriber = rospy.Subscriber(
-      self.JOINT_STATES_TOPIC, JointState, self._handle_joint_states)
-    self._start_server()
-
-  def _handle_joint_states(self, data):
-    # position of pan and tlt of the lander is obtained from JointStates
-    ANTENNA_PAN_JOINT = "j_ant_pan"
-    ANTENNA_TILT_JOINT = "j_ant_tilt"
-    try:
-      id_pan = data.name.index(ANTENNA_PAN_JOINT)
-      id_tilt = data.name.index(ANTENNA_TILT_JOINT)
-    except ValueError as err:
-      rospy.logerr_throttle(1,
-        f"AntennaPanTiltServer: {err}; joint value missing in "\
-        f"{self.JOINT_STATES_TOPIC} topic")
-      return
-    self._pan_pos = data.position[id_pan]
-    self._tilt_pos = data.position[id_tilt]
+  def publish_feedback_cb(self):
+    self._publish_feedback(pan_position = self._pan_pos,
+                           tilt_position = self._tilt_pos)
 
   def execute_action(self, goal):
-    # FIXME: tolerance should not be necessary once the float precision
-    #        problem is fixed by command unification (OW-1085)
-    if not in_closed_range(goal.pan,
-        constants.PAN_MIN, constants.PAN_MAX,
-        constants.PAN_TILT_INPUT_TOLERANCE):
-      self._set_aborted(f"Requested pan {goal.pan} is not within allowed " \
-                        f"limits and was rejected.",
-                        pan_position = self._pan_pos,
-                        tilt_position = self._tilt_pos)
+    try:
+      not_preempted = self.move_pan_and_tilt(goal.pan, goal.tilt)
+    except RuntimeError as err:
+      self._set_aborted(str(err),
+        pan_position = self._pan_pos, tilt_position = self._tilt_pos)
       return
-    if not in_closed_range(goal.tilt,
-        constants.TILT_MIN, constants.TILT_MAX,
-        constants.PAN_TILT_INPUT_TOLERANCE):
-      self._set_aborted(f"Requested tilt {goal.tilt} is not within allowed " \
-                        f"limits and was rejected.",
-                        pan_position = self._pan_pos,
-                        tilt_position = self._tilt_pos)
-      return
-
-    # publish requested values to start pan/tilt trajectory
-    self._pan_pub.publish(goal.pan)
-    self._tilt_pub.publish(goal.tilt)
-
-    # FIXME: The outcome of ReferenceMission1 happens to be closely tied to
-    #        the value of FREQUENCY. When a fast frequency was selected (10 Hz),
-    #        the image used to identify a sample location would be slightly to
-    #        the right than the image would have been if the frequency is set to
-    #        1 Hz, which would result in a sample location being selected that
-    #        is about half a meter closer to the lander than otherwise.
-    #        Such a dependency on FREQUENCY should not occur and implies that
-    #        the loop terminates before the antenna mast has completed its
-    #        movement. This breaks the synchronicity of actions, and therefore
-    #        of PLEXIL commands.
-    #        The loop break should instead trigger when both antenna joint
-    #        velocities are near enough to zero.
-    # loop until pan/tilt reach their goal values
-    FREQUENCY = 1 # Hz
-    TIMEOUT = 60 # seconds
-    rate = rospy.Rate(FREQUENCY)
-    for i in range(0, int(TIMEOUT * FREQUENCY)):
-      if self._is_preempt_requested():
-        self._set_preempted("Action was preempted",
-          pan_position = self._pan_pos, tilt_position = self._tilt_pos)
-        return
-      # publish feedback message
-      self._publish_feedback(pan_position = self._pan_pos,
-                             tilt_position = self._tilt_pos)
-      # check if joints have arrived at their goal values
-      if (radians_equivalent(goal.pan, self._pan_pos, constants.PAN_TOLERANCE) and
-          radians_equivalent(goal.tilt, self._tilt_pos, constants.TILT_TOLERANCE)):
+    else:
+      if not_preempted:
         self._set_succeeded("Reached commanded pan/tilt values",
           pan_position=self._pan_pos, tilt_position=self._tilt_pos)
-        return
-      rate.sleep()
-    self._set_aborted(
-      "Timed out waiting for pan/tilt values to reach goal.",
-      pan_position=self._pan_pos, tilt_position=self._tilt_pos
-    )
+      else:
+        self._set_preempted("Action was preempted",
+          pan_position=self._pan_pos, tilt_position=self._tilt_pos)
+
+class PanTiltMoveCartesianServer(PanTiltMoveMixin, ActionServerBase):
+
+  name          = 'PanTiltMoveCartesian'
+  action_type   = owl_msgs.msg.PanTiltMoveCartesianAction
+  goal_type     = owl_msgs.msg.PanTiltMoveCartesianGoal
+  feedback_type = owl_msgs.msg.PanTiltMoveCartesianFeedback
+  result_type   = owl_msgs.msg.PanTiltMoveCartesianResult
+
+  def execute_action(self, goal):
+
+    # fancy maths go here
+
+    pan = 0
+    tilt = 0
+
+    try:
+      not_preempted = self.move_pan_and_tilt(pan, tilt)
+    except RuntimeError as err:
+      self._set_aborted(str(err),
+        pan_position=self._pan_pos, tilt_position=self._tilt_pos)
+      return
+    else:
+      if not_preempted:
+        self._set_succeeded("Reached commanded pan/tilt values",
+          pan_position=self._pan_pos, tilt_position=self._tilt_pos)
+      else:
+        self._set_preempted("Action was preempted",
+          pan_position=self._pan_pos, tilt_position=self._tilt_pos)

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -783,7 +783,7 @@ class PanTiltMoveCartesianServer(PanTiltMoveMixin, ActionServerBase):
     # vector and the x-y plane.
     # Antenna tilt is measured from the +z axis, so a pi/2 is subtracted.
     # Finally, tilt rotates in reverse of the unit circle, so we multiple the
-    # the result by zero.
+    # the result by -1.
     tilt_raw = -(a + b - (math.pi / 2))
     tilt = normalize_radians(tilt_raw)
     try:

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -746,16 +746,18 @@ class PanTiltMoveCartesianServer(PanTiltMoveMixin, ActionServerBase):
     # compute length of the lever arm between tilt joint and camera center
     l = math3d.norm(math3d.subtract(cam_center.transform.translation,
                                     til_joint.transform.translation))
-    # Imagine the camera is already pointed at the lookat position and that
-    # there is a vector that extends from the camera to the lookat position.
-    # The angle between tilt_to_lookat and that vector can be computed from the
-    # length of of the lever arm and the length of tilt_to_lookat
+    # Imagine the cameras are already pointed at the lookat position and that a
+    # vector extends out from their midpoint to the lookat position. If we
+    # approximate the angle between that vector and the camera lever arm to be
+    # pi/2 then the vector, tilt_to_lookat, and the camera lever arm form a
+    # right triangle. Therefore, the angle between tilt_to_lookat and the camera
+    # lever arm can be approximated from only their lengths.
     a = math.acos(l / math3d.norm(tilt_to_lookat))
-    # compute the angle between tilt_to_lookat and the horizontal plane (X-Y)
+    # compute the angle between tilt_to_lookat and the X-Y plane
     b = math.atan2(tilt_to_lookat.z,
                    math.sqrt(tilt_to_lookat.x**2 + tilt_to_lookat.y**2))
-    # The sum of a and b gives the angle between the desired vector that extends
-    # from the camera center to lookat and the x-y plane
+    # The sum of a and b gives the angle between the desired camera lever arm
+    # vector and the x-y plane.
     # Antenna tilt is measured from the +z axis, so a pi/2 is subtracted.
     # Finally, tilt rotates in reverse of the unit circle, so we multiple the
     # the result by zero.

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -723,7 +723,7 @@ class AntennaPanTiltServer(PanTiltMoveMixin, ActionServerBase):
       not_preempted = self.move_pan_and_tilt(goal.pan, goal.tilt)
     except RuntimeError as err:
       self._set_aborted(str(err),
-        pan_position = self._pan_pos, tilt_position = self._tilt_pos)
+        pan_position=self._pan_pos, tilt_position=self._tilt_pos)
     else:
       if not_preempted:
         self._set_succeeded("Reached commanded pan/tilt values",
@@ -742,16 +742,16 @@ class PanTiltMoveCartesianServer(PanTiltMoveMixin, ActionServerBase):
 
   def execute_action(self, goal):
     cam_center = FrameTransformer().lookup_transform(constants.FRAME_ID_BASE,
-                                                    'StereoCameraCenter_link')
-    til_joint = FrameTransformer().lookup_transform(constants.FRAME_ID_BASE,
-                                                    'l_ant_panel')
+                                                     'StereoCameraCenter_link')
+    tilt_joint = FrameTransformer().lookup_transform(constants.FRAME_ID_BASE,
+                                                     'l_ant_panel')
     lookat = goal.point if goal.frame == constants.FRAME_BASE \
               else FrameTransformer().transform_present(
                 goal.point,
                 constants.FRAME_ID_BASE,
                 constants.FRAME_ID_MAP[goal.frame]
               )
-    if cam_center is None or til_joint is None or lookat is None:
+    if cam_center is None or tilt_joint is None or lookat is None:
       self._set_aborted("Failed to perform necessary transforms to compute "
                         "appropriate pan and tilt values.")
       return
@@ -761,14 +761,14 @@ class PanTiltMoveCartesianServer(PanTiltMoveMixin, ActionServerBase):
     # this assumption is small enough to be ignored.
 
     # compute the vector from the tilt joint to the lookat position
-    tilt_to_lookat = math3d.subtract(lookat, til_joint.transform.translation)
+    tilt_to_lookat = math3d.subtract(lookat, tilt_joint.transform.translation)
     # pan is the +Z Euler angle of tilt_to_lookat
     # pi/2 must be added because pan's zero position faces in the -y direction
     pan_raw = math.atan2(tilt_to_lookat.y, tilt_to_lookat.x) + (math.pi / 2)
     pan = normalize_radians(pan_raw)
     # compute length of the lever arm between tilt joint and camera center
     l = math3d.norm(math3d.subtract(cam_center.transform.translation,
-                                    til_joint.transform.translation))
+                                    tilt_joint.transform.translation))
     # Imagine the cameras are already pointed at the lookat position and that a
     # vector extends out from their midpoint to the lookat position. If we
     # approximate the angle between that vector and the camera lever arm to be

--- a/ow_lander/src/ow_lander/common.py
+++ b/ow_lander/src/ow_lander/common.py
@@ -34,7 +34,7 @@ def is_shou_yaw_goal_in_range(joint_goal):
   else:
     return True
 
-def _normalize_radians(angle):
+def normalize_radians(angle):
   """
   :param angle: (float)
   :return: (float) the angle in [-pi, pi)
@@ -43,7 +43,7 @@ def _normalize_radians(angle):
   return (angle + pi) % tau - pi
 
 def radians_equivalent(angle1, angle2, tolerance) :
-  return abs(_normalize_radians(angle1 - angle2)) <= tolerance
+  return abs(normalize_radians(angle1 - angle2)) <= tolerance
 
 def in_closed_range(val, lo, hi, tolerance):
   """

--- a/ow_lander/src/ow_lander/frame_transformer.py
+++ b/ow_lander/src/ow_lander/frame_transformer.py
@@ -23,13 +23,13 @@ class FrameTransformer(metaclass = Singleton):
     self._buffer = tf2_ros.Buffer()
     self._listener = tf2_ros.TransformListener(self._buffer)
 
-  def transform_present(self, geometry, source_frame, target_frame, \
+  def transform_present(self, geometry, target_frame, source_frame, \
       timeout=rospy.Duration(0.1)):
     """Performs a transform on a supported geometry_msgs object. Transform is
     performed in the present; use the transform method for past transforms.
     geometry -- A geometry_msgs object. Supported: Point, Pose, Vector3, Wrench
-    source_frame -- ROS identifier string from the frame being transformed from
     target_frame -- ROS identifier string for the frame to be transformed into
+    source_frame -- ROS identifier string from the frame being transformed from
     returns a geometry_msgs object of the same type as provided, but transformed
     into the target_frame. None if transform call fails
     """

--- a/ow_lander/src/ow_lander/math3d.py
+++ b/ow_lander/src/ow_lander/math3d.py
@@ -12,7 +12,7 @@ def add(a, b):
   """Adds two vectors
   a -- geometry_msgs Vector3 or Point
   b -- geometry_msgs Vector3 or Point
-  returns a vector that represents a + b
+  returns a Vector3 that represents a + b
   """
   return Vector3(a.x + b.x, a.y + b.y, a.z + b.z)
 
@@ -20,7 +20,7 @@ def subtract(a, b):
   """Subtracts two vectors
   a -- geometry_msgs Vector3 or Point
   b -- geometry_msgs Vector3 or Point
-  returns a vector that represents a - b
+  returns a Vector3 that represents a - b
   """
   return Vector3(a.x - b.x, a.y - b.y, a.z - b.z)
 

--- a/ow_lander/src/ow_lander/math3d.py
+++ b/ow_lander/src/ow_lander/math3d.py
@@ -3,7 +3,7 @@
 # this repository.
 
 from math import sqrt, isclose, acos
-from geometry_msgs.msg import Quaternion
+from geometry_msgs.msg import Quaternion, Vector3
 
 def _types_match(a, b):
   return type(a) == type(b)
@@ -14,7 +14,7 @@ def add(a, b):
   b -- geometry_msgs Vector3 or Point
   returns a vector that represents a + b
   """
-  return type(a)(a.x + b.x, a.y + b.y, a.z + b.z)
+  return Vector3(a.x + b.x, a.y + b.y, a.z + b.z)
 
 def subtract(a, b):
   """Subtracts two vectors
@@ -22,8 +22,7 @@ def subtract(a, b):
   b -- geometry_msgs Vector3 or Point
   returns a vector that represents a - b
   """
-  assert(_types_match(a, b))
-  return type(a)(a.x - b.x, a.y - b.y, a.z - b.z)
+  return Vector3(a.x - b.x, a.y - b.y, a.z - b.z)
 
 def scalar_multiply(a, b):
   """Computes the multiplication of the scalar a to the vector b

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -11,14 +11,15 @@ define non-arm mixins.
 import sys
 from abc import ABC, abstractmethod
 import rospy
-import actionlib
 import moveit_commander
 from tf2_geometry_msgs import do_transform_pose
+from std_msgs.msg import Float64
+from sensor_msgs.msg import JointState
 
 from ow_lander.arm_interface import ArmInterface
 from ow_lander.trajectory_planner import ArmTrajectoryPlanner
 from ow_lander.subscribers import LinkStateSubscriber, JointAnglesSubscriber
-from ow_lander.common import radians_equivalent
+from ow_lander.common import radians_equivalent, in_closed_range
 from ow_lander import math3d
 from ow_lander.frame_transformer import FrameTransformer
 from ow_lander import constants
@@ -239,3 +240,77 @@ class ModifyJointValuesMixin(ArmActionMixin, ABC):
   @abstractmethod
   def modify_joint_positions(self, goal):
     pass
+
+class PanTiltMoveMixin:
+
+  JOINT_STATES_TOPIC = "/joint_states"
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    ANTENNA_PAN_POS_TOPIC  = '/ant_pan_position_controller/command'
+    ANTENNA_TILT_POS_TOPIC = '/ant_tilt_position_controller/command'
+    self._pan_pub = rospy.Publisher(
+      ANTENNA_PAN_POS_TOPIC, Float64, queue_size=1)
+    self._tilt_pub = rospy.Publisher(
+      ANTENNA_TILT_POS_TOPIC, Float64, queue_size=1)
+    self._subscriber = rospy.Subscriber(
+      self.JOINT_STATES_TOPIC, JointState, self._handle_joint_states)
+    self._start_server()
+
+  def _handle_joint_states(self, data):
+    # position of pan and tilt of the lander is obtained from JointStates
+    try:
+      self._pan_pos = data.position[constants.JOINT_STATES_MAP["j_ant_pan"]]
+      self._tilt_pos = data.position[constants.JOINT_STATES_MAP["j_ant_tilt"]]
+    except KeyError as err:
+      rospy.logerr_throttle(1,
+        f"PanTiltMoveMixin: {err}; joint value missing in "\
+        f"{self.JOINT_STATES_TOPIC} topic")
+      return
+
+  def move_pan_and_tilt(self, pan, tilt):
+    # FIXME: tolerance should not be necessary once the float precision
+    #        problem is fixed by command unification (OW-1085)
+    if not in_closed_range(pan, constants.PAN_MIN, constants.PAN_MAX,
+                           constants.PAN_TILT_INPUT_TOLERANCE):
+      raise RuntimeError(f"Requested pan {pan} is not within allowed limits.")
+    if not in_closed_range(tilt, constants.TILT_MIN, constants.TILT_MAX,
+                           constants.PAN_TILT_INPUT_TOLERANCE):
+      raise RuntimeError(f"Requested tilt {tilt} is not within allowed limits.")
+
+    # publish requested values to start pan/tilt trajectory
+    self._pan_pub.publish(pan)
+    self._tilt_pub.publish(tilt)
+
+    # FIXME: The outcome of ReferenceMission1 happens to be closely tied to
+    #        the value of FREQUENCY. When a fast frequency was selected (10 Hz),
+    #        the image used to identify a sample location would be slightly to
+    #        the right than the image would have been if the frequency is set to
+    #        1 Hz, which would result in a sample location being selected that
+    #        is about half a meter closer to the lander than otherwise.
+    #        Such a dependency on FREQUENCY should not occur and implies that
+    #        the loop terminates before the antenna mast has completed its
+    #        movement. This breaks the synchronicity of actions, and therefore
+    #        of PLEXIL commands.
+    #        The loop break should instead trigger when both antenna joint
+    #        velocities are near enough to zero.
+    # loop until pan/tilt reach their goal values
+    FREQUENCY = 1 # Hz
+    TIMEOUT = 60 # seconds
+    rate = rospy.Rate(FREQUENCY)
+    for i in range(0, int(TIMEOUT * FREQUENCY)):
+      if self._is_preempt_requested():
+        return False
+      # publish feedback message
+      self.publish_feedback_cb()
+      # check if joints have arrived at their goal values
+      if radians_equivalent(pan, self._pan_pos, constants.PAN_TOLERANCE) and \
+          radians_equivalent(tilt, self._tilt_pos, constants.TILT_TOLERANCE):
+        return True
+      rate.sleep()
+    raise RuntimeError("Timed out waiting for pan/tilt values to reach goal.")
+
+  def publish_feedback_cb(self):
+    """overrideable"""
+    pass
+

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -294,6 +294,7 @@ class PanTiltMoveMixin:
     #        of PLEXIL commands.
     #        The loop break should instead trigger when both antenna joint
     #        velocities are near enough to zero.
+    #         This issue is captured by OW-1105
     # loop until pan/tilt reach their goal values
     FREQUENCY = 1 # Hz
     TIMEOUT = 60 # seconds

--- a/owl_msgs/CMakeLists.txt
+++ b/owl_msgs/CMakeLists.txt
@@ -74,6 +74,7 @@ add_action_files(
   ArmMoveCartesian.action
   ArmMoveCartesianGuarded.action
   ArmFindSurface.action
+  PanTiltMoveCartesian.action
 )
 
 ## Generate added messages and services with any dependencies listed here

--- a/owl_msgs/action/PanTiltMoveCartesian.action
+++ b/owl_msgs/action/PanTiltMoveCartesian.action
@@ -1,0 +1,7 @@
+# goal definition
+int32 frame
+geometry_msgs/Point point   # position in space antenna mast will look at
+---
+# result
+---
+# feedback


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-933](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-933) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-879](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-879) |


## Summary of Changes
* **PanTiltMoveCartesian** action added
* Antenna move logic collected into a mixin shared by both antenna move actions.

## Tests
Ensure your **ow_autonomy** is on the latest commit of the epic branch, [OCEANWATER-933-command-unification-epic](https://github.com/nasa/ow_simulator/tree/OCEANWATER-933-command-unification-epic), then rebuild. 

Launch atacama_y1a along with an RQT GUI. 

### Help Message
Check that the language makes sense 
```
rosrun ow_lander pan_tilt_move_cartesian.py --help
```

### Fail to look at stuff
Request an impossible view position. Since pan has full 360 coverage, I believe tilt is the only value that may be unreachable. 
```
rosrun ow_lander pan_tilt_move_cartesian.py -z -5
```

The antenna will not move, and you will see the following output
```
PanTiltMoveCartesian action started
PanTiltMoveCartesian: Aborted - Requested tilt 1.5644910165286037 is not within allowed limits.
PanTiltMoveCartesian action complete
```

### Look at Stuff
To verify mast pose, we will use the images from both cameras. In RQT, open a second Image View by clicking **Plugins > Visualization > Image View**. In the second Image View window, select `/StereoCamera/right/image_raw` from the dropdown list.  Perform the following steps and confirm the left/right camera images agree with the ones I have provided.

Each command should result in the following output from the action
```
PanTiltMoveCartesian action started
PanTiltMoveCartesian: Succeded - Reached commanded pan/tilt values
PanTiltMoveCartesian action complete
```

#### 1. Unstow arm and look at it
```
rosrun ow_lander arm_unstow.py
rosrun ow_lander pan_tilt_move_cartesian.py -f 1
rosrun ow_lander camera_capture_action_client.py
```
![Screenshot_20230120_173608](https://user-images.githubusercontent.com/17039973/213829465-bcf3097c-7f89-4aa2-965d-82664cb58cc2.png)

#### 2. Look at the reddish mound in front of lander

```
rosrun ow_lander pan_tilt_move_cartesian.py -x 1.46 -y -0.4 -z -0.05
rosrun ow_lander camera_capture_action_client.py
```
![Screenshot_20230120_173723](https://user-images.githubusercontent.com/17039973/213829510-1276559d-ad54-498d-9e76-5350e2a1a202.png)

#### 3. Send arm to some coordinate, then look at that coordinate with **PanTiltMoveCartesian**
```
rosrun ow_lander arm_move_cartesian.py -x 0.5 -y -0.5 -z 1.5
rosrun ow_lander pan_tilt_move_cartesian.py -x 0.5 -y -0.5 -z 1.5
rosrun ow_lander camera_capture_action_client.py
```
![Screenshot_20230120_174426](https://user-images.githubusercontent.com/17039973/213829937-507c9db3-f0b3-4163-8106-610d06c274f2.png)

This may look wrong, but we must keep in mind three things: 
**A**) The tip of the scoop's blade is the subject of focus because that is what is posed by **ArmMoveCartesian**
**B**) Neither camera will show the scoop tip in the center of their image, but rather slightly to the right of center in the left cam and slightly to the left of center in the right cam
**C**) The distance the subject is off from the center in both images increases the closer the subject is to the cameras. 

#### 4. Pretend to discard sample and image where we would expect sample to land
```
rosrun ow_lander discard_action_client.py
rosrun ow_lander pan_tilt_move_cartesian.py -f 1 -x 0.7
rosrun ow_lander camera_capture_action_client.py
```
![Screenshot_20230120_175527](https://user-images.githubusercontent.com/17039973/213830508-514125a7-3026-485b-94ec-a773b50c4bd5.png)

#### 5. Take in the view
```
rosrun ow_lander pan_tilt_move_cartesian.py -x -125800 -y -81170 -z 80533
rosrun ow_lander camera_capture_action_client.py
```
![Screenshot_20230120_175803](https://user-images.githubusercontent.com/17039973/213830675-7e95881d-211c-429c-b162-493a9ce7c864.png)


