### PR TITLE
More rigorous transform waiting

### DIFF
--- a/ow_lander/scripts/lander_action_servers.py
+++ b/ow_lander/scripts/lander_action_servers.py
@@ -7,8 +7,12 @@
 import rospy
 
 from ow_lander import actions
+from ow_lander import frame_transformer
 
 rospy.init_node('arm_action_servers')
+
+# handles initialization that must occur after init_node call
+frame_transformer.initialize()
 
 # arm actions
 server_stop           = actions.ArmStopServer()

--- a/ow_lander/src/ow_lander/common.py
+++ b/ow_lander/src/ow_lander/common.py
@@ -4,12 +4,13 @@
 
 """Defines functions required by multiple modules within the package"""
 
-from math import pi, tau, acos, sqrt
+from math import pi, tau
 from ow_lander import constants
 from std_msgs.msg import Header
 from rospy import Time
-# import roslib; roslib.load_manifest('urdfdom_py')
+
 from urdf_parser_py.urdf import URDF
+
 
 class Singleton(type):
   """When passed to the metaclass parameter in the class definition, the class
@@ -52,5 +53,5 @@ def in_closed_range(val, lo, hi):
   """
   return val >= lo and val <= hi
 
-def create_header(frame_id, timestamp):
+def create_header(frame_id, timestamp=Time(0)):
   return Header(0, timestamp, frame_id)

--- a/ow_lander/src/ow_lander/common.py
+++ b/ow_lander/src/ow_lander/common.py
@@ -52,5 +52,5 @@ def in_closed_range(val, lo, hi):
   """
   return val >= lo and val <= hi
 
-def create_most_recent_header(frame_id):
-  return Header(0, Time(0), frame_id)
+def create_header(frame_id, timestamp):
+  return Header(0, timestamp, frame_id)

--- a/ow_lander/src/ow_lander/frame_transformer.py
+++ b/ow_lander/src/ow_lander/frame_transformer.py
@@ -45,16 +45,16 @@ class FrameTransformer(metaclass = Singleton):
     stamped = None
     if isinstance(geometry, Point):
       stamped = PointStamped(
-        header=create_header(source_frame, rospy.Time.now()), point=geometry)
+        header=create_header(source_frame, timestamp), point=geometry)
     elif isinstance(geometry, Pose):
       stamped = PoseStamped(
-        header=create_header(source_frame, rospy.Time.now()), pose=geometry)
+        header=create_header(source_frame, timestamp), pose=geometry)
     elif isinstance(geometry, Vector3):
       stamped = Vector3Stamped(
-        header=create_header(source_frame, rospy.Time.now()), vector=geometry)
+        header=create_header(source_frame, timestamp), vector=geometry)
     elif isinstance(geometry, Wrench):
       stamped = WrenchStamped(
-        header=create_header(source_frame, rospy.Time.now()), wrench=geometry)
+        header=create_header(source_frame, timestamp), wrench=geometry)
     else:
       rospy.logerr(f"Unsupported geometry type {type(geometry)}")
       return None

--- a/ow_lander/src/ow_lander/frame_transformer.py
+++ b/ow_lander/src/ow_lander/frame_transformer.py
@@ -30,6 +30,20 @@ class FrameTransformer(metaclass = Singleton):
     geometry -- A geometry_msgs object. Supported: Point, Pose, Vector3, Wrench
     target_frame -- ROS identifier string for the frame to be transformed into
     source_frame -- ROS identifier string from the frame being transformed from
+    timestamp -- The time of the desired transform. Assigning rospy.Time(0) will
+                 request the most recent transform available in the cache. Even
+                 older transforms may be requested, but be careful not to
+                 request transforms further in the past than the cache saves.
+                 Using ropsy.Time.now() will acquire the next (newest)
+                 transform. If a rospy.Time.now() or a transform in the future
+                 is used, a sufficiently long timeout must be set, or the frame
+                 transform will not be found, resulting in an error.
+                 default: rospy.Time(0)
+    timeout -- The maximum time interval the method will block for while waiting
+               for the requested transform to become available. Using
+               rospy.Duration(0) will ensure the method returns immediately, and
+               should only be used when requesting a timestamp in the past.
+               default: rospy.Duration(0)
     returns a geometry_msgs object of the same type as provided, but transformed
     into the target_frame. None if transform call fails
     """
