### PR TITLE
Improved trajectory accuracy for all trenching commands

### DIFF
--- a/ow_lander/scripts/task_grind.py
+++ b/ow_lander/scripts/task_grind.py
@@ -4,31 +4,34 @@
 # Research and Simulation can be found in README.md in the root directory of
 # this repository.
 
+import argparse
+
 from ow_lander import actions
 from ow_lander import node_helper
 from ow_lander import constants
 
-import argparse
-
-from distutils.util import strtobool
-
 parser = argparse.ArgumentParser(
   formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-  description="A grinder is used excavate the terrain.")
-parser.add_argument('x_start', type=float, nargs='?', default=1.65,
-  help="X-coordinate of grinding starting point")
-parser.add_argument('y_start', type=float, nargs='?', default=0.0,
-  help="Y-coordinate of grinding starting point")
-parser.add_argument('depth', type=float, nargs='?', default=0.05,
-  help="Desired excavation depth")
-parser.add_argument('length', type=float, nargs='?', default=0.6,
-  help="Desired trench length")
-parser.add_argument('parallel', type=strtobool, nargs='?', default = True,
-  help="If True, resulting trench is parallel to arm. If False, " \
-  "perpendicular to arm")
-parser.add_argument('ground_position', type=float, nargs='?',
-  default=constants.DEFAULT_GROUND_HEIGHT,
-  help="Z-coordinate of ground level in base_link frame")
+  description="The grinder is used process the terrain for excavation.")
+parser.add_argument('-x', type=float, default=1.45,
+  help="X-coordinate of grinding starting point in base_link frame")
+parser.add_argument('-y', type=float, default=0.0,
+  help="Y-coordinate of grinding starting point in base_link frame")
+parser.add_argument('-z', type=float, default=constants.DEFAULT_GROUND_HEIGHT,
+  help="Estimate of ground position at point (x, y) in base_link frame")
+parser.add_argument('--depth', '-d', type=float, default=0.05,
+  help="Depth of grinder tip")
+parser.add_argument('--length', '-l', type=float, default=0.6,
+  help="Length of trench")
+parser.add_argument('--perpendicular', '-p', action='store_true', default=False,
+  help="The trench will be perpendicular to the vector that extends from "
+       "the lander's base to the end-effector. By default the trench will be "
+       "aligned parallel with this vector. NOTE: A perpendicular grind will "
+       "interpret (x, y) as the center of its trench, where as a parallel "
+       "trench will interpret (x, y) as the end of the trench nearest to the "
+       "lander.")
 args = parser.parse_args()
 
-node_helper.call_single_use_action_client(actions.TaskGrindServer, **vars(args))
+node_helper.call_single_use_action_client(actions.TaskGrindServer,
+  x_start=args.x, y_start=args.y, ground_position=args.z,
+  depth=args.depth, length=args.length, parallel=not args.perpendicular)

--- a/ow_lander/scripts/task_scoop_circular.py
+++ b/ow_lander/scripts/task_scoop_circular.py
@@ -4,13 +4,13 @@
 # Research and Simulation can be found in README.md in the root directory of
 # this repository.
 
-from ow_lander import actions
-from ow_lander import node_helper
-from ow_lander import constants
+import argparse
 
 from geometry_msgs.msg import Point
 
-import argparse
+from ow_lander import actions
+from ow_lander import node_helper
+from ow_lander import constants
 
 parser = argparse.ArgumentParser(
   formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -23,16 +23,16 @@ parser.add_argument('--frame', '-f', type=int, default=0,
 parser.add_argument('--relative', '-r', action='store_true', default=False,
   help="Position will be interpreted as relative to the current position")
 parser.add_argument('-x', type=float, default=1.65,
-  help="X-coordinate on surface where trench starts")
+  help="X-coordinate on surface where trench is centered")
 parser.add_argument('-y', type=float, default=0,
-  help="Y-coordinate on surface where trench starts")
+  help="Y-coordinate on surface where trench is centered")
 parser.add_argument('-z', type=float, default=constants.DEFAULT_GROUND_HEIGHT,
-  help="Z-coordinate on surface where trench starts")
-parser.add_argument('--depth', '-d', type=float, default=0.01,
-  help="Desired scooping depth")
+  help="Estimate of ground position at point (x, y) in base_link frame")
+parser.add_argument('--depth', '-d', type=float, default=0.02,
+  help="Depth of scoop at the bottom of the circular arc")
 parser.add_argument('--perpendicular', '-p', action='store_true', default=False,
-  help="Dig a trench that is perpendicular to the vector that extends from "
-       "the arm's base to the end-effector. By default the trench will be "
+  help="The trench will be perpendicular to the vector that extends from "
+       "the lander's base to the end-effector. By default the trench will be "
        "aligned parallel with this vector.")
 args = parser.parse_args()
 

