### PR TITLE
Removed redundant Result parameters from LightSetIntensity

### DIFF
--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -653,11 +653,7 @@ class LightSetIntensityServer(ActionServerBase):
     name = goal.name.lower()
     # check intensity range
     if intensity < 0.0 or intensity > 1.0:
-      msg = f"Intensity = {intensity} is out of range."
-      # NOTE: This action's result format is redundant since actionlib already
-      #       conveys both a "success" flag and a "message" string. This
-      #       redundancy will be removed following command unification.
-      self._set_aborted(msg, success=False, message=msg)
+      self._set_aborted(f"Intensity = {intensity} is out of range.")
       return
     # check for correct names
     if name == 'left':
@@ -665,13 +661,11 @@ class LightSetIntensityServer(ActionServerBase):
     elif name == 'right':
       self.light_msg.paramName = 'spotlightIntensityScale[1]'
     else:
-      msg = f"\'{name}\' is not a light indentifier."
-      self._set_aborted(msg, success=False, message=msg)
+      self._set_aborted(f"\'{name}\' is not a light identifier.")
       return
     self.light_msg.paramValue = str(goal.intensity)
     self.light_pub.publish(self.light_msg)
-    msg = f"{name} light intensity set successfully."
-    self._set_succeeded(msg, success=True, message=msg)
+    self._set_succeeded(f"{name} light intensity set successfully.")
 
 
 class CameraCaptureServer(ActionServerBase):

--- a/owl_msgs/action/LightSetIntensity.action
+++ b/owl_msgs/action/LightSetIntensity.action
@@ -3,7 +3,5 @@ string name        # "left" or "right" corresponding to the two mast lights
 float64 intensity  # in the range [0..1], 0 is off and 1 is max intensity
 ---
 # result
-bool success
-string message
 ---
 # feedback


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-933](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-933) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1122](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1122) |

## Summary of Changes
* Removed `success` and `message` from LightSetIntensity's Result. This also unify's it with JPL's testbed. 

## Test Action Client
1. Tilt mast down so the lights can be seen `rosrun ow_lander pan_tilt_move_joints.py 0 1.2`
2. Turn off the left light `rosrun ow_lander light_set_intensity.py left 0`
The left light turns off and you will see
```
[INFO:/lander_action_servers] LightSetIntensity action started
[INFO:/lander_action_servers] LightSetIntensity: Succeeded - left light intensity set successfully.
[INFO:/lander_action_servers] LightSetIntensity action complete
```
Messages from `GlobalShaderParamPlugin::cacheParams` will occur unpredictably, and they should be ignored.

3. Set the right light to half brightness `rosrun ow_lander light_set_intensity.py right 0.5`
Right light will be less bright and you will see 
```
[INFO:/lander_action_servers] LightSetIntensity action started
[INFO:/lander_action_servers] LightSetIntensity: Succeeded - right light intensity set successfully.
[INFO:/lander_action_servers] LightSetIntensity action complete
```

4. Set an out of range brightness `rosrun ow_lander light_set_intensity.py right 1.1`
No change in the simulation world and you will see 
```
[INFO:/lander_action_servers] LightSetIntensity action started
[ERROR:/lander_action_servers] LightSetIntensity: Aborted - Intensity = 1.1 is out of range.
[INFO:/lander_action_servers] LightSetIntensity action complete
```

### Test ow_plexil's Interface
In another terminal do `roslaunch ow_plexil ow_exec.launch plan:=TestLanderLights.plx`. Ensure the test completes without errors. 