@@ -69,6 +83,20 @@ class FrameTransformer(metaclass = Singleton):
     """Performs a transform on a stamped geometry_msgs object
     stamped_type -- A stamped geometry_msgs object
     target_frame -- ROS identifier string for the frame to be transformed into
+    timestamp -- The time of the desired transform. Assigning rospy.Time(0) will
+                 request the most recent transform available in the cache. Even
+                 older transforms may be requested, but be careful not to
+                 request transforms further in the past than the cache saves.
+                 Using ropsy.Time.now() will acquire the next (newest)
+                 transform. If a rospy.Time.now() or a transform in the future
+                 is used, a sufficiently long timeout must be set, or the frame
+                 transform will not be found, resulting in an error.
+                 default: rospy.Time(0)
+    timeout -- The maximum time interval the method will block for while waiting
+               for the requested transform to become available. Using
+               rospy.Duration(0) will ensure the method returns immediately, and
+               should only be used when requesting a timestamp in the past.
+               default: rospy.Duration(0)
     returns a stamped object of the same type only transformed into target_frame
     or None if transform call fails
     """
@@ -83,8 +111,20 @@ class FrameTransformer(metaclass = Singleton):
     """Computes a transform from the source frame to the target frame
     source_frame -- The frame from which the transform is computed
     target_frame -- The frame transformed into
-    timestamp    -- Time on the ROS clock to look up frame transform. Too far in
-                    the past will through an error. Defaults to most recent.
+    timestamp -- The time of the desired transform. Assigning rospy.Time(0) will
+                 request the most recent transform available in the cache. Even
+                 older transforms may be requested, but be careful not to
+                 request transforms further in the past than the cache saves.
+                 Using ropsy.Time.now() will acquire the next (newest)
+                 transform. If a rospy.Time.now() or a transform in the future
+                 is used, a sufficiently long timeout must be set, or the frame
+                 transform will not be found, resulting in an error.
+                 default: rospy.Time(0)
+    timeout -- The maximum time interval the method will block for while waiting
+               for the requested transform to become available. Using
+               rospy.Duration(0) will ensure the method returns immediately, and
+               should only be used when requesting a timestamp in the past.
+               default: rospy.Duration(0)
     returns a transform or None if lookup_transform call fails
     """
     try:

--- a/ow_lander/src/ow_lander/frame_transformer.py
+++ b/ow_lander/src/ow_lander/frame_transformer.py
@@ -19,18 +19,12 @@ class FrameTransformer(metaclass = Singleton):
   transform operations on stamped geometry_msgs objects.
   """
 
-  # NOTE: If you see the "frame not found" error when calling a transform
-  #       method, try increasing the timeout for your call to that function.
-  #       If the error occurs for all transform calls regardless of frame,
-  #       try increasing the value of this class variable.
-  DEFAULT_TIMEOUT = rospy.Duration(1.0)
-
   def __init__(self):
     self._buffer = tf2_ros.Buffer()
     self._listener = tf2_ros.TransformListener(self._buffer)
 
-  def transform_geometry(self, geometry, target_frame, source_frame, \
-      timestamp, timeout=DEFAULT_TIMEOUT):
+  def transform_geometry(self, geometry, target_frame, source_frame,
+                         timestamp=rospy.Time(0), timeout=rospy.Duration(0)):
     """Performs a transform on a supported geometry_msgs object. Transform is
     performed in the present; use the transform method for past transforms.
     geometry -- A geometry_msgs object. Supported: Point, Pose, Vector3, Wrench