--- a/ow_lander/scripts/task_scoop_linear.py
+++ b/ow_lander/scripts/task_scoop_linear.py
@@ -5,8 +5,8 @@
 # this repository.
 
 from ow_lander import actions
-from ow_lander import constants
 from ow_lander import node_helper
+from ow_lander import constants
 
 from geometry_msgs.msg import Point
 
@@ -22,15 +22,15 @@ parser.add_argument('--frame', '-f', type=int, default=0,
        + str(constants.FRAME_ID_MAP))
 parser.add_argument('--relative', '-r', action='store_true', default=False,
   help="Position will be interpreted as relative to the current position")
-parser.add_argument('-x', type=float, default=1.46,
+parser.add_argument('-x', type=float, default=1.55,
   help="X-coordinate on surface where trench starts")
 parser.add_argument('-y', type=float, default=0,
   help="Y-coordinate on surface where trench starts")
 parser.add_argument('-z', type=float, default=constants.DEFAULT_GROUND_HEIGHT,
-  help="Z-coordinate on surface where trench starts")
-parser.add_argument('--depth', '-d', type=float, default=0.01,
-  help="Desired scooping depth")
-parser.add_argument('--length', '-l', type=float, default=0.1,
+  help="Estimate of ground position at point (x, y) in base_link frame")
+parser.add_argument('--depth', '-d', type=float, default=0.02,
+  help="Depth of scoop during linear segment")
+parser.add_argument('--length', '-l', type=float, default=0.2,
   help="Length of the linear segment of the scoop's trajectory")
 args = parser.parse_args()
 

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -409,8 +409,6 @@ class TaskScoopLinearServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
     # orientations scoop will transition between
     digging_orientation = math3d.quaternion_from_euler(math.pi, 0, yaw)
     entry_orietation = math3d.quaternion_from_euler(math.pi, ENTRY_PITCH, yaw)
-    # exit_arc = self._compute_arc_for_circular_height_change(
-    #   goal.depth + RETRACT_DISTANCE, EXIT_RADIUS)
     exit_orientation = math3d.quaternion_from_euler(math.pi, EXIT_PITCH, yaw)
     # point under the surface where linear movement starts
     linear_start = math3d.add(dig_point, Vector3(0, 0, -goal.depth))

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -306,10 +306,10 @@ class TaskScoopCircularServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
     trench_bottom = Point(
       trench_surface.x,
       trench_surface.y,
-      trench_surface.z - goal.depth + constants.R_PARALLEL_FALSE_A
+      trench_surface.z - goal.depth
     )
     sequence = TrajectorySequence(
-      self._arm.robot, self._arm.move_group_scoop, 'l_scoop')
+      self._arm.robot, self._arm.move_group_scoop, 'l_scoop_tip')
     # place end-effector above trench position
     sequence.plan_to_named_joint_positions(
       j_shou_yaw = _compute_workspace_shoulder_yaw(
@@ -321,6 +321,8 @@ class TaskScoopCircularServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
       j_scoop_yaw = 0.0
     )
     if goal.parallel:
+      # the radial distance between the wrist axis and the tip of the scoop
+      R_WRIST_AXIS_TO_SCOOP_TIP = 0.394
       # rotate hand so scoop bottom points down
       sequence.plan_to_named_joint_positions(j_hand_yaw = 0.0)
       # rotate scoop to face radially out from lander
@@ -332,8 +334,10 @@ class TaskScoopCircularServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
       # perform scoop by rotating distal pitch, and scoop through surface
       sequence.plan_to_named_joint_translations(j_dist_pitch = 2.0/3.0*math.pi)
     else:
+      # the radial distance between the hand yaw axis and the tip of the scoop
+      R_HAND_AXIS_TO_SCOOP_TIP = 0.230 # meters
       # lower to trench position, maintaining up-right orientation
-      sequence.plan_to_position(trench_bottom)
+      sequence.plan_to_position(trench_surface)
       # rotate hand yaw so scoop tip points into surface
       sequence.plan_to_named_joint_positions(j_hand_yaw = math.pi/2.2)
       # lower scoop back to down z-position with new hand yaw position set

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -336,12 +336,17 @@ class TaskScoopCircularServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
     else:
       # the radial distance between the hand yaw axis and the tip of the scoop
       R_HAND_AXIS_TO_SCOOP_TIP = 0.230 # meters
+      SURFACE_APPROACH_DISTANCE = 0.02 # meters
       # lower to trench position, maintaining up-right orientation
-      sequence.plan_to_position(trench_surface)
+      sequence.plan_to_position(
+        math3d.add(trench_surface, Vector3(0, 0, SURFACE_APPROACH_DISTANCE))
+      )
       # rotate hand yaw so scoop tip points into surface
       sequence.plan_to_named_joint_positions(j_hand_yaw = math.pi/2.2)
       # lower scoop back to down z-position with new hand yaw position set
-      sequence.plan_to_z(trench_bottom.z)
+      sequence.plan_to_translation(
+        Vector3(0, 0, -goal.depth - SURFACE_APPROACH_DISTANCE)
+      )
       # perform scoop by rotating hand yaw, and scoop through surface
       sequence.plan_to_named_joint_positions(j_hand_yaw = -0.29*math.pi)
     return sequence.merge()

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -234,12 +234,13 @@ class TaskGrindServer(mixins.GrinderTrajectoryMixin, ActionServerBase):
     grind_point = Point(goal.x_start, goal.y_start, goal.ground_position)
 
     yaw = _compute_workspace_shoulder_yaw(grind_point.x, grind_point.y)
-    trench_direction = Vector3(math.sin(yaw),0 -math.cos(yaw), 0.0)
+    trench_direction = Vector3(math.sin(yaw), -math.cos(yaw), 0.0)
 
     grind_orientation = math3d.quaternion_from_euler(math.pi, math.pi / 2, 0)
     segment1_offset_from_dig_point = Vector3(
       -SEGMENT_SEPARATION_DISTANCE / 2, 0, 0)
-    segment_separation = Vector3(SEGMENT_SEPARATION_DISTANCE, 0, 0)
+    segment_separation = math3d.scalar_multiply(
+      -SEGMENT_SEPARATION_DISTANCE, math3d.orthogonal(trench_direction))
 
     if goal.parallel:
       rot_to_parallel = math3d.quaternion_from_euler(0, 0, math.pi / 2)

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -117,18 +117,18 @@ class GuardedMoveServer(mixins.ArmActionMixin, ActionServerBase):
 
   def plan_trajectory(self, goal):
     sequence = TrajectorySequence(
-      'l_scoop', self._arm.robot, self._arm.move_group_scoop)
+      self._arm.robot, self._arm.move_group_scoop, 'l_scoop')
     # STUB: GROUND HEIGHT TO BE EXTRACTED FROM DEM
     targ_elevation = -0.2
