### PR TITLE
Oceanwater 1120 light params switch lights

### DIFF
--- a/ow_gazebo_plugins/src/CMakeLists.txt
+++ b/ow_gazebo_plugins/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 #add_subdirectory(CosimulationPlugin)
 add_subdirectory(LinkForcePlugin)
 add_subdirectory(OWLensFlareSensorPlugin)
+add_subdirectory(OWLightControlPlugin)
 add_subdirectory(BalovnevModelPlugin)

--- a/ow_gazebo_plugins/src/OWLightControlPlugin/CMakeLists.txt
+++ b/ow_gazebo_plugins/src/OWLightControlPlugin/CMakeLists.txt
@@ -1,0 +1,25 @@
+set(TARGET_NAME OWLightControlPlugin)
+
+set (HEADERS
+  OWLightControlPlugin.h
+)
+
+set (SOURCES
+  OWLightControlPlugin.cpp
+)
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+  ${GAZEBO_INCLUDE_DIRS}
+)
+
+add_library(${TARGET_NAME} SHARED 
+  ${HEADERS}
+  ${SOURCES}
+)
+
+target_link_libraries(${TARGET_NAME}
+  ${catkin_LIBRARIES}
+  ${GAZEBO_LIBRARIES}
+)
+set_target_properties(${TARGET_NAME} PROPERTIES COMPILE_FLAGS "${GAZEBO_CXX_FLAGS}")

--- a/ow_gazebo_plugins/src/OWLightControlPlugin/OWLightControlPlugin.cpp
+++ b/ow_gazebo_plugins/src/OWLightControlPlugin/OWLightControlPlugin.cpp
@@ -1,0 +1,82 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+#include "OWLightControlPlugin.h"
+#include <gazebo/rendering/rendering.hh>
+
+
+namespace gazebo
+{
+
+GZ_REGISTER_VISUAL_PLUGIN(OWLightControlPlugin)
+
+OWLightControlPlugin::OWLightControlPlugin() :
+  VisualPlugin()
+{
+}
+
+OWLightControlPlugin::~OWLightControlPlugin()
+{
+}
+
+void OWLightControlPlugin::Load(gazebo::rendering::VisualPtr visual, sdf::ElementPtr sdf)
+{
+  m_nodeHandle.reset(new ros::NodeHandle("OWLightControlPlugin"));
+
+  m_lightName.push_back("lander::lander_lights_link::lander_light_light0");
+  m_paramName.push_back("left_light");
+  m_lightIntensity.push_back(1.0);
+  m_lightName.push_back("lander::lander_lights_link::lander_light_light1");
+  m_paramName.push_back("right_light");
+  m_lightIntensity.push_back(1.0);
+
+  for (size_t i = 0; i < m_paramName.size(); i++)
+  {
+    m_nodeHandle->setParam(m_paramName[i], m_lightIntensity[i]);
+  }
+
+  mPreRenderConnection = gazebo::event::Events::ConnectPreRender(
+    boost::bind(&OWLightControlPlugin::onPreRender, this));
+}
+
+void OWLightControlPlugin::onPreRender()
+{
+  double intensity;
+  gazebo::rendering::ScenePtr scene;
+
+  for (size_t i = 0; i < m_paramName.size(); i++) {
+    m_nodeHandle->getParamCached(m_paramName[i], intensity);
+
+    if (m_lightIntensity[i] != intensity)
+    {
+      m_lightIntensity[i] = intensity;
+
+      if (!scene) {
+        scene = gazebo::rendering::get_scene();
+        if (!scene || !scene->Initialized()) {
+          gzwarn << "Gazebo scene not initialized." << std::endl;
+          return;
+        }
+
+        // Helper code for outputting light names
+        /*uint32_t lightCnt = scene->LightCount();
+        for (uint32_t i = 0; i < lightCnt; ++i) {
+          gzmsg << scene->LightByIndex(i)->Name() << std::endl;
+        }*/
+      }
+
+      gazebo::rendering::LightPtr light = scene->LightByName(m_lightName[i]);
+      if (!light) {
+        gzwarn << "Found no light named " << m_lightName[i] << std::endl;
+        continue;
+      }
+
+      intensity = std::clamp(intensity, 0.0, 1.0);
+      ignition::math::Color color = ignition::math::Color(intensity, intensity, intensity);
+      light->SetDiffuseColor(color);
+    }
+  }
+}
+
+}

--- a/ow_gazebo_plugins/src/OWLightControlPlugin/OWLightControlPlugin.cpp
+++ b/ow_gazebo_plugins/src/OWLightControlPlugin/OWLightControlPlugin.cpp
@@ -11,18 +11,9 @@ namespace gazebo
 
 GZ_REGISTER_VISUAL_PLUGIN(OWLightControlPlugin)
 