@@ -71,7 +65,7 @@ class FrameTransformer(metaclass = Singleton):
     else:
       return None
 
-  def transform(self, stamped_type, target_frame, timeout=DEFAULT_TIMEOUT):
+  def transform(self, stamped_type, target_frame, timeout=rospy.Duration(0)):
     """Performs a transform on a stamped geometry_msgs object
     stamped_type -- A stamped geometry_msgs object
     target_frame -- ROS identifier string for the frame to be transformed into
@@ -85,7 +79,7 @@ class FrameTransformer(metaclass = Singleton):
       return None
 
   def lookup_transform(self, target_frame, source_frame,
-                       timestamp, timeout=DEFAULT_TIMEOUT):
+                       timestamp=rospy.Time(0), timeout=rospy.Duration(0)):
     """Computes a transform from the source frame to the target frame
     source_frame -- The frame from which the transform is computed
     target_frame -- The frame transformed into
@@ -99,3 +93,7 @@ class FrameTransformer(metaclass = Singleton):
     except tf2_ros.TransformException as err:
       rospy.logerr(f"FrameTransfomer.lookup_transform failure: {str(err)}")
       return None
+
+def initialize():
+  """Initialize tf2 Buffer. Call this following rospy.init_node"""
+  FrameTransformer()

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -123,9 +123,9 @@ class FrameMixin:
     return frame_id, relative
 
   @classmethod
-  def get_tool_transform(cls):
+  def get_current_tool_transform(cls):
     tool_transform = FrameTransformer().lookup_transform(
-      cls.COMPARISON_FRAME, constants.FRAME_ID_TOOL)
+      cls.COMPARISON_FRAME, constants.FRAME_ID_TOOL, rospy.Time.now())
     if tool_transform is None:
       raise RuntimeError("Failed to lookup TOOL frame transform")
     return tool_transform

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -215,6 +215,14 @@ class FrameMixin:
 
   def get_end_effector_pose(self, frame_id, timestamp=rospy.Time(0),
                             timeout=rospy.Duration(0)):
+    """Look up the pose of the set end-effector
+    frame_id     -- Frame ID in which to provide the result
+    timestamp    -- See method comments in frame_transformer.py for usage
+                    default: rospy.Time(0)
+    timeout      -- See method comments in frame_tansformer.py for usage
+                    default: rospy.Duration(0)
+    returns geometry_msgs.PoseStamped
+    """
     return self._planner.get_end_effector_pose(self._end_effector, frame_id,
                                                timestamp, timeout)
 

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -20,8 +20,7 @@ from geometry_msgs.msg import Pose, PoseStamped, PointStamped
 from ow_lander.arm_interface import ArmInterface
 from ow_lander.trajectory_planner import ArmTrajectoryPlanner
 from ow_lander.subscribers import LinkStateSubscriber, JointAnglesSubscriber
-from ow_lander.common import (radians_equivalent, in_closed_range,
-                              create_most_recent_header)
+from ow_lander.common import radians_equivalent, in_closed_range, create_header
 from ow_lander import math3d
 from ow_lander.frame_transformer import FrameTransformer
 from ow_lander import constants
@@ -114,8 +113,8 @@ class FrameMixin:
 
   @classmethod
   def get_comparison_transform(cls, source_frame):
-    transform = FrameTransformer().lookup_transform(
-      cls.COMPARISON_FRAME, source_frame, rospy.Time.now())
+    transform = FrameTransformer().lookup_transform(cls.COMPARISON_FRAME,
+                                                    source_frame)
     if transform is None:
       raise RuntimeError("Failed to acquire transform")
     return transform
@@ -178,13 +177,13 @@ class FrameMixin:
     intended_position = position
     if move_relative:
       # treat as additive to the current pose
-      current_position = self.get_end_effector_pose(frame_id).pose.position
-      if current_position == None:
+      current = self.get_end_effector_pose(frame_id)
+      if current == None:
         raise RuntimeError("Failed to query current end-effector position in "
                            f"the {frame_id} frame. Cannot perform relative "
                            "motion.")