-    if (goal.point.z+targ_elevation) == 0:
+    if (goal.start.z+targ_elevation) == 0:
       offset = goal.search_distance
     else:
-      offset = (goal.point.z*goal.search_distance)/(goal.point.z+targ_elevation)
+      offset = (goal.start.z*goal.search_distance)/(goal.start.z+targ_elevation)
     # Compute shoulder yaw angle to target
-    alpha = math.atan2((goal.point.y+goal.normal.y*offset)-constants.Y_SHOU,
-                       (goal.point.x+goal.normal.x*offset)-constants.X_SHOU)
-    h = math.sqrt(pow((goal.point.y+goal.normal.y*offset)-constants.Y_SHOU, 2) +
-                  pow((goal.point.x+goal.normal.x*offset)-constants.X_SHOU, 2))
+    alpha = math.atan2((goal.start.y+goal.normal.y*offset)-constants.Y_SHOU,
+                       (goal.start.x+goal.normal.x*offset)-constants.X_SHOU)
+    h = math.sqrt(pow((goal.start.y+goal.normal.y*offset)-constants.Y_SHOU, 2) +
+                  pow((goal.start.x+goal.normal.x*offset)-constants.X_SHOU, 2))
     l = constants.Y_SHOU - constants.HAND_Y_OFFSET
     beta = math.asin(l/h)
     # align scoop above target point
