### PR TITLE
Report error codes from follow_joint_trajectory actions

### DIFF
--- a/ow_lander/src/ow_lander/arm_interface.py
+++ b/ow_lander/src/ow_lander/arm_interface.py
@@ -107,7 +107,6 @@ class OWArmInterface(metaclass = Singleton):
     action_feedback_cb -- A function called at 100 Hz during execution of a
                           trajectory. Exists to publish the action's feedback
                           message. Handles no arguments.
-    returns True if plan was executed successfully and without preempt.
     """
 
     OWArmInterface._assert_arm_is_checked_out()
@@ -129,17 +128,26 @@ class OWArmInterface(metaclass = Singleton):
     # publish feedback while waiting for trajectory execution completion
     FEEDBACK_RATE = 100 # hertz
     rate = rospy.Rate(FEEDBACK_RATE)
-    timeout = plan.joint_trajectory.points[-1].time_from_start \
-              - plan.joint_trajectory.points[0].time_from_start
-    start_time = rospy.get_time()
-    while rospy.get_time() - start_time < timeout.to_sec() \
-          or self.__executor.is_active():
+    while self.__executor.is_active():
       if OWArmInterface._stopped:
         self.__executor.cease_execution()
         raise ArmExecutionError("Stop was called; trajectory execution ceased")
       if action_feedback_cb is not None:
         action_feedback_cb()
       rate.sleep()
+
+    result = self.__executor.result()
+    # NOTE: a None result is indicative that trajectory execution was ceased
+    #       intentionally by calling ceased_exectuion and does not mean there
+    #       was an error
+    if result is not None and result.error_code != 0:
+      # the follow_joint_trajectory action server does not cease trajectory
+      # execution when an error occurs, so do so manually
+      self.__executor.cease_execution()
+      raise ArmExecutionError("The follow_joint_trajectory action server for "
+                              f"{self.__executor.get_active_controller()} "
+                              f"resulted in error code {result.error_code} "
+                              f"with the message: {result.error_string}")
 
   def get_end_effector_pose(self, end_effector, frame_id,
                             timestamp=rospy.Time(0), timeout=rospy.Duration(0)):


### PR DESCRIPTION
## Linked Issues:
Jira Ticket 🎟️ | [OCEANWATER-1091](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1091)

## Summary of Changes
* Error codes from the follow_joint_trajectory actions are now captured and reported. Trajectory execution will be ceased when such an error occurs.

## Test
1. Open any world with dynamic terrain.
2. Perform a full dig sequence to test nominal operation. The following pasted into the terminal will call all commands in sequence.
```
rosrun ow_lander arm_unstow.py; 
rosrun ow_lander arm_find_surface.py -x 1.6 -z -0.1; 
rosrun ow_lander arm_unstow.py; 
rosrun ow_lander task_grind.py; 
rosrun ow_lander task_scoop_linear.py; 
rosrun ow_lander task_deliver_sample.py;
```
Watch their execution and ensure nothing weird happens. All command should succeed like in the following output
```
[INFO:/lander_action_servers] ArmUnstow action started
[INFO:/lander_action_servers] ArmUnstow: Succeeded - ArmUnstow trajectory succeeded
[INFO:/lander_action_servers] ArmUnstow action complete
[INFO:/lander_action_servers] ArmFindSurface action started
[INFO:/lander_action_servers] ArmFindSurface: Succeeded - ArmFindSurface trajectory stopped by a force of 258.39 N. Surface found at (1.616, -0.001, -0.187)
[INFO:/lander_action_servers] ArmFindSurface action complete
[INFO:/lander_action_servers] ArmUnstow action started
[INFO:/lander_action_servers] ArmUnstow: Succeeded - ArmUnstow trajectory succeeded
[INFO:/lander_action_servers] ArmUnstow action complete
[INFO:/lander_action_servers] TaskGrind action started
[INFO:/lander_action_servers] TaskGrind: Succeeded - TaskGrind trajectory succeeded
[INFO:/lander_action_servers] TaskGrind action complete
[INFO:/lander_action_servers] TaskScoopLinear action started
[ INFO:/regolith_node] Spawning regolith
[ INFO:/gazebo] ApplyBodyWrench: reference_frame is empty/world/map, using inertial frame, transferring from body relative to inertial frame
[Msg] GlobalShaderParamPlugin::cacheParams(sunIntensity, 24)
[Msg] GlobalShaderParamPlugin::cacheParams(sunVisibility, 20)
[ INFO:/regolith_node] Spawning regolith
[ INFO:/gazebo] ApplyBodyWrench: reference_frame is empty/world/map, using inertial frame, transferring from body relative to inertial frame
[Msg] GlobalShaderParamPlugin::cacheParams(sunIntensity, 25)
[Msg] GlobalShaderParamPlugin::cacheParams(sunVisibility, 21)
[ INFO:/regolith_node] Spawning regolith
[ INFO:/gazebo] ApplyBodyWrench: reference_frame is empty/world/map, using inertial frame, transferring from body relative to inertial frame
[Msg] GlobalShaderParamPlugin::cacheParams(sunIntensity, 26)
[Msg] GlobalShaderParamPlugin::cacheParams(sunVisibility, 22)
[ INFO:/regolith_node] Spawning regolith
[ INFO:/gazebo] ApplyBodyWrench: reference_frame is empty/world/map, using inertial frame, transferring from body relative to inertial frame
[Msg] GlobalShaderParamPlugin::cacheParams(sunIntensity, 27)
[Msg] GlobalShaderParamPlugin::cacheParams(sunVisibility, 23)
[ INFO:/regolith_node] Spawning regolith
[ INFO:/gazebo] ApplyBodyWrench: reference_frame is empty/world/map, using inertial frame, transferring from body relative to inertial frame
[Msg] GlobalShaderParamPlugin::cacheParams(sunIntensity, 28)
[Msg] GlobalShaderParamPlugin::cacheParams(sunVisibility, 24)
[ INFO:/regolith_node] Spawning regolith
[ INFO:/gazebo] ApplyBodyWrench: reference_frame is empty/world/map, using inertial frame, transferring from body relative to inertial frame
[Msg] GlobalShaderParamPlugin::cacheParams(sunIntensity, 29)
[Msg] GlobalShaderParamPlugin::cacheParams(sunVisibility, 25)
[INFO:/lander_action_servers] TaskScoopLinear: Succeeded - TaskScoopLinear trajectory succeeded
[INFO:/lander_action_servers] TaskScoopLinear action complete
[INFO:/lander_action_servers] TaskDeliverSample action started
[INFO:/lander_action_servers] TaskDeliverSample: Succeeded - TaskDeliverSample trajectory succeeded
[INFO:/lander_action_servers] TaskDeliverSample action complete
```
3. To force an error out of the follow_joint_trajectory action, we'll command a dig in a spot that has not been processed by the grinder.
`rosrun ow_lander task_scoop_circular.py -y 0.4`
The scoop will become jammed against the terrain. Wait about 10 seconds and you should see the following.
```
[INFO:/lander_action_servers] TaskScoopCircular action started
[ERROR:/lander_action_servers] TaskScoopCircular: Aborted - The follow_joint_trajectory action server for arm_controller resulted in error code -5 with the message: j_dist_pitch goal error 1.988257
[INFO:/lander_action_servers] TaskScoopCircular action complete
```
Prior to this PR, an action that was incapable of completing it trajectory like this would erroneously mark itself successful. 
