### PR TITLE
increased default frame transform timeout

### DIFF
--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -179,7 +179,7 @@ class TaskScoopCircularServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
     point = FrameTransformer().transform_present(goal.point, 'world', frame_id)
     if point is None:
       raise RuntimeError(f"Failed to transform dig point from {frame_id} " \
-                         f"to the end-effector frame")
+                         f"to the world frame")
     return self._planner.dig_circular(point, goal.depth, goal.parallel)
 
 
@@ -200,7 +200,7 @@ class TaskScoopLinearServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
     point = FrameTransformer().transform_present(goal.point, 'world', frame_id)
     if point is None:
       raise RuntimeError(f"Failed to transform dig point from {frame_id} " \
-                         f"to the end-effector frame")
+                         f"to the world frame")
     return self._planner.dig_linear(point, goal.depth, goal.length)
 
 

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -172,14 +172,17 @@ class TaskScoopCircularServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
   result_type   = owl_msgs.msg.TaskScoopCircularResult
 
   def plan_trajectory(self, goal):
+    # TODO check if base_link is ever different from world
+    PLANNING_FRAME = 'world'
     frame_id, _relative = self.interpret_frame_goal(goal)
     if frame_id is None:
       raise RuntimeError(f"Unrecognized frame {goal.frame}")
     # NOTE: the dig_circular method computes trajectory in the world frame
-    point = FrameTransformer().transform_present(goal.point, 'world', frame_id)
+    point = FrameTransformer().transform_present(
+      goal.point, PLANNING_FRAME, frame_id)
     if point is None:
       raise RuntimeError(f"Failed to transform dig point from {frame_id} " \
-                         f"to the world frame")
+                         f"to the {PLANNING_FRAME} frame")
     return self._planner.dig_circular(point, goal.depth, goal.parallel)
 
 
@@ -193,14 +196,17 @@ class TaskScoopLinearServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
   result_type   = owl_msgs.msg.TaskScoopLinearResult
 
   def plan_trajectory(self, goal):
+    # TODO check if base_link is ever different from world
+    PLANNING_FRAME = 'world'
     frame_id, _relative = self.interpret_frame_goal(goal)
     if frame_id is None:
       raise RuntimeError(f"Unrecognized frame {goal.frame}")
     # NOTE: the dig_linear method computes trajectory in the world frame
-    point = FrameTransformer().transform_present(goal.point, 'world', frame_id)
+    point = FrameTransformer().transform_present(
+      goal.point, PLANNING_FRAME, frame_id)
     if point is None:
       raise RuntimeError(f"Failed to transform dig point from {frame_id} " \
-                         f"to the world frame")
+                         f"to the {PLANNING_FRAME} frame")
     return self._planner.dig_linear(point, goal.depth, goal.length)
 
 
@@ -214,14 +220,15 @@ class TaskDiscardSampleServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
   result_type   = owl_msgs.msg.TaskDiscardSampleResult
 
   def plan_trajectory(self, goal):
+    PLANNING_FRAME = 'base_link'
     frame_id, _relative = self.interpret_frame_goal(goal)
     if frame_id is None:
       raise RuntimeError(f"Unrecognized frame {goal.frame}")
     point = FrameTransformer().transform_present(
-      goal.point, 'base_link', frame_id)
+      goal.point, PLANNING_FRAME, frame_id)
     if point is None:
       raise RuntimeError(f"Failed to transform discard point from {frame_id} " \
-                         f"to the end-effector frame")
+                         f"to the {PLANNING_FRAME} frame")
     return self._planner.discard_sample(point, goal.height)
 
 

--- a/ow_lander/src/ow_lander/frame_transformer.py
+++ b/ow_lander/src/ow_lander/frame_transformer.py
@@ -19,6 +19,10 @@ class FrameTransformer(metaclass = Singleton):
   transform operations on stamped geometry_msgs objects.
   """
 
+  # NOTE: If you see the "frame not found" error when calling a transform
+  #       method, try increasing the timeout for your call to that function.
+  #       If the error occurs for all transform calls regardless of frame,
+  #       try increasing the value of this class variable.
   DEFAULT_TIMEOUT = rospy.Duration(0.4)
 
   def __init__(self):

--- a/ow_lander/src/ow_lander/frame_transformer.py
+++ b/ow_lander/src/ow_lander/frame_transformer.py
@@ -19,12 +19,14 @@ class FrameTransformer(metaclass = Singleton):
   transform operations on stamped geometry_msgs objects.
   """
 
+  DEFAULT_TIMEOUT = rospy.Duration(0.4)
+
   def __init__(self):
     self._buffer = tf2_ros.Buffer()
     self._listener = tf2_ros.TransformListener(self._buffer)
 
   def transform_present(self, geometry, target_frame, source_frame, \
-      timeout=rospy.Duration(0.1)):
+      timeout=DEFAULT_TIMEOUT):
     """Performs a transform on a supported geometry_msgs object. Transform is
     performed in the present; use the transform method for past transforms.
     geometry -- A geometry_msgs object. Supported: Point, Pose, Vector3, Wrench
@@ -65,12 +67,7 @@ class FrameTransformer(metaclass = Singleton):
     else:
       return None
 
-  # NOTE: Calling this function can sometimes result in the following error
-  # > "world" passed to lookupTransform argument target_frame does not exist.
-  # This example occurred when transforming to the "world" frame, which should
-  # exist, but it may occur when transforming into other frames as well.
-  # See Jira OW-1115
-  def transform(self, stamped_type, target_frame, timeout=rospy.Duration(0.1)):
+  def transform(self, stamped_type, target_frame, timeout=DEFAULT_TIMEOUT):
     """Performs a transform on a stamped geometry_msgs object
     stamped_type -- A stamped geometry_msgs object
     target_frame -- ROS identifier string for the frame to be transformed into
@@ -84,7 +81,7 @@ class FrameTransformer(metaclass = Singleton):
       return None
 
   def lookup_transform(self, target_frame, source_frame,
-                       timestamp=rospy.Time(0), timeout=rospy.Duration(0.1)):
+                       timestamp=rospy.Time(0), timeout=DEFAULT_TIMEOUT):
     """Computes a transform from the source frame to the target frame
     source_frame -- The frame from which the transform is computed
     target_frame -- The frame transformed into


### PR DESCRIPTION
Jira Ticket 🎟️  [OCEANWATER-1115](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1115)

## Summary of Changes
* Increased the default timeout for frame transforms from 0.1 to 0.4 seconds.

## Test
1. Launch atacama_y1a
2. Grind out a trench `rosrun ow_lander task_grind.py`
3. Call scoop circular as many times as needed `rosrun ow_lander task_scoop_circular.py`
The test fails if this error appears for any of the calls to TaskScoopCircular.
```
[ERROR]: FrameTransfomer.transform failure: "world" passed to lookupTransform argument target_frame does not exist.
```