@@ -141,7 +141,7 @@ class GuardedMoveServer(mixins.ArmActionMixin, ActionServerBase):
       j_scoop_yaw = 0.0
     )
     # once aligned to move goal and offset, place scoop tip at surface target offset
-    sequence.plan_to_position(goal.point)
+    sequence.plan_to_position(goal.start)
     # drive scoop along anti-normal vector by the search distance
     sequence.plan_to_translation(
         math3d.scalar_multiply(-goal.search_distance, goal.normal)
@@ -157,7 +157,7 @@ class GuardedMoveServer(mixins.ArmActionMixin, ActionServerBase):
     # define the callback locally to avoid making detector a member variable
     def ground_detect_cb():
       # publish feedback
-      self.publish_feedback_cb()
+      self._publish_feedback(current=self._arm_tip_monitor.get_link_position())
       # check if ground has been detected
       if detector.was_ground_detected():
         self._arm.stop_trajectory_silently()

--- a/ow_lander/src/ow_lander/constants.py
+++ b/ow_lander/src/ow_lander/constants.py
@@ -58,7 +58,10 @@ GRINDER_OFFSET = 0.16
 # Distance between scoop center of mass and lower blade
 SCOOP_HEIGHT = 0.076
 
-DEFAULT_GROUND_HEIGHT = -0.155
+# selected by using ArmFindSurface to interrogate several spots directly in
+# front of the lander in both atacama_y1a and europa_terminator_workspace and
+# averaging the results
+DEFAULT_GROUND_HEIGHT = -0.172
 
 X_DELIV = 0.2
 Y_DELIV = 0.2

--- a/ow_lander/src/ow_lander/math3d.py
+++ b/ow_lander/src/ow_lander/math3d.py
@@ -2,12 +2,14 @@
 # Research and Simulation can be found in README.md in the root directory of
 # this repository.
 
-from math import sqrt, isclose, acos
-from geometry_msgs.msg import Quaternion, Vector3
+from math import sqrt, isclose, acos, sin
+from geometry_msgs.msg import Quaternion, Vector3, Point
 import tf.transformations
 
-def _types_match(a, b):
-  return type(a) == type(b)
+def _types_compatible(a, b):
+  return (type(a) == type(b)) \
+      or (type(a) == Vector3 and type(b) == Point) \
+      or (type(a) == Point and type(b) == Vector3)
 
 def add(a, b):
   """Adds two vectors
@@ -33,15 +35,34 @@ def scalar_multiply(a, b):
   """
   return type(b)(a * b.x, a * b.y, a * b.z)
 
+def quaternion_inverse(a):
+  """Compute the inverse of a quaternion
+  a -- geometry_msgs Quaternion
+  returns the quaternion inverse of a
+  """
+  return Quaternion(-a.x, -a.y, -a.z, a.w)
+
 def quaternion_multiply(a, b):
-  """Computes the product of two quaternions multiplied together (a * b)
+  """Compute the product of two quaternions multiplied together (a * b)
   a -- geometry_msgs Quaternion
   b -- geometry_msgs Quaternion
+  returns quaternion product of a and b
   """
   return Quaternion(a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y,
                     a.w * b.y - a.x * b.z + a.y * b.w + a.z * b.x,
                     a.w * b.z + a.x * b.y - a.y * b.x + a.z * b.w,
                     a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z)
+
+def quaternion_rotate(q, v):
+  """Perform a passive rotation of a vector using a quaternion
+  q -- geometry_msgs Quaternion -- Should be a unit quaternion
+  v -- geometry_msgs Pointer/Vector3
+  returns v rotated by q as the same type as v
+  """
+  v_quat = Quaternion(v.x, v.y, v.z, 0)
+  q_inv = quaternion_inverse(q)
+  product = quaternion_multiply(quaternion_multiply(q, v_quat), q_inv)
+  return type(v)(product.x, product.y, product.z)
 
 def dot(a, b):
   """Computes dot product between vectors/Quaternions a and b (a * b)
@@ -49,7 +70,7 @@ def dot(a, b):
   b -- geometry_msgs Vector3, Point, or Quaternions
   returns a float that is the result of a * b
   """
-  assert(_types_match(a, b))
+  assert(_types_compatible(a, b))
   dot = a.x * b.x + a.y * b.y + a.z * b.z
   if hasattr(a, 'w'):
     dot += a.w * b.w
@@ -61,7 +82,7 @@ def cross(a, b):
   b -- geometry_msgs Vector3 or Point
   returns a vector that is the result of a x b
   """
-  assert(_types_match(a, b))
+  assert(_types_compatible(a, b))
   return type(a)(a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x)
 
 def norm_squared(v):
@@ -125,9 +146,9 @@ def orthogonal(v):
 def quaternion_from_euler(x, y, z):
   """A version of tf.transformation's quaternion_from_euler that returns a
   geometry_msgs Quaternion
-  x -- Radian rotation around x
-  y -- Radian rotation around y
-  z -- Radian rotation around z
+  x -- Radian rotation around x (roll)
+  y -- Radian rotation around y (pitch)
+  z -- Radian rotation around z (yaw)
   returns a geometry_msgs Quaternion
   """
   return Quaternion(*list(tf.transformations.quaternion_from_euler(x, y, z)))
@@ -139,6 +160,41 @@ def euler_from_quaternion(q):
   returns a 3-tuple of Euler angles (x, y, z)
   """
   return tuple(tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w]))
+
+def slerp_quaternion(q1, q2, t):
+  """Computes a spherical linear interpolation (slerp) between two quaternions.
+  This wraps the method quaternion_slerp from tf.transformation so that it
+  accepts and returns geometry_msgs types.
+  q1 -- geometry_msgs Quaternion -- The value returned when t=0
+  q2 -- geometry_msgs Quaternion -- The value returned when t=1
+  t  -- Fraction between q1 and q1. 0 <= t <= 1
+  returns a geometry_msgs quaternion between q1 and q1 by a fractional amount t
+  """
+  return Quaternion(
+    *list(
+      tf.transformations.quaternion_slerp(
+        [q1.x, q1.y, q1.z, q1.w], [q2.x, q2.y, q2.z, q2.w], t
+      )
+    )
+  )
+
+def slerp(a, b, t):
+  """Compute a spherical linear interpolation (slerp) between two vectors.
+  a -- geometry_msgs Point/Vector3 -- The value returned when t=0
+  b -- geometry_msgs Point/Vector3 -- The value returned when t=1
+  t -- Fraction between a and b. 0 <= t <= 1
+  returns a geometry_msgs Point/Vector3 between a and b by a fractional amount t
+  """
+  # handle case where points of contact are within floating-precision error of
+  # each other
+  if isclose(distance(a, b), 0):
+    return a
+  # compute arc length between points of contact
+  al = acos(dot(normalize(a), normalize(b)))
+  # compute scalar weight for a and b respectively
+  weight_a = sin((1 - t) * al) / sin(al)
+  weight_b = sin(t * al) / sin(al)
+  return add(scalar_multiply(weight_a, a), scalar_multiply(weight_b, b))
 
 def quaternion_rotation_between(a, b):
   """Computes the quaternion rotation between the vectors a and b.
@@ -157,11 +213,20 @@ def quaternion_rotation_between(a, b):
   v = cross(a, b)
   return normalize(Quaternion(v.x, v.y, v.z, w))
 
+def vectors_approx_equivalent(a, b, tolerance):
+  """Check if two vectors are nearly the same.
+  a -- geometry_msgs Point/Vector3
+  b -- geometry_msgs Point/Vector3
+  tolerance -- The maximal distance positions can differ by
+  returns True if the difference between a and b are below the tolerance
+  """
+  return distance(a, b) <= tolerance
+
 def poses_approx_equivalent(pose1, pose2, linear_tolerance, angular_tolerance):
-  """Checks if two poses are nearly the same position and orientation.
+  """Check if two poses are nearly the same position and orientation.
   pose1 -- geometry_msgs Pose
   pose2 -- geometry_msgs Pose to be checked against pose1
-  linear_tolerance  -- The maximal distance positions can differ by (meters)
+  linear_tolerance  -- The maximal distance positions can differ by
   angular_tolerance -- The maximal spherical distance orientations can differ by
                        (radians)
   returns True if the difference between pose1 and pose2's position and
@@ -169,7 +234,7 @@ def poses_approx_equivalent(pose1, pose2, linear_tolerance, angular_tolerance):
   """
   p1 = pose1.position
   p2 = pose2.position
-  if distance(p1, p2) <= linear_tolerance:
+  if vectors_approx_equivalent(p1, p2, linear_tolerance):
     o1 = pose1.orientation
     o2 = pose2.orientation
     # check that the geodesic norm between the 2 quaternions is below tolerance

--- a/ow_lander/src/ow_lander/trajectory_sequence.py
+++ b/ow_lander/src/ow_lander/trajectory_sequence.py
@@ -1,5 +1,11 @@
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
 import rospy
 import time
+import math
+from numpy import arange
 from moveit_msgs.srv import GetPositionFK
 from moveit_msgs.msg import RobotTrajectory, MoveItErrorCodes
 from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
@@ -30,11 +36,18 @@ class TrajectorySequence:
     rospy.wait_for_service(self.SRV_COMPUTE_FK, SERVICE_TIMEOUT)
     self._compute_fk_srv = rospy.ServiceProxy(self.SRV_COMPUTE_FK,
                                               GetPositionFK)
+    if self._ee is not None:
+      self._old_ee = self._group.get_end_effector_link()
+      # compute_cartesian_path requires this is set to work properly
+      self._group.set_end_effector_link(self._ee)
 
   def __del__(self):
     # clean-up any target states left-over in move_group so they are not carried
     # over to unrelated planning
     self._group.clear_pose_targets()
+    # reset to previous end-effector
+    if self._ee is not None:
+      self._group.set_end_effector_link(self._old_ee)
 
   def _assert_end_effector_set(self):
     if self._ee is None:
@@ -177,8 +190,81 @@ class TrajectorySequence:
     )
     planning_time = time.time() - start
     if fraction != 1.0:
-      raise ArmPlanningError("Linear path planning failed. Can only make it "
+      raise ArmPlanningError("Linear path planning failed. Can only plan up to "
                             f"{fraction * 100:.1f}% of the way")
+    self._append_trajectory(trajectory, planning_time)
+
+  def plan_circular_path_to_pose(self, pose, center):
+    """Plan the end-effector along a circular path from its most recent pose in
+    the sequence to a new pose.
+    NOTE: If the most recent pose in the sequence and the intended pose do not
+    lie on the same circle centered at center, the path will not be circular,
+    but will be curved. It is up to the method caller to provide arguments that
+    define a circular path with the most recent pose.
+    pose   -- geometry_msgs Pose -- Pose that will be acquired at the end of
+              the circular path.
+    center -- geometry_msgs Point/Vector3 -- The center of the circle traced out
+              by the end-effector.
+    """
+    ARC_INCREMENT = 0.02 # meters
+    # track planning time
+    start_time = time.time()
+    current = self._compute_forward_kinematics(self._most_recent_state)
+    # compute pose positions relative to the circle's center (points of contact)
+    poc1 = math3d.subtract(current.position, center)
+    poc2 = math3d.subtract(pose.position, center)
+    if math3d.vectors_approx_equivalent(poc1, poc2, 0.0):
+      raise ArmPlanningError(
+        "Circular path planning failed. The intended end-effector position "
+        "may not be the same as the most recent position in the sequence."
+      )
+    r1 = math3d.norm(poc1)
+    r2 = math3d.norm(poc2)
+    if r1 == 0 or r2 == 0:
+      raise ArmPlanningError(
+        "Circular path planning failed. The position of the circle's center "
+        "may not be at the same location as the intended position or the most "
+        "recent end-effector position in the sequence."
+      )
+    # use the cosine identity of the dot product to find the arc length between
+    # the two points of contact
+    # NOTE: this allows for r1 =\= r2, but if this is the case the trajectory
+    # will not necessarily be circular
+    arc_length = r1 * math.acos(math3d.dot(poc1, poc2) / (r1 * r2))
+    # populate a list of poses along the circle between pose1 and pose2
+    poses = list()
+    for t in arange(0.0, 1.0,  ARC_INCREMENT / arc_length):
+      poc = math3d.slerp(poc1, poc2, t)
+      orientation = math3d.slerp_quaternion(
+        current.orientation, pose.orientation, t
+      )
+      poses.append(Pose(math3d.add(center, poc), orientation))
+    # the previous loop excludes the final pose, so add it now
+    poses.append(pose)
+    # plan path using the series of Cartesian poses
+    self._group.set_start_state(self._most_recent_state)
+    trajectory, fraction = self._group.compute_cartesian_path(
+      poses, ARC_INCREMENT / 2.0, 0
+    )
+    planning_time = time.time() - start_time
+    if len(trajectory.joint_trajectory.points) < 3:
+      raise ArmPlanningError(
+        "Circular path planning failed. Only two or fewer trajectory points "
+        "were generated. Either the commanded circle radius or arc length are "
+        "too small and will not produce a circular movement."
+      )
+    if fraction != 1.0:
+      raise ArmPlanningError(
+        "Circular path planning failed. Can only plan up to "
+        f"{fraction * 100:.1f}% of the way"
+      )
+    # NOTE: There appears to be a bug with compute_cartesian_path that causes
+    #       it to sometimes return a trajectory with the first 2 points
+    #       overlapping at time zero. This check works around the bug.
+    if trajectory.joint_trajectory.points[0].time_from_start == \
+          trajectory.joint_trajectory.points[1].time_from_start:
+      trajectory.joint_trajectory.points \
+        = trajectory.joint_trajectory.points[1:]
     self._append_trajectory(trajectory, planning_time)
 
   def plan_linear_translation(self, translation):

--- a/ow_lander/src/ow_lander/trajectory_sequence.py
+++ b/ow_lander/src/ow_lander/trajectory_sequence.py
@@ -228,12 +228,14 @@ class TrajectorySequence:
       )
     # use the cosine identity of the dot product to find the arc length between
     # the two points of contact
-    # NOTE: this allows for r1 =\= r2, but if this is the case the trajectory
+    # NOTE: this allows for r1 =/= r2, but if this is the case the trajectory
     # will not necessarily be circular
     arc_length = r1 * math.acos(math3d.dot(poc1, poc2) / (r1 * r2))
     # populate a list of poses along the circle between pose1 and pose2
     poses = list()
-    for t in arange(0.0, 1.0,  ARC_INCREMENT / arc_length):
+    t_step = ARC_INCREMENT / arc_length
+    # start at t_step so the starting pose is not included in the resulting list
+    for t in arange(t_step, 1.0, t_step):
       poc = math3d.slerp(poc1, poc2, t)
       orientation = math3d.slerp_quaternion(
         current.orientation, pose.orientation, t
@@ -258,13 +260,6 @@ class TrajectorySequence:
         "Circular path planning failed. Can only plan up to "
         f"{fraction * 100:.1f}% of the way"
       )
-    # NOTE: There appears to be a bug with compute_cartesian_path that causes
-    #       it to sometimes return a trajectory with the first 2 points
-    #       overlapping at time zero. This check works around the bug.
-    if trajectory.joint_trajectory.points[0].time_from_start == \
-          trajectory.joint_trajectory.points[1].time_from_start:
-      trajectory.joint_trajectory.points \
-        = trajectory.joint_trajectory.points[1:]
     self._append_trajectory(trajectory, planning_time)
 
   def plan_linear_translation(self, translation):

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -780,6 +780,27 @@
     </actuator>
   </transmission>
 
+  <!-- link that we can reference in Gazebo to get altitude of tip
+     of grinder above the terrain. Note that without an inertial
+     tag, the link will not show up in the SDF/Gazebo at all -->
+  <link name="l_grinder_tip">
+    <inertial>
+      <mass value="0.0"/>
+      <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+    </inertial>
+  </link>
+  <joint name="l_grinder_tip_joint" type="fixed">
+    <origin xyz="-0.1550 -0.2684 0.0" rpy="1.5708 1.5708 -0.5236"/>
+
+    <!-- 1.5708 0 -0.5236 -->
+    <!-- fix to hand so it does not rotate with grinder -->
+    <parent link="l_hand"/>
+    <child link="l_grinder_tip"/>
+  </joint>
+  <gazebo reference="l_grinder_tip_joint">
+    <preserveFixedJoint>true</preserveFixedJoint>
+  </gazebo>
+
   <link name="l_ant_foot">
     <inertial>
       <origin

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -790,11 +790,9 @@
     </inertial>
   </link>
   <joint name="l_grinder_tip_joint" type="fixed">
-    <origin xyz="-0.1550 -0.2684 0.0" rpy="1.5708 1.5708 -0.5236"/>
-
-    <!-- 1.5708 0 -0.5236 -->
-    <!-- fix to hand so it does not rotate with grinder -->
-    <parent link="l_hand"/>
+    <origin xyz="0.16 0 0" rpy="0 0 0"/>
+    <parent link="l_grinder"/>
+    <!-- <parent link="l_hand"/> -->
     <child link="l_grinder_tip"/>
   </joint>
   <gazebo reference="l_grinder_tip_joint">


### PR DESCRIPTION
## Linked Issues:
Jira Ticket 🎟️ | [OCEANWATER-1131](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1131)

@anthonykoutroulis Please review code, testing is optional.
@kmdalal Please perform tests and review the design of each of the 3 trajectories. Code review is optional, but some of the contents of the `plan_trajectory` methods for the 3 actions may be helpful towards understanding trajectory design. 

## Summary of Changes
* Trajectories for **TaskGrind**, **TaskScoopCircular**, and **TaskScoopLinear** all rebuilt such that:
  * Commanded depths will be accurate assuming the provided ground_position (or z-coordinate) are accurate.
  * Consistent trajectory shape across the workspace. _e.g. The shape of a TaskScoopLinear at coordinate (1.7, 0.0) will be the same (1.7, 0.4)_
* A reference link, l_grinder_tip, added to the lander for accurate positioning of the grinder, similar to how its done for the scoop. 
* Updated defaults and some parameter descriptions in action client scripts.
* Updated the action client script of **TaskGrind** to match the format of other actions. The action definition remains the same. 
* Circular trajectory planning made possible in TrajectorySequence.

## Test 
Launch atacama_y1a so test results are consistent.
I tested resulting digging depths on the OCEANWATER-1069 branch, which already has code that computes scoop depth. The depth proved to be accurate within half a cm.  I don't expect the tester to go through the trouble of merging in another branch for testing purposes, so eyeballing the scoop depth should be just fine. Use the following image as reference. Note that the scoop is about 78 mm tall. 
![Screenshot_20230503_125927](https://user-images.githubusercontent.com/17039973/236017591-dc42416f-abc6-45d2-b411-0f3176a41e45.png)

For each trench, we will interrogate the surface using **ArmFindSurface**, to achieve an accurate digging depth. 

We will start with **TaskGrind** and **TaskScoopLinear** at their default workspace position
1. Pick a spot along the trench to interrogate the surface height `rosrun arm_find_surface.py -x 1.65`
I get a height of -0.187, as seen in the last coordinate of the resulting log message, but yours may vary by a couple millimeters.
```
[INFO:/lander_action_servers] ArmFindSurface: Succeeded - ArmFindSurface trajectory stopped by a force of 315.17 N. Surface found at (1.660, 0.001, -0.187)
```
2. Now perform a grind using the acquired ground position `rosrun ow_lander task_grind.py -z -0.187`
3. Now dig `rosrun ow_lander task_scoop_linear.py -z -0.187`
Verify the trajectories look similar as in the video. Recording was made at a real-time factor of x3.

https://user-images.githubusercontent.com/17039973/236066336-e91b7c2e-2fb6-45c9-a047-8ce20f43589d.mp4

Now a perpendicular **TaskGrind** followed by a perpendicular **TaskScoopCircular**. We will assume the ground position is roughly the same.
4. `rosrun ow_lander task_grind.py -z -0.187 --perpendicular`
5. `rosrun ow_lander task_scoop_circular.py -x 1.45 -z -0.187 --perpendicular`
Verify the trajectories look  similar as in the video

https://user-images.githubusercontent.com/17039973/236066887-09a61c3b-5179-4770-9c76-cf86b71e18f5.mp4

## Freestyle Testing
I encourage reviewers to try different commands. There are many potential variations. 

## Caveat
You will notice it is difficult to select the correct (x, y) coordinate for a TaskScoop* that matches a TaskGrind if y =/= 0. This is because the (x, y) coordinate means something different in each command. For TaskGrind (parallel), (x, y) is halfway between the starting position and ending position of grind segments 1 and 2. For TaskGrind (perpendicular) (x, y) is halfway between each segment and in the center of each segment. For TaskScoopCircular (x, y) always represents the center of the trench, or the deepest part. For TaskScoopLinear (x, y) is the start of the linear segment; however, the entry point may be as much as 2 cm behind that point.

I have a proposal in mind to make the semantics of these commands more consistent and make a TaskGrind position easily translatable into a TaskScoop* position. However, I would like to get feedback on it from the rest of the team first, and I do not wish to inflate the scoop of this PR any further. 