-OWLightControlPlugin::OWLightControlPlugin() :
-  VisualPlugin()
-{
-}
-
-OWLightControlPlugin::~OWLightControlPlugin()
-{
-}
-
 void OWLightControlPlugin::Load(gazebo::rendering::VisualPtr visual, sdf::ElementPtr sdf)
 {
-  m_nodeHandle.reset(new ros::NodeHandle("OWLightControlPlugin"));
+  m_nodeHandle = std::make_unique<ros::NodeHandle>("OWLightControlPlugin");
 
   m_lightName.push_back("lander::lander_lights_link::lander_light_light0");
   m_paramName.push_back("left_light");
@@ -48,6 +39,10 @@ void OWLightControlPlugin::onPreRender()
   for (size_t i = 0; i < m_paramName.size(); i++) {
     m_nodeHandle->getParamCached(m_paramName[i], intensity);
 
+    // Intensity is a scale factor ranging from off to full power,
+    // so we clamp it in a plausible way.
+    intensity = std::clamp(intensity, 0.0, 1.0);
+
     if (m_lightIntensity[i] != intensity)
     {
       m_lightIntensity[i] = intensity;
@@ -72,7 +67,6 @@ void OWLightControlPlugin::onPreRender()
         continue;
       }
 
-      intensity = std::clamp(intensity, 0.0, 1.0);
       ignition::math::Color color = ignition::math::Color(intensity, intensity, intensity);
       light->SetDiffuseColor(color);
     }

--- a/ow_gazebo_plugins/src/OWLightControlPlugin/OWLightControlPlugin.h
+++ b/ow_gazebo_plugins/src/OWLightControlPlugin/OWLightControlPlugin.h
@@ -1,0 +1,37 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+#ifndef OWLightControlPlugin_h
+#define OWLightControlPlugin_h
+
+#include <gazebo/common/Plugin.hh>
+#include <ros/ros.h>
+
+
+namespace gazebo {
+  
+class OWLightControlPlugin : public gazebo::VisualPlugin
+{
+public:
+  OWLightControlPlugin();
+  ~OWLightControlPlugin();
+
+  virtual void Load(gazebo::rendering::VisualPtr visual, sdf::ElementPtr sdf);
+
+protected:
+  void onPreRender();
+
+private:
+  std::unique_ptr<ros::NodeHandle> m_nodeHandle;
+
+  gazebo::event::ConnectionPtr mPreRenderConnection;
+
+  std::vector<std::string> m_lightName;
+  std::vector<std::string> m_paramName;
+  std::vector<double> m_lightIntensity;
+};
+
+}
+
+#endif // OWLightControlPlugin_h

--- a/ow_gazebo_plugins/src/OWLightControlPlugin/OWLightControlPlugin.h
+++ b/ow_gazebo_plugins/src/OWLightControlPlugin/OWLightControlPlugin.h
@@ -14,8 +14,8 @@ namespace gazebo {
 class OWLightControlPlugin : public gazebo::VisualPlugin
 {
 public:
-  OWLightControlPlugin();
-  ~OWLightControlPlugin();
+  OWLightControlPlugin() {}
+  ~OWLightControlPlugin() {}
 
   virtual void Load(gazebo::rendering::VisualPtr visual, sdf::ElementPtr sdf);
 

--- a/ow_lander/materials/scripts/ow_lander.frag
+++ b/ow_lander/materials/scripts/ow_lander.frag
@@ -35,12 +35,11 @@ uniform sampler2DShadow shadowMap2;
 uniform float inverseShadowmapSize[3];
 in vec4 lsPos[3];
 
-uniform float spotlightIntensityScale[2];
 uniform vec4 vsLightPos[3];
 uniform vec4 vsLightDir[3];
+uniform vec4 lightDiffuseColor[3];
+uniform vec4 lightAtten[3];
 uniform vec4 spotlightParams[3];
-uniform vec4 spotlightColor0;
-uniform vec4 spotlightAtten0;
 in vec4 spotlightTexCoord[2];
 
 uniform samplerCube irradianceMap;
@@ -237,8 +236,8 @@ void lighting(vec3 wsDirToSun, vec3 wsDirToEye, vec3 wsNormal, vec4 wsDetailNorm
   vec3 vsDirToEye = normalize(normalMatrix * wsDirToEye);
   vec3 vsDetailNormal = normalize(normalMatrix * wsDetailNormalHeight.xyz);
   for (int i=0; i<2; i++) {
-    spotlight(vsLightPos[i+1].xyz - vsPos, -vsLightDir[i+1].xyz, spotlightAtten0,
-              spotlightParams[1+1], spotlightColor0.rgb * spotlightIntensityScale[i],
+    spotlight(vsLightPos[i+1].xyz - vsPos, -vsLightDir[i+1].xyz, lightAtten[i+1],
+              spotlightParams[i+1], lightDiffuseColor[i+1].rgb,
               spotlightTexCoord[i], vsDirToEye, vsDetailNormal, specular_power,
               diffuse, specular);
   }

--- a/ow_lander/materials/scripts/ow_lander.material
+++ b/ow_lander/materials/scripts/ow_lander.material
@@ -50,14 +50,14 @@ fragment_program ow_lander_frag glsl
     param_named irradianceMap                  int 3
 
     // lander lights
-    param_named spotlightIntensityScale[0]     float 1.0
-    param_named spotlightIntensityScale[1]     float 1.0
+    // Control status of rover lights (spotlights)
     param_named_auto vsLightPos                light_position_view_space_array 3
     param_named_auto vsLightDir                light_direction_view_space_array 3
+    // Color is misused to turn lights on and off
+    param_named_auto lightDiffuseColor         light_diffuse_colour_array 3
+    // Light intensity is baked into attenuation
+    param_named_auto lightAtten                light_attenuation_array 3
     param_named_auto spotlightParams           spotlight_params_array 3
-    // Assuming these spotlights are the same, these parameters can be reused for each.
-    param_named_auto spotlightColor0           light_diffuse_colour 1
-    param_named_auto spotlightAtten0           light_attenuation 1
     // spotlight texture
     param_named spotlightMap                   int 4
   }

--- a/ow_lander/materials/scripts/ow_lander.material
+++ b/ow_lander/materials/scripts/ow_lander.material
@@ -50,7 +50,7 @@ fragment_program ow_lander_frag glsl
     param_named irradianceMap                  int 3
 
     // lander lights
-    // Control status of rover lights (spotlights)
+    // Control status of lander lights (spotlights)
     param_named_auto vsLightPos                light_position_view_space_array 3
     param_named_auto vsLightDir                light_direction_view_space_array 3
     // Color is misused to turn lights on and off

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -12,7 +12,6 @@ from std_msgs.msg import Empty, Float64
 from sensor_msgs.msg import PointCloud2
 from geometry_msgs.msg import Point
 from geometry_msgs.msg import Vector3, PoseStamped, Pose
-from irg_gazebo_plugins.msg import ShaderParamUpdate
 from ow_regolith.srv import RemoveRegolith
 from ow_regolith.msg import Contacts
 
@@ -589,12 +588,6 @@ class LightSetIntensityServer(ActionServerBase):
 
   def __init__(self):
     super(LightSetIntensityServer, self).__init__()
-    # set up interface for changing mast light brightness
-    self.light_pub = rospy.Publisher('/gazebo/global_shader_param',
-                                     ShaderParamUpdate,
-                                     queue_size=1)
-    self.light_msg = ShaderParamUpdate()
-    self.light_msg.shaderType = ShaderParamUpdate.SHADER_TYPE_FRAGMENT
     self._start_server()
 
   def execute_action(self, goal):
@@ -606,14 +599,12 @@ class LightSetIntensityServer(ActionServerBase):
       return
     # check for correct names
     if name == 'left':
-      self.light_msg.paramName = 'spotlightIntensityScale[0]'
+      rospy.set_param('/OWLightControlPlugin/left_light', intensity)
     elif name == 'right':
-      self.light_msg.paramName = 'spotlightIntensityScale[1]'
+      rospy.set_param('/OWLightControlPlugin/right_light', intensity)
     else:
       self._set_aborted(f"\'{name}\' is not a light identifier.")
       return
-    self.light_msg.paramValue = str(goal.intensity)
-    self.light_pub.publish(self.light_msg)
     self._set_succeeded(f"{name} light intensity set successfully.")
 
 

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -85,6 +85,7 @@
       <plugin name="visibility" filename="libIRGVisibilityPlugin.so">
         <visibility_bitmask>${vis_mask}</visibility_bitmask>
       </plugin>
+      <plugin name="OWLightControlPlugin" filename="libOWLightControlPlugin.so" />
     </visual>
     <selfCollide>1</selfCollide>
     <!-- If freezing the lander in place, turn off collisions with the terrain


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️ | [OCEANWATER-1120](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1120) |


## Summary of Changes
* Control light intensities by setting an Ogre-controlled shader uniform instead of a custom uniform. This ensures that light intensities go to the correct lights.
* You will also need sibling PR: https://github.com/nasa/ow_europa/pull/23

## Test
* Run any ow sim world
* rosrun ow_lander light_set_intensity.py left 0.5
* Use rqt Message Publisher to set antenna tilt to 1.3
* Use rqt Message Publisher to set antenna pan to 1.0
* Use rqt Message Publisher to set antenna pan to -1.0

Without the PR you will see light intensities on top of the lander flicker between lights. With this PR both light intensities stay with the correct lights.