### PR TITLE
Oceanwater 1100 refactor fault publishing

### DIFF
--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -33,7 +33,7 @@ class FaultDetector
 {
 public:
   FaultDetector(ros::NodeHandle& nh);
-  ~FaultDetector(){}
+  ~FaultDetector() = default;
   
   FaultDetector (const FaultDetector&) = delete;
   FaultDetector& operator= (const FaultDetector&) = delete;
@@ -69,8 +69,8 @@ private:
   // OWLAT MESSAGE FUNCTIONS AND PUBLISHERS
   template<typename fault_msg>
   void setFaultsMessageHeader(fault_msg& msg);
-  template<typename faults_msg_pub_t, typename faults_msg_t, typename faults_flags_t>
-  void publishFaultsMessage(faults_msg_pub_t& faults_msg_pub, faults_msg_t& faults_msg, faults_flags_t faults_flags);
+  template<typename pub_t, typename msg_t, typename flags_t>
+  void publishFaultsMessage(pub_t& faults_pub, msg_t faults_msg, flags_t faults_flags);
 
   // PUBLISHERS AND SUBSCRIBERS
   

--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -57,24 +57,20 @@ private:
   // Get index from m_joint_index_map. If found, modify out_index and return
   // true. Otherwise, return false.
   bool findJointIndex(const unsigned int joint, unsigned int& out_index);
-
-  // Antenna
-  void antPublishFaultMessages();
   
   // Camera
   void cameraTriggerCb(const std_msgs::Empty& msg);
   void cameraRawCb(const sensor_msgs::Image& msg);
-  void cameraPublishFaultMessages(bool is_fault);
 
   // Power
-  void publishPowerSystemFault();
   void powerSOCListener(const owl_msgs::BatteryStateOfCharge& msg);
   void powerTemperatureListener(const owl_msgs::BatteryTemperature& msg);
 
   // OWLAT MESSAGE FUNCTIONS AND PUBLISHERS
-  void publishSystemFaultsMessage();
   template<typename fault_msg>
   void setFaultsMessageHeader(fault_msg& msg);
+  template<typename faults_msg_pub_t, typename faults_msg_t, typename faults_flags_t>
+  void publishFaultsMessage(faults_msg_pub_t& faults_msg_pub, faults_msg_t& faults_msg, faults_flags_t faults_flags);
 
   // PUBLISHERS AND SUBSCRIBERS
   
@@ -85,32 +81,23 @@ private:
   ros::Publisher m_power_faults_msg_pub;
   ros::Publisher m_system_faults_msg_pub;
 
-  // Arm and antenna
-  ros::Subscriber m_joint_states_sub;
-
-  // Camera
+  // faults topic subscribers;
+  ros::Subscriber m_joint_states_sub; // for arm and antenna
   ros::Subscriber m_camera_original_trigger_sub;
   ros::Subscriber m_camera_raw_sub;
-
-  // Power
   ros::Subscriber m_power_soc_sub;
   ros::Subscriber m_power_temperature_sub;
 
-  // VARIABLES
-  
-  // System 
-  uint64_t m_system_faults_flags = 0;
+  // faults bitflags
+  uint64_t m_arm_faults_flags     = owl_msgs::ArmFaultsStatus::NONE;
+  uint64_t m_antenna_faults_flags = owl_msgs::PanTiltFaultsStatus::NONE;
+  uint64_t m_camera_faults_flags  = owl_msgs::CameraFaultsStatus::NONE;
+  uint64_t m_power_faults_flags   = owl_msgs::PowerFaultsStatus::NONE;
+  uint64_t m_system_faults_flags  = owl_msgs::SystemFaultsStatus::NONE;
+
+  // component variables
   std::vector<unsigned int> m_joint_state_indices;
-  
-  // Antenna
-  bool m_pan_fault;
-  bool m_tilt_fault;
-  
-  // Camera
   bool m_camera_data_pending = false;
-  
-  // Power
-  uint64_t m_power_faults_flags = 0;
   float m_last_soc = std::numeric_limits<float>::quiet_NaN();
 };
 

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -177,14 +177,15 @@ void FaultDetector::cameraTriggerCb(const std_msgs::Empty& msg)
   if (m_camera_data_pending) {
     m_camera_faults_flags |= CameraFaultsStatus::NO_IMAGE;
     m_system_faults_flags |= SystemFaultsStatus::CAMERA_EXECUTION_ERROR;
+
+    // publish updated faults messages
+    owl_msgs::CameraFaultsStatus camera_faults_msg;
+    publishFaultsMessage(m_camera_faults_msg_pub, camera_faults_msg, m_camera_faults_flags);
+    owl_msgs::SystemFaultsStatus system_faults_msg;
+    publishFaultsMessage(m_system_faults_msg_pub, system_faults_msg, m_system_faults_flags);
+    // exonerated faults will get published in the camera raw callback
   }
   m_camera_data_pending = true;
-
-  // publish updated faults messages
-  owl_msgs::CameraFaultsStatus camera_faults_msg;
-  publishFaultsMessage(m_camera_faults_msg_pub, camera_faults_msg, m_camera_faults_flags);
-  owl_msgs::SystemFaultsStatus system_faults_msg;
-  publishFaultsMessage(m_system_faults_msg_pub, system_faults_msg, m_system_faults_flags);
 }
 
 void FaultDetector::cameraRawCb(const sensor_msgs::Image& msg)


### PR DESCRIPTION
This is strictly a code cleanup of the fault detector module. A lot of redundant publishing functions were introduced during telemetry unification, but the components essentially all do the same thing: set flags based on fault logic matching the component's fault message (from owl_msgs), similarly update system faults message, and publish the messages with values that directly correspond to the fault flags.

This PR restructures the code around that design and uses a single generic `publishFaultMessage` function and removes individual publishing functions

## Summary of Changes
* Update component listeners to set fault flags with a standardized format
* Introduce a generic `publishFaultsMessage` function which is called whenever a listener updates fault flags
* Remove specific publishing messages and state variables

## Test
* Build with the [OceanWATERS-934_telemetry_unification_epic](https://github.com/nasa/ow_autonomy/tree/OCEANWATER-934_telemetry_unification_epic) branch
* launch the Atacama sim
* Open five additional sourced terminals, each subscribing to one of the faults topics
  * `rostopic echo /system_faults_status`  
  * `rostopic echo /arm_faults_status`
  * `rostopic echo /camera_faults_status`
  * `rostopic echo /pan_tilt_faults_status`
  * `rostopic echo /power_faults_status`
 * Exercise each fault with the appropriate fault injections
 * Observe fault topics change and exonerate values appropriately