-      intended_position = math3d.add(current_position, position)
-    return PointStamped(header=create_most_recent_header(frame_id),
+      intended_position = math3d.add(current.pose.position, position)
+    return PointStamped(header=create_header(frame_id),
                         point=intended_position)
 
   def get_intended_pose(self, frame_index, move_relative, pose):
@@ -194,24 +193,30 @@ class FrameMixin:
     intended_pose = Pose(position, orientation)
     if move_relative:
       # treat as additive to the current pose
-      current_pose = self.get_end_effector_pose(frame_id).pose
-      if current_pose == None:
+      current = self.get_end_effector_pose(frame_id)
+      if current == None:
         raise RuntimeError("Failed to query current end-effector pose in the"
                            f"{frame_id} frame. Cannot perform relative motion.")
       intended_pose = Pose(
-        math3d.add(current_pose.position, position),
-        math3d.quaternion_multiply(current_pose.orientation, orientation)
+        math3d.add(current.pose.position, position),
+        math3d.quaternion_multiply(current.pose.orientation, orientation)
       )
-    return PoseStamped(header=create_most_recent_header(frame_id),
+    return PoseStamped(header=create_header(frame_id),
                        pose=intended_pose)
 
   def verify_pose_reached(self, intended_pose, transform):
     expected = do_transform_pose(intended_pose, transform)
-    actual = self.get_end_effector_pose(self.COMPARISON_FRAME)
+    # NOTE: When checking if a pose has been reached following a movement, it's
+    # safest to wait for the next transform to become available in case there is
+    # residual movement
+    actual = self.get_end_effector_pose(
+      self.COMPARISON_FRAME, rospy.Time.now(), rospy.Duration(1.0))
     return self.poses_equivalent(expected.pose, actual.pose)
 
-  def get_end_effector_pose(self, frame_id='base_link'):
-    return self._planner.get_end_effector_pose(self._end_effector, frame_id)
+  def get_end_effector_pose(self, frame_id, timestamp=rospy.Time(0),
+                            timeout=rospy.Duration(0)):
+    return self._planner.get_end_effector_pose(self._end_effector, frame_id,
+                                               timestamp, timeout)
 
   def plan_end_effector_to_pose(self, pose):
     return self._planner.plan_arm_to_pose(pose, self._end_effector)

--- a/ow_lander/src/ow_lander/trajectory_planner.py
+++ b/ow_lander/src/ow_lander/trajectory_planner.py
@@ -18,8 +18,7 @@ from shape_msgs.msg import SolidPrimitive
 from moveit_msgs.srv import GetPositionFK
 
 from ow_lander import constants
-from ow_lander.common import (Singleton, is_shou_yaw_goal_in_range,
-                              create_header)
+from ow_lander.common import Singleton, is_shou_yaw_goal_in_range, create_header
 from ow_lander.frame_transformer import FrameTransformer
 
 def _cascade_plans(plan1, plan2):

--- a/ow_lander/src/ow_lander/trajectory_planner.py
+++ b/ow_lander/src/ow_lander/trajectory_planner.py
@@ -101,6 +101,15 @@ class ArmTrajectoryPlanner(metaclass = Singleton):
     def get_end_effector_pose(self, end_effector, frame_id,
                               timestamp=rospy.Time(0),
                               timeout=rospy.Duration(0)):
+        """Look up the pose of an end-effector
+        end_effector -- Name of the end-effector link
+        frame_id     -- Frame ID in which to provide the result
+        timestamp    -- See method comments in frame_transformer.py for usage
+                        default: rospy.Time(0)
+        timeout      -- See method comments in frame_tansformer.py for usage
+                        default: rospy.Duration(0)
+        returns geometry_msgs.PoseStamped
+        """
         pose = self._move_arm.get_current_pose(end_effector)
         pose.header.stamp = timestamp
         return FrameTransformer().transform(pose, frame_id, timeout)

--- a/ow_lander/src/ow_lander/trajectory_planner.py
+++ b/ow_lander/src/ow_lander/trajectory_planner.py
@@ -19,7 +19,7 @@ from moveit_msgs.srv import GetPositionFK
 
 from ow_lander import constants
 from ow_lander.common import (Singleton, is_shou_yaw_goal_in_range,
-                              create_most_recent_header)
+                              create_header)
 from ow_lander.frame_transformer import FrameTransformer
 
 def _cascade_plans(plan1, plan2):
@@ -93,7 +93,7 @@ class ArmTrajectoryPlanner(metaclass = Singleton):
     def compute_forward_kinematics(self, fk_target_link, robot_state):
         # TODO: may raise ROSSerializationException
         goal_pose_stamped = self._compute_fk_srv(
-            create_most_recent_header('base_link'),
+            create_header('base_link', rospy.Time.now()),
             [fk_target_link],
             robot_state
         )

--- a/ow_lander/src/ow_lander/trajectory_planner.py
+++ b/ow_lander/src/ow_lander/trajectory_planner.py
@@ -98,15 +98,12 @@ class ArmTrajectoryPlanner(metaclass = Singleton):
         )
         return goal_pose_stamped.pose_stamped[0].pose
 
