### PR TITLE
Add Timestamps to Battery Topics

### DIFF
--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -463,6 +463,13 @@ void PowerSystemNode::parseEoD_Event(const ProgEvent& eod_event,
   auto& model = dynamic_cast<ModelBasedPrognoser*>(m_prognoser.get())->getModel();
   auto model_output = model.outputEqn(now_s.count(), static_cast<PrognosticsModel::state_type>(state));
   battery_temperature_msg.value = model_output[TEMPERATURE_INDEX];
+
+  // apply most recent timestamp to each message header
+  auto timestamp = ros::Time::now();
+  battery_rul_msg.header.stamp = timestamp;
+  battery_soc_msg.header.stamp = timestamp;
+  battery_temperature_msg.header.stamp = timestamp;
+
 }
 
 void PowerSystemNode::runPrognoser(double electrical_power)


### PR DESCRIPTION
This change makes the power test easier, and allows RQT Plot to handle battery topics.

## Summary of Changes
* Timestamps of the present time are given to battery topics before they are published

## Test
Perform optional step 8.1 of [Test 8 - Power System](https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/OW-TEST-011-8+Power+System). If the values show up in the plot, then the test passes.
