### PR TITLE
Hotfix - Work-around for follow joint trajectory commonly resulting in error code

### DIFF
--- a/ow_lander/config/ros_controllers.yaml
+++ b/ow_lander/config/ros_controllers.yaml
@@ -80,6 +80,10 @@ arm_controller:
     # Velocity to be considered approximately equal to zero.
     stopped_velocity_tolerance: 0.001
     # Position tolerance for a particular joint to reach the goal and throughout the trajectory
+    # NOTE: A zero trajectory tolerance is a work-around for joint trajectories
+    #       being generated that contain a discontinuity in their positions. The
+    #       discontinuity would always result in a PATH_TOLERANCE_VIOLATION.
+    # j_shou_yaw: {trajectory: &traj_tolerance 0.5, goal: &goal_tolerance 0.1}
     j_shou_yaw: {trajectory: &traj_tolerance 0, goal: &goal_tolerance 0.1}
     j_shou_pitch: {trajectory: *traj_tolerance, goal: *goal_tolerance}
     j_prox_pitch: {trajectory: *traj_tolerance, goal: *goal_tolerance}

--- a/ow_lander/config/ros_controllers.yaml
+++ b/ow_lander/config/ros_controllers.yaml
@@ -80,7 +80,7 @@ arm_controller:
     # Velocity to be considered approximately equal to zero.
     stopped_velocity_tolerance: 0.001
     # Position tolerance for a particular joint to reach the goal and throughout the trajectory
-    j_shou_yaw: {trajectory: &traj_tolerance 0.5, goal: &goal_tolerance 0.1}
+    j_shou_yaw: {trajectory: &traj_tolerance 0, goal: &goal_tolerance 0.1}
     j_shou_pitch: {trajectory: *traj_tolerance, goal: *goal_tolerance}
     j_prox_pitch: {trajectory: *traj_tolerance, goal: *goal_tolerance}
     j_dist_pitch: {trajectory: *traj_tolerance, goal: *goal_tolerance}

--- a/ow_lander/src/ow_lander/arm_interface.py
+++ b/ow_lander/src/ow_lander/arm_interface.py
@@ -269,16 +269,13 @@ class ArmTrajectoryExecutor(metaclass=Singleton):
     def get_active_controller(self):
         return self._active_controller
 
-    def execute(self, trajectory, goal_time_tolerance=rospy.Time(0.1),
+    def execute(self, trajectory,
                 done_cb=None, active_cb=None, feedback_cb=None):
         """Execute the provided trajectory asynchronously.
         trajectory -- An instance of moveit_msgs.msg.RobotTrajectory that
                       describes the desired trajectory.
         """
-        goal = FollowJointTrajectoryGoal(
-            trajectory = trajectory,
-            goal_time_tolerance = goal_time_tolerance
-        )
+        goal = FollowJointTrajectoryGoal(trajectory=trajectory)
         self._get_active_follow_client().send_goal(
             goal, done_cb, active_cb, feedback_cb)
 

--- a/ow_lander/src/ow_lander/arm_interface.py
+++ b/ow_lander/src/ow_lander/arm_interface.py
@@ -226,18 +226,17 @@ class ArmTrajectoryExecutor(metaclass=Singleton):
         self._active_controller = self.SUPPORTED_CONTROLLERS[0]
         self._follow_action_clients = dict()
         for controller in self.SUPPORTED_CONTROLLERS:
-            self._follow_action_clients[controller] = actionlib.SimpleActionClient(
-                f"{controller}/follow_joint_trajectory",
-                FollowJointTrajectoryAction
-            )
+            action = f"{controller}/follow_joint_trajectory"
+            self._follow_action_clients[controller] = actionlib. \
+              SimpleActionClient(action, FollowJointTrajectoryAction)
             if not self._follow_action_clients[controller].wait_for_server(
                     rospy.Duration(ACTION_CLIENT_TIMEOUT)):
                 raise TimeoutError(
                   f"Timed out waiting {ACTION_CLIENT_TIMEOUT} seconds for "\
-                  f"connection the {controller} joint trajectory action server."
+                  f"connection to the {action} action server."
                 )
-            rospy.loginfo(f"Successfully connected to {controller} joint "\
-                          f"trajectory action server.")
+            rospy.loginfo(
+              f"Successfully connected to the {action} action server.")
         # initialize controller switch service proxy to enable grinder trajectories
         SWITCH_CONTROLLER_SERVICE = '/controller_manager/switch_controller'
         SERVICE_PROXY_TIMEOUT = 30 # seconds

--- a/ow_lander/src/ow_lander/arm_interface.py
+++ b/ow_lander/src/ow_lander/arm_interface.py
@@ -264,8 +264,11 @@ class ArmTrajectoryExecutor(metaclass=Singleton):
         rate = rospy.Rate(CHECK_RATE)
         for i in range(int(CHECK_RATE * MAX_WAIT)):
           if self.is_active():
-            break
+            return
           rate.sleep()
+        rospy.logwarn(f"The {self._active_controller}/follow_joint_trajectory "
+                      f"action failed to become active within {MAX_WAIT} "
+                      "seconds of sending a goal.")
 
     def cease_execution(self):
         """Stops the execution of the last trajectory submitted for execution"""

--- a/ow_lander/src/ow_lander/arm_interface.py
+++ b/ow_lander/src/ow_lander/arm_interface.py
@@ -74,9 +74,6 @@ class ArmInterface:
   def stop_trajectory_silently(self):
     """Will bypass the stop flag and cease trajectory execution directly. This
     results in no exception being thrown."""
-    # NOTE: Until OW-1090 is fixed, this will stop a trajectory without an
-    #       exception being thrown, but execute_arm_trajectory will continue to
-    #       block for the remainder of the expected trajectory duration.
     self._executor.cease_execution()
 
   def switch_to_grinder_controller(self):
@@ -123,38 +120,19 @@ class ArmInterface:
       feedback_cb=self._stop_arm_if_fault)
 
     # publish feedback while waiting for trajectory execution completion
