### PR TITLE
ResetPhysicsState call removed for more consistent scoop motion

### DIFF
--- a/ow_gazebo_plugins/src/BalovnevModelPlugin/BalovnevModelPlugin.cpp
+++ b/ow_gazebo_plugins/src/BalovnevModelPlugin/BalovnevModelPlugin.cpp
@@ -120,7 +120,7 @@ void BalovnevModelPlugin::onUpdate()
   if (link_vel.Dot(SCOOP_FORWARD) < 0.0) {
     // reset force if pushback occurs
     resetForces();
-    m_link->ResetPhysicsStates();
+    m_link->SetLinearVel(ignition::math::Vector3d(0, 0, 0));
   }
   if (m_horizontal_force == 0.0 && m_vertical_force == 0.0)
     return; // no force to apply, early return

--- a/ow_gazebo_plugins/src/BalovnevModelPlugin/BalovnevModelPlugin.cpp
+++ b/ow_gazebo_plugins/src/BalovnevModelPlugin/BalovnevModelPlugin.cpp
@@ -117,10 +117,11 @@ void BalovnevModelPlugin::onUpdate()
   }
   // check for pushback
   auto link_vel = m_link->RelativeLinearVel();
-  if (link_vel.Dot(SCOOP_FORWARD) < 0.0) {
+  double BACKWARD_MOTION_CHECK_TRHESHOLD = 0.001; // meters
+  if (link_vel.Length() > BACKWARD_MOTION_CHECK_TRHESHOLD
+      && link_vel.Dot(SCOOP_FORWARD) < 0.0) {
     // reset force if pushback occurs
     resetForces();
-    m_link->SetLinearVel(ignition::math::Vector3d(0, 0, 0));
   }
   if (m_horizontal_force == 0.0 && m_vertical_force == 0.0)
     return; // no force to apply, early return

--- a/ow_gazebo_plugins/src/BalovnevModelPlugin/BalovnevModelPlugin.cpp
+++ b/ow_gazebo_plugins/src/BalovnevModelPlugin/BalovnevModelPlugin.cpp
@@ -117,8 +117,8 @@ void BalovnevModelPlugin::onUpdate()
   }
   // check for pushback
   auto link_vel = m_link->RelativeLinearVel();
-  double BACKWARD_MOTION_CHECK_TRHESHOLD = 0.001; // meters
-  if (link_vel.Length() > BACKWARD_MOTION_CHECK_TRHESHOLD
+  double BACKWARD_MOTION_CHECK_THRESHOLD = 0.001; // meters
+  if (link_vel.Length() > BACKWARD_MOTION_CHECK_THRESHOLD
       && link_vel.Dot(SCOOP_FORWARD) < 0.0) {
     // reset force if pushback occurs
     resetForces();


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-1134](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1134) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1069](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1069) |

`ResetPhysicsState` was causing the scoop to be pushed towards the lander at the start of a perpendicular **TaskScoopCircular**. It is not clear why this happened, but the intention behind the call was to prevent the scoop from moving backwards as a result of dig forces, and this is already accomplished by simply setting dig forces to zero during backward motion.

Additionally, the backward motion if-statement is entered during non-dig trajectories and even while the scoop is stationary. The former due to any downward arc of the scoop being detected as a dig, and the latter due to floating point precision errors. Messing with the physics of the scoop outside of digging like this could result in non-physical dynamics, so now the if-statement only has an internal effect on the system and does not affect the scoop state except in cases of actual digging (when terrain volume is removed). A 1 mm velocity threshold was also added to avoid the if-statement from triggering due to floating point precision errors. 

## Test
1. Call a `rosrun ow_lander task_grind.py 1.65 0 0.05 .6 False` in atacama_y1a
2. Followed by `rosrun ow_lander task_scoop_circular.py --perpendicular` 
3. Verify the trajectory of **TaskScoopCircular** is normal and does not get pushed off-course towards the lander. Some jittering of the scoop might be observed at the end of the trajectory. This is expected, and is probably a result of the dig force. 

