### PR TITLE
Oceanwater 1104 separate pan and tilt actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
+*.~*
 ow_ephemeris/data

--- a/ow_lander/scripts/lander_action_servers.py
+++ b/ow_lander/scripts/lander_action_servers.py
@@ -32,6 +32,8 @@ server_camera_capture      = actions.CameraCaptureServer()
 server_camera_set_exposure = actions.CameraSetExposureServer()
 server_dock_ingest_sample  = actions.DockIngestSampleServer()
 server_antenna_pan_tilt    = actions.AntennaPanTiltServer()
+server_antenna_pan         = actions.PanServer()
+server_antenna_tilt        = actions.PanServer()
 server_pan_tilt_move_cartesian = actions.PanTiltMoveCartesianServer()
 
 rospy.spin()

--- a/ow_lander/scripts/lander_action_servers.py
+++ b/ow_lander/scripts/lander_action_servers.py
@@ -33,7 +33,7 @@ server_camera_set_exposure = actions.CameraSetExposureServer()
 server_dock_ingest_sample  = actions.DockIngestSampleServer()
 server_antenna_pan_tilt    = actions.AntennaPanTiltServer()
 server_antenna_pan         = actions.PanServer()
-server_antenna_tilt        = actions.PanServer()
+server_antenna_tilt        = actions.TiltServer()
 server_pan_tilt_move_cartesian = actions.PanTiltMoveCartesianServer()
 
 rospy.spin()

--- a/ow_lander/scripts/pan.py
+++ b/ow_lander/scripts/pan.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+from ow_lander import actions
+from ow_lander import node_helper
+
+import argparse
+
+parser = argparse.ArgumentParser(
+  formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+  description="Set a pan value for the antenna mast."
+)
+parser.add_argument(
+  'pan', type=float, nargs='?', default=0,
+  help="Antenna pan value in radians [-3.2, 3.2]"
+)
+args = parser.parse_args()
+
+node_helper.call_single_use_action_client(actions.PanServer, **vars(args))

--- a/ow_lander/scripts/tilt.py
+++ b/ow_lander/scripts/tilt.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+from ow_lander import actions
+from ow_lander import node_helper
+
+import argparse
+
+parser = argparse.ArgumentParser(
+  formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+  description="Set a tilt value for the antenna mast."
+)
+parser.add_argument(
+  'tilt', type=float, nargs='?', default=0,
+  help="Antenna tilt value in radians [-3.2, 3.2]"
+)
+args = parser.parse_args()
+
+node_helper.call_single_use_action_client(actions.TiltServer, **vars(args))

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -732,6 +732,55 @@ class AntennaPanTiltServer(PanTiltMoveMixin, ActionServerBase):
         self._set_preempted("Action was preempted",
           pan_position=self._pan_pos, tilt_position=self._tilt_pos)
 
+
+class PanServer(PanTiltMoveMixin, ActionServerBase):
+
+  name          = 'PanAction'
+  action_type   = owl_msgs.msg.PanAction
+  goal_type     = owl_msgs.msg.PanGoal
+  feedback_type = owl_msgs.msg.PanFeedback
+  result_type   = owl_msgs.msg.PanResult
+
+  def publish_feedback_cb(self):
+    self._publish_feedback(pan_position = self._pan_pos)
+
+  def execute_action(self, goal):
+    try:
+      not_preempted = self.move_pan(goal.pan)
+    except RuntimeError as err:
+      self._set_aborted(str(err), pan_position=self._pan_pos)
+    else:
+      if not_preempted:
+        self._set_succeeded("Reached commanded pan value",
+                            pan_position=self._pan_pos)
+      else:
+        self._set_preempted("Action was preempted",
+                            pan_position=self._pan_pos)
+
+class TiltServer(PanTiltMoveMixin, ActionServerBase):
+
+  name          = 'TiltAction'
+  action_type   = owl_msgs.msg.TiltAction
+  goal_type     = owl_msgs.msg.TiltGoal
+  feedback_type = owl_msgs.msg.TiltFeedback
+  result_type   = owl_msgs.msg.TiltResult
+
+  def publish_feedback_cb(self):
+    self._publish_feedback(tilt_position = self._tilt_pos)
+
+  def execute_action(self, goal):
+    try:
+      not_preempted = self.move_tilt(goal.tilt)
+    except RuntimeError as err:
+      self._set_aborted(str(err), tilt_position=self._tilt_pos)
+    else:
+      if not_preempted:
+        self._set_succeeded("Reached commanded tilt value",
+                            tilt_position=self._tilt_pos)
+      else:
+        self._set_preempted("Action was preempted",
+                            tilt_position=self._tilt_pos)
+
 class PanTiltMoveCartesianServer(PanTiltMoveMixin, ActionServerBase):
 
   name          = 'PanTiltMoveCartesian'

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -340,7 +340,7 @@ class PanTiltMoveMixin:
 
   def move_tilt(self, tilt):
     if not in_closed_range(tilt, constants.TILT_MIN, constants.TILT_MAX,
-                           constants.TILT_TILT_INPUT_TOLERANCE):
+                           constants.PAN_TILT_INPUT_TOLERANCE):
       raise RuntimeError(f"Requested tilt {tilt} is not within allowed limits.")
 
     # publish requested values to start tilt trajectory

--- a/owl_msgs/CMakeLists.txt
+++ b/owl_msgs/CMakeLists.txt
@@ -74,7 +74,9 @@ add_action_files(
   ArmMoveCartesian.action
   ArmMoveCartesianGuarded.action
   ArmFindSurface.action
+  Pan.action
   PanTiltMoveCartesian.action
+  Tilt.action
 )
 
 ## Generate added messages and services with any dependencies listed here

--- a/owl_msgs/action/Pan.action
+++ b/owl_msgs/action/Pan.action
@@ -1,0 +1,9 @@
+# goal
+float64 pan
+---
+# result
+float64 pan_position
+---
+# feedback
+float64 pan_position
+

--- a/owl_msgs/action/Tilt.action
+++ b/owl_msgs/action/Tilt.action
@@ -1,0 +1,9 @@
+# goal
+float64 tilt
+---
+# result
+float64 tilt_position
+---
+# feedback
+float64 tilt_position
+


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-933](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-933) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1104](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1104) |
| Github :octocat:  | # |

## Summary of Changes
* Separate Pan and Tilt actions and user scripts.

## Test 
1. Build this branch clean along with the `OCEANWATER-933-command-unification-epic` branch of ow_autonomy.
2. Start any simulator world.
3. Try the new `pan.py` and `tilt.py` scripts with the `-h` option, with no arguments, and with values of your choosing.

NOTE: Most of the code has been dumbly factored out of the `AntennaPanTilt` action, and could perhaps be improved (now or in a future iteration).