-    # NOTE : Looping for a timeout like this is prone to errors and results in a
-    #        large discontinuity between the final "current" value (in feedback)
-    #        and the "final" value (in result). This is at least partially
-    #        responsible for final positions varying far more than the eye can
-    #        see in the simulation because previously the "final" value was
-    #        assigned to whatever the most recent "current" value was, even if
-    #        timeout caused that "current" value to be grabbed milliseconds
-    #        before the actual completion of the action.
-    #        Ideally this would loop so long as _executor is active, or in other
-    #        words, so long as the active follow_joint_trajectory action client
-    #        in _executor returns a get_state() of 1 (ACTIVE). However, this is
-    #        bugged and an aborted state is commonly returned by this method in
-    #        the middle of a trajectory. See OW-1090 for more details.
     FEEDBACK_RATE = 100 # hertz
     rate = rospy.Rate(FEEDBACK_RATE)
     timeout = plan.joint_trajectory.points[-1].time_from_start \
               - plan.joint_trajectory.points[0].time_from_start
     start_time = rospy.get_time()
-    while rospy.get_time() - start_time < timeout.secs:
+    while rospy.get_time() - start_time < timeout.to_sec() \
+          or self._executor.is_active():
       if ArmInterface._stopped:
         self._executor.cease_execution()
         raise RuntimeError("Stop was called; trajectory execution ceased")
       if action_feedback_cb is not None:
         action_feedback_cb()
       rate.sleep()
-
-    # wait for action to complete in case it takes longer than the timeout
-    self._executor.wait()
-
-    # FIXME: follow trajectory action sometimes returns an early result; this
-    #        sleep provides a buffer in time in case that happens (OW-1097)
-    rospy.sleep(4.0)
 
 class ArmFaultMonitor(metaclass=Singleton):
     """Checks whether the arm has faulted."""
@@ -267,6 +245,8 @@ class ArmTrajectoryExecutor(metaclass=Singleton):
         return success
 
     def get_active_controller(self):