-    def get_end_effector_pose(self, end_effector, frame_id = None):
+    def get_end_effector_pose(self, end_effector, frame_id,
+                              timestamp=rospy.Time(0),
+                              timeout=rospy.Duration(0)):
         pose = self._move_arm.get_current_pose(end_effector)
-        if frame_id is None \
-                or frame_id == self._move_arm.get_pose_reference_frame():
-            return pose
-        else:
-            # ensures the most recent transform is used
-            pose.header.stamp = rospy.Time(0)
-            return FrameTransformer().transform(pose, frame_id)
+        pose.header.stamp = timestamp
+        return FrameTransformer().transform(pose, frame_id, timeout)
 
     def _set_joint_position_target(self, joint_positions):
         try:


### PR DESCRIPTION
## Linked Issues:
Jira Ticket 🎟️ | [OCEANWATER-1119](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1119)

## Reviewer Instructions
@mikedalal Only perform the test and report on results.
@mogumbo Only review the code (and approach).

## Summary of Changes
* `rospy.Time.now()` used in favor of `rospy.Time(0)`. 
* Increased the default timeout of FrameTransformer to 1 second. 
* Made timestamp and non-optional parameter for FrameTransformer methods, which makes it easier to understand what a method call is doing. 

## Test
The following actions may use a frame transform depending on the parameters passed: TaskScoopCircular, TaskScoopLinear, TaskDiscardSample, ArmMoveCartesian, ArmMoveCartesianGuarded, ArmFindSurface, and PanTiltCartesian. This test will call each one with the appropriate parameters to make it uses a frame transform. The test passes if no errors result from these calls and movement looks expected. 

1. Grind a trench so that scoop tasks can be called 
`rosrun ow_lander task_grind.py`

2. Perform circular scoop
`rosrun ow_lander task_scoop_circular.py`

3. Discard sample
`rosrun ow_lander task_discard_sample.py`

4. Perform linear scoop
`rosrun ow_lander task_scoop_linear.py`

5. Perform a relative motion, un-guarded
`rosrun ow_lander arm_move_cartesian.py -f 1 -y 0.4`

6. Move back to the previous position, guarded
`rosrun ow_lander arm_move_cartesian_guarded.py -f 1 -y -0.4`

7. Orient scoop into a better position for a TOOL-relative motion.
`rosrun ow_lander arm_move_cartesian.py -x 1.7 -y 0.4 -z 0.2 -e 3.14 0 0`

8. Interrogate surface directly below scoop
`rosrun ow_lander arm_find_surface.py -f 1 -z 0.3`

9. Look at scoop
`rosrun ow_lander pan_tilt_move_cartesian.py -f 1`
