### PR TITLE
Oceanwater 1112 - Validate and normalize quaternions and unit vectors

### DIFF
--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -262,7 +262,7 @@ class ArmMoveCartesianServer(mixins.FrameMixin, mixins.ArmActionMixin,
       self._set_aborted(f"Unrecognized frame {goal.frame}")
       return
     position = goal.pose.position
-    orientation = self.normalize_quaternion(goal.pose.orientation)
+    orientation = self.validate_normalization(goal.pose.orientation)
     if orientation is None:
       return
     pose = PoseStamped(
@@ -314,7 +314,7 @@ class ArmMoveCartesianGuardedServer(mixins.FrameMixin, mixins.ArmActionMixin,
       self._set_aborted(f"Unrecognized frame {goal.frame}")
       return
     position = goal.pose.position
-    orientation = self.normalize_quaternion(goal.pose.orientation)
+    orientation = self.validate_normalization(goal.pose.orientation)
     if orientation is None:
       return
     pose = PoseStamped(
@@ -399,10 +399,12 @@ class ArmFindSurfaceServer(mixins.FrameMixin, mixins.ArmActionMixin,
     if frame_id is None:
       self._set_aborted(f"Unrecognized frame {goal.frame}")
       return
+    normal = self.validate_normalization(goal.normal)
+    if normal is None:
+      return
     # orient scoop so that the bottom points in the opposite to the normal
     # NOTE: regardless of frame parameter orientation is in the base_link frame
-    orientation = math3d.quaternion_rotation_between(SCOOP_DOWNWARD,
-                                                     goal.normal)
+    orientation = math3d.quaternion_rotation_between(SCOOP_DOWNWARD, normal)
     start = goal.position
     if relative:
       start = FrameTransformer().transform_present(start,
@@ -412,7 +414,7 @@ class ArmFindSurfaceServer(mixins.FrameMixin, mixins.ArmActionMixin,
                           "trajectory planning.")
         return
     max_distance = goal.distance + goal.overdrive
-    displacement = math3d.scalar_multiply(max_distance, goal.normal)
+    displacement = math3d.scalar_multiply(max_distance, normal)
     end = math3d.add(start, displacement)
     # pose before end-effector is driven towards surface
     pose1 = PoseStamped(

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -254,9 +254,13 @@ class ArmMoveCartesianServer(mixins.FrameMixin, mixins.ArmActionMixin,
     if frame_id is None:
       self._set_aborted(f"Unrecognized frame {goal.frame}")
       return
+    position = goal.pose.position
+    orientation = self.normalize_quaternion(goal.pose.orientation)
+    if orientation is None:
+      return
     pose = PoseStamped(
       header=create_most_recent_header(frame_id),
-      pose=goal.pose
+      pose=Pose(position, orientation)
     )
     try:
       self._arm.checkout_arm(self.name)
@@ -302,9 +306,13 @@ class ArmMoveCartesianGuardedServer(mixins.FrameMixin, mixins.ArmActionMixin,
     if frame_id is None:
       self._set_aborted(f"Unrecognized frame {goal.frame}")
       return
+    position = goal.pose.position
+    orientation = self.normalize_quaternion(goal.pose.orientation)
+    if orientation is None:
+      return
     pose = PoseStamped(
       header=create_most_recent_header(frame_id),
-      pose=goal.pose
+      pose=Pose(position, orientation)
     )
     # monitor F/T sensor and define a callback to check its status
     monitor = FTSensorThresholdMonitor(force_threshold=goal.force_threshold,

--- a/ow_lander/src/ow_lander/math3d.py
+++ b/ow_lander/src/ow_lander/math3d.py
@@ -73,6 +73,7 @@ def normalize(v):
   returns the normalized version of v
   """
   n = norm(v)
+  assert(n != 0)
   if hasattr(v, 'w'):
     return type(v)(v.x / n, v.y / n, v.z / n, v.w / n)
   else:

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -176,6 +176,25 @@ class FrameMixin:
   def get_end_effector_pose(self, frame_id='base_link'):
     return self._planner.get_end_effector_pose(self.END_EFFECTOR, frame_id)
 
+  def normalize_quaternion(self, q):
+    """Normalize a quaternion, or reject if it is the zero-quaternion
+    q -- Quaternion, typically representing an orientation
+    return the normalized form of q, or None if all elements of q are zeroes
+    """
+    dp = math3d.dot(q, q)
+    if dp == 0:
+      self._set_aborted("Orientation is the zero-quaternion which cannot "
+                        "represent a rotation.")
+      return None
+    elif dp != 1.0:
+      n = math3d.normalize(q)
+      rospy.logwarn(f"Orientation is a non-normalized quaternion, and will be "
+                    f"interpreted as ({n.x}, {n.y}, {n.z}, {n.w}) instead of "
+                    f"the provided value.")
+      return n
+    else:
+      return q
+
 class ModifyJointValuesMixin(ArmActionMixin, ABC):
 
   def __init__(self, *args, **kwargs):

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -161,10 +161,10 @@ class FrameMixin:
                       "a {represents}"
       if is_quaternion:
         self._set_aborted(INVALID_ERROR.format(
-           meaning='orientation', geometry='quaternion', represents='rotation'))
+           meaning='Orientation', geometry='quaternion', represents='rotation'))
       else:
         self._set_aborted(INVALID_ERROR.format(
-           meaning='normal', geometry='vector', represents='direction'))
+           meaning='Normal', geometry='vector', represents='direction'))
       return None
     elif dp != 1.0:
       n = math3d.normalize(x)
@@ -172,10 +172,10 @@ class FrameMixin:
                       "as {value} instead of the provided value"
       if is_quaternion:
         rospy.logwarn(MODIFIED_WARN.format(
-          meaning='orientation', value=f"({n.x}, {n.y}, {n.z}, {n.w})"))
+          meaning='Orientation', value=f"({n.x}, {n.y}, {n.z}, {n.w})"))
       else:
         rospy.logwarn(MODIFIED_WARN.format(
-          meaning='normal', value=f"({n.x}, {n.y}, {n.z}"))
+          meaning='Normal', value=f"({n.x}, {n.y}, {n.z})"))
       return math3d.normalize(x)
     else:
       return x


### PR DESCRIPTION
## Linked Issues:
Jira Ticket 🎟️  [OCEANWATER-1112](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1112) 

## Summary of Changes
* If an action's normal/orientation goal is not normalized it will either be rejected or normalized possible. 
   * If the normal/orientation consists of all zeroes, the action is aborted with an error.
   * If the above is not true but the normal/orientation is non-normalized, it is normalized and a warning is logged.

## Test 1 - Orientations
1. Start any simulator world
2. Trigger the zero-quaternion error `rosrun ow_lander arm_move_cartesian.py -x 1.8 -z 0.5 -q 0 0 0 0`
    Arm should not move and output will be
```
[INFO:/lander_action_servers] ArmMoveCartesian action started
[ERROR:/lander_action_servers] ArmMoveCartesian: Aborted - orientation is the zero-quaternion and cannot represent a rotation
[INFO:/lander_action_servers] ArmMoveCartesian action complete
```
4. Recall with a well-formated quaternion `rosrun ow_lander arm_move_cartesian.py -x 1.8 -z 0.5 -q 0 0 1 0`
    Output and scoop pose should be
```
[INFO:/lander_action_servers] ArmMoveCartesian action started
[INFO:/lander_action_servers] ArmMoveCartesian: Succeeded - ArmMoveCartesian trajectory succeeded
[INFO:/lander_action_servers] ArmMoveCartesian action complete
```
![default_gzclient_camera(1)-2023-02-14T17_13_42 795390](https://user-images.githubusercontent.com/17039973/218892784-0082b55d-a4c2-4645-8930-0b7fb9f31f95.jpg)


5. Recall with an non-normalized quaternion `rosrun ow_lander arm_move_cartesian.py -x 1.8 -z 0.5 -q 0 0 1 1`
    Output and scoop pose should be
```
[INFO:/lander_action_servers] ArmMoveCartesian action started
[WARN:/lander_action_servers] orientation is not normalized and will be interpreted as (0.0, 0.0, 0.7071067811865475, 0.7071067811865475) instead of the provided value
[INFO:/lander_action_servers] ArmMoveCartesian: Succeeded - ArmMoveCartesian trajectory succeeded
```
![default_gzclient_camera(1)-2023-02-14T17_17_09 891680](https://user-images.githubusercontent.com/17039973/218892791-71202af6-58ef-49fa-9d68-dc0cce02e022.jpg)

## Test 2 - Normals
1. Use any simulation world. Previous instance works fine.
2. Trigger the zero-normal error `rosrun ow_lander arm_find_surface.py -x 1.8 -z 0.5 -n 0 0 0`
     Scoop will not move and output should be 
```
[INFO:/lander_action_servers] ArmFindSurface action started
[ERROR:/lander_action_servers] ArmFindSurface: Aborted - normal is the zero-vector and cannot represent a direction
[INFO:/lander_action_servers] ArmFindSurface action complete
```
3. Use a well-formated normal `rosrun ow_lander arm_find_surface.py -x 1.8 -z 0.5 -n 0 0 -1`
    Output and arm pose when it finishes should be
```
[INFO:/lander_action_servers] ArmFindSurface action started
[INFO:/lander_action_servers] ArmFindSurface: Succeeded - No surface was found
[INFO:/lander_action_servers] ArmFindSurface action complete
```
![default_gzclient_camera(1)-2023-02-14T17_22_31 866042](https://user-images.githubusercontent.com/17039973/218893428-ee00e7f7-cbad-4684-8e9a-85879f3fd80e.jpg)
4. Use a non-normalized normal `rosrun ow_lander arm_find_surface.py -x 1.8 -z 0.5 -n 0 1 -1`
    Output and arm pose should be
```
[INFO:/lander_action_servers] ArmFindSurface action started
[WARN:/lander_action_servers] normal is not normalized and will be interpreted as (0.0, 0.7071067811865475, -0.7071067811865475 instead of the provided value
[INFO:/lander_action_servers] ArmFindSurface: Succeeded - No surface was found
[INFO:/lander_action_servers] ArmFindSurface action complete
```
![default_gzclient_camera(1)-2023-02-14T17_23_47 434014](https://user-images.githubusercontent.com/17039973/218893614-35d6b39b-3f74-4ebb-9c54-5a34cd74c6fb.jpg)