+        """Returns the name of the currently active joint controller
+        """
         return self._active_controller
 
     def execute(self, trajectory,
@@ -278,28 +258,34 @@ class ArmTrajectoryExecutor(metaclass=Singleton):
         goal = FollowJointTrajectoryGoal(trajectory=trajectory)
         self._get_active_follow_client().send_goal(
             goal, done_cb, active_cb, feedback_cb)
+        # block until client is active, which should only take some milliseconds
+        CHECK_RATE = 500 # hertz
+        MAX_WAIT = 1.0 # seconds
+        rate = rospy.Rate(CHECK_RATE)
+        for i in range(int(CHECK_RATE * MAX_WAIT)):
+          if self.is_active():
+            break
+          rate.sleep()
 
-    # FIXME: May not cancel follow_client if it has failed. See OW-1090
     def cease_execution(self):
         """Stops the execution of the last trajectory submitted for execution"""
         if self._get_active_follow_client().get_state() == GoalStatus.ACTIVE:
             self._get_active_follow_client().cancel_goal()
 
     def wait(self, timeout=0):
-        """
-        Blocks until the execution of the current trajectory comes to an end
-        :type timeout: int
+        """Blocks until the execution of the current trajectory comes to an end
+        timeout -- Seconds to wait for results
         """
         self._get_active_follow_client().wait_for_result(
             timeout=rospy.Duration(timeout))
 
     def result(self):
-        """
-        Gets the result of the last goal
+        """Gets the result of the last goal
         """
         return self._get_active_follow_client().get_result()
 
-    # FIXME: returns 4 (GoalStatus.ABORTED) after the initial movement on
-    #        complex trajectories like grind (see OW-1090 for more details)
     def is_active(self):
+        """Returns true if a trajectory is being executed and has not resulted
+        in an error code.
+        """
         return self._get_active_follow_client().get_state() == GoalStatus.ACTIVE


### PR DESCRIPTION
## Linked Issues:
* [OW-1090](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1090) - follow_joint_trajectory action server usually results in an error code
* [OW-1064](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1064) - Arm trajectories sometimes cannot be stopped
* [OW-1097](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1097) - /arm_controller/follow_joint_trajectory action sometimes returns a result before trajectory has completed

## Summary of Changes
* The `goal_tolerance` defined in `ros_controllers.yaml` is now used instead of being overridden by a much smaller value in a method call. This fixes GOAL_TOLERANCE_VIOLATION error code resulting for stow, unstow, and likely other actions. 
* All values of `traj_tolerance` defined in `ros_controllers.yaml` changed to zero, effectively disabling path tolerance checking. This works around PATH_TOLERANCE_VIOLATION, which was an error that was not handled anyways and would only result in being unable to stop the arm. 
* Arm interface now uses the follow joint trajectory action status to block until trajectory completion, rather than the action's expected time interval alone. It will now only return when an action is complete without the need for an arbitrary sleep duration. 

## Caveat
Ideally we would have path tolerance checking enabled. The difficulty is some of our generated plans result in a discontinuity in joint positions, typically j_hand_yaw's positions. The discontinuity appears to simply be the joint position wrapping around by 2*pi when it goes too far in one direction or the other, but the follow_joint_trajectory actions interpret this as a path tolerance violation.

This may take some time to figure out. For now its worthwhile to just ignore path checking, which we already were doing before by not handling the error code. 

**Note:** The error code from follow_joint_trajectory is still not handled. This will be in another PR and is capture by [OW-1091](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1091)

## Test 1 - Consecutive Actions Calls
This will verify that OW-1097 is solved. 
Open any simulator world
1. Monitor the arm_controller result topic
```
rostopic echo /arm_controller/follow_joint_trajectory/result
```
2. Monitor the grinder_controller result topic
```
rostopic echo /grinder_controller/follow_joint_trajectory/result
```
3. Call several arm trajectories in quick succession. The following command will call them immediately after the prior using the `;` operator. 
 ```
rosrun ow_lander task_grind.py ; rosrun ow_lander task_scoop_linear.py ; rosrun ow_lander task_deliver_sample.py ; rosrun ow_lander arm_move_cartesian.py -x 1.8 -z 0.5
```
### Expected Outcome
a. Watch the output of the two rostopics and confirm the end of each of the 4 actions results in `error_code: 0`
b. Confirm actions all execute one after the other. The simulator output should look like so, message order matters.
```
[INFO:/lander_action_servers] TaskGrind action started
[INFO:/lander_action_servers] TaskGrind: Succeeded - TaskGrind trajectory succeeded
[INFO:/lander_action_servers] TaskGrind action complete
[INFO:/lander_action_servers] TaskScoopLinear action started
[INFO:/lander_action_servers] TaskScoopLinear: Succeeded - Arm trajectory succeeded
[INFO:/lander_action_servers] TaskScoopLinear action complete
[INFO:/lander_action_servers] TaskDeliverSample action started
[INFO:/lander_action_servers] TaskDeliverSample: Succeeded - Arm trajectory succeeded
[INFO:/lander_action_servers] TaskDeliverSample action complete
[INFO:/lander_action_servers] ArmMoveCartesian action started
[INFO:/lander_action_servers] ArmMoveCartesian: Succeeded - ArmMoveCartesian trajectory succeeded
[INFO:/lander_action_servers] ArmMoveCartesian action complete
```

## Test 2 - Stop action
The following can be done in the same simulation instance. We will be replicating one of the specific cases where `arm_stop.py` would be ignored, and this will require some precise timing. 
1. In a separate terminal type out the command `rosrun ow_lander arm_stop.py`, but do not press enter.
2. Call the following command sequence, and pay close attention to the Gazebo client.
```
rosrun ow_lander task_grind.py ; rosrun ow_lander task_scoop_linear.py 
```
3. Allow the TaskGrind action to complete. 
4. At the start of the TaskScoopLinear action the scoop will move from this pose
![default_gzclient_camera(1)-2023-03-28T14_58_54 501728](https://user-images.githubusercontent.com/17039973/228366397-fa7670ac-4c37-46f4-ba8a-a5a9608c16ef.jpg)

to this pose

![default_gzclient_camera(1)-2023-03-28T14_59_12 519041](https://user-images.githubusercontent.com/17039973/228366071-75fc2bed-9e1b-4dcf-a68c-1c7f36bfc3f8.jpg)
In between these two poses, send the `arm_stop.py` command we previously typed. 
### Expected Outcome
The arm should stop. Previously ArmStop would be ignored at this point in the trajectory. 
