### PR TITLE
All dig points now correspond to the center of the trench

### DIFF
--- a/ow_lander/scripts/task_grind.py
+++ b/ow_lander/scripts/task_grind.py
@@ -13,7 +13,7 @@ from ow_lander import constants
 parser = argparse.ArgumentParser(
   formatter_class=argparse.ArgumentDefaultsHelpFormatter,
   description="The grinder is used process the terrain for excavation.")
-parser.add_argument('-x', type=float, default=1.45,
+parser.add_argument('-x', type=float, default=1.75,
   help="X-coordinate of grinding starting point in base_link frame")
 parser.add_argument('-y', type=float, default=0.0,
   help="Y-coordinate of grinding starting point in base_link frame")

--- a/ow_lander/scripts/task_scoop_circular.py
+++ b/ow_lander/scripts/task_scoop_circular.py
@@ -22,7 +22,7 @@ parser.add_argument('--frame', '-f', type=int, default=0,
        + str(constants.FRAME_ID_MAP))
 parser.add_argument('--relative', '-r', action='store_true', default=False,
   help="Position will be interpreted as relative to the current position")
-parser.add_argument('-x', type=float, default=1.65,
+parser.add_argument('-x', type=float, default=1.75,
   help="X-coordinate on surface where trench is centered")
 parser.add_argument('-y', type=float, default=0,
   help="Y-coordinate on surface where trench is centered")

--- a/ow_lander/scripts/task_scoop_linear.py
+++ b/ow_lander/scripts/task_scoop_linear.py
@@ -30,7 +30,7 @@ parser.add_argument('-z', type=float, default=constants.DEFAULT_GROUND_HEIGHT,
   help="Estimate of ground position at point (x, y) in base_link frame")
 parser.add_argument('--depth', '-d', type=float, default=0.02,
   help="Depth of scoop during linear segment")
-parser.add_argument('--length', '-l', type=float, default=0.25,
+parser.add_argument('--length', '-l', type=float, default=0.3,
   help="Length of the linear segment of the scoop's trajectory")
 args = parser.parse_args()
 

--- a/ow_lander/scripts/task_scoop_linear.py
+++ b/ow_lander/scripts/task_scoop_linear.py
@@ -22,7 +22,7 @@ parser.add_argument('--frame', '-f', type=int, default=0,
        + str(constants.FRAME_ID_MAP))
 parser.add_argument('--relative', '-r', action='store_true', default=False,
   help="Position will be interpreted as relative to the current position")
-parser.add_argument('-x', type=float, default=1.55,
+parser.add_argument('-x', type=float, default=1.75,
   help="X-coordinate on surface where trench starts")
 parser.add_argument('-y', type=float, default=0,
   help="Y-coordinate on surface where trench starts")
@@ -30,7 +30,7 @@ parser.add_argument('-z', type=float, default=constants.DEFAULT_GROUND_HEIGHT,
   help="Estimate of ground position at point (x, y) in base_link frame")
 parser.add_argument('--depth', '-d', type=float, default=0.02,
   help="Depth of scoop during linear segment")
-parser.add_argument('--length', '-l', type=float, default=0.2,
+parser.add_argument('--length', '-l', type=float, default=0.25,
   help="Length of the linear segment of the scoop's trajectory")
 args = parser.parse_args()
 

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -230,6 +230,7 @@ class TaskGrindServer(mixins.GrinderTrajectoryMixin, ActionServerBase):
     APPROACH_DISTANCE = 0.25 # meters
     # distance between the backward and forward linear paths
     SEGMENT_SEPARATION_DISTANCE = 0.08 # meters
+
     # NOTE: grind_point lies halfway between the two segments in the center of
     #       the trench
     grind_point = Point(goal.x_start, goal.y_start, goal.ground_position)
@@ -315,17 +316,16 @@ class TaskScoopCircularServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
     ARC = math.pi / 2
     RETRACT_DISTANCE = 0.2 # meters
 
-    trench_surface = self.transform_to_planning_frame(
+    # NOTE: dig point is on the surface in the center of the circular trench
+    dig_point = self.transform_to_planning_frame(
       self.get_intended_position(goal.frame, goal.relative, goal.point)).point
-    trench_bottom = Point(
-      trench_surface.x,
-      trench_surface.y,
-      trench_surface.z - goal.depth
-    )
+    # place end-effector above trench position
+    yaw = _compute_workspace_shoulder_yaw(dig_point.x, dig_point.y)
+    trench_bottom = Point(dig_point.x,
+                          dig_point.y,
+                          dig_point.z - goal.depth)
     # center of the circular arc
     center = math3d.add(trench_bottom, Vector3(0, 0, RADIUS))
-    # place end-effector above trench position
-    yaw = _compute_workspace_shoulder_yaw(trench_bottom.x, trench_bottom.y)
     # rotates a downward facing point of contact (POC) on the circle to the
     # start and end of the perpendicular downward arc trajectory
     rot_down_to_start = math3d.quaternion_from_euler(ARC / 2, 0, yaw)
@@ -369,7 +369,7 @@ class TaskScoopCircularServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
     # move through downward circular arc and end with scoop pitched up
     sequence.plan_circular_path_to_pose(Pose(p2, o2), center)
     # retract out of the trench so the next arm movement can be made safely
-    sequence.plan_to_z(trench_surface.z + RETRACT_DISTANCE)
+    sequence.plan_to_z(dig_point.z + RETRACT_DISTANCE)
     return sequence.merge()
 
 
@@ -397,8 +397,8 @@ class TaskScoopLinearServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
     # this pitch was picked to avoid hand collision with terrain
     EXIT_PITCH = -0.8 # radians
 
-    # the commanded dig point is on the surface directly above the start of the
-    # linear segment
+    # NOTE: commanded dig point is halfway between the start of the entry
+    #       circular trajectory and the start of the exit circular trajectory
     dig_point = self.transform_to_planning_frame(
       self.get_intended_position(goal.frame, goal.relative, goal.point)).point
     yaw = _compute_workspace_shoulder_yaw(dig_point.x, dig_point.y)
@@ -407,18 +407,24 @@ class TaskScoopLinearServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
     digging_orientation = math3d.quaternion_from_euler(math.pi, 0, yaw)
     entry_orietation = math3d.quaternion_from_euler(math.pi, ENTRY_PITCH, yaw)
     exit_orientation = math3d.quaternion_from_euler(math.pi, EXIT_PITCH, yaw)
+    # point on the surface above where linear movement starts
+    linear_start_surface = math3d.add(dig_point,
+      math3d.scalar_multiply(-goal.length / 2, trench_direction))
     # point under the surface where linear movement starts
-    linear_start = math3d.add(dig_point, Vector3(0, 0, -goal.depth))
+    linear_start_bottom = math3d.add(linear_start_surface,
+                                     Vector3(0, 0, -goal.depth))
     # point under the surface where linear movement ends
-    linear_end = math3d.add(linear_start,
+    linear_end_bottom = math3d.add(linear_start_bottom,
       math3d.scalar_multiply(goal.length, trench_direction))
     # center of the circular entry arc
-    entry_circle_center = math3d.add(linear_start, Vector3(0, 0, ENTRY_RADIUS))
+    entry_circle_center = math3d.add(linear_start_bottom,
+                                     Vector3(0, 0, ENTRY_RADIUS))
     # center of the circular exit arc
-    exit_circle_center = math3d.add(linear_end, Vector3(0, 0, EXIT_RADIUS))
+    exit_circle_center = math3d.add(linear_end_bottom,
+                                    Vector3(0, 0, EXIT_RADIUS))
     # rotate around center by entry arc
     entry_rot = math3d.quaternion_from_euler(0, ENTRY_PITCH, yaw)
-    linear_start_poc = math3d.subtract(linear_start, entry_circle_center)
+    linear_start_poc = math3d.subtract(linear_start_bottom, entry_circle_center)
     entry_arc_start_poc = math3d.quaternion_rotate(entry_rot, linear_start_poc)
     entry_arc_start = math3d.add(entry_arc_start_poc, entry_circle_center)
     # place approach directly above the start of the entry arc
@@ -426,7 +432,7 @@ class TaskScoopLinearServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
     entry_approach.z = dig_point.z + APPROACH_DISTANCE
     # rotate around center by exit arc
     exit_rot = math3d.quaternion_from_euler(0, EXIT_PITCH, yaw)
-    linear_end_poc = math3d.subtract(linear_end, exit_circle_center)
+    linear_end_poc = math3d.subtract(linear_end_bottom, exit_circle_center)
     exit_arc_end_poc = math3d.quaternion_rotate(exit_rot, linear_end_poc)
     exit_arc_end = math3d.add(exit_arc_end_poc, exit_circle_center)
     # z-position scoop will retract to after exit
@@ -449,12 +455,16 @@ class TaskScoopLinearServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
     # entry orientation
     sequence.plan_to_position(entry_arc_start)
     # rotate scoop tip into terrain
-    sequence.plan_circular_path_to_pose(Pose(linear_start, digging_orientation),    entry_circle_center)
+    sequence.plan_circular_path_to_pose(
+      Pose(linear_start_bottom, digging_orientation),
+      entry_circle_center
+    )
     # move the scoop along a linear path to the end of the trench
-    sequence.plan_linear_path_to_pose(Pose(linear_end, digging_orientation))
+    sequence.plan_linear_path_to_pose(
+      Pose(linear_end_bottom, digging_orientation))
     # pitch scoop upward and out of the exit point
     sequence.plan_circular_path_to_pose(Pose(exit_arc_end, exit_orientation),
-      exit_circle_center)
+                                        exit_circle_center)
     # retract up from terrain while maintaining exit orientation
     # NOTE: only required for especially deep digs
     if sequence.get_final_pose().position.z < exit_retract_z:


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-1146](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1146) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1153](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1153) |


## Summary of Changes
* X and Y for all dig actions (TaskGrind, TaskScoopLinear, and TaskScoopCircular) now correspond to the center of their resulting trench.
  * This allows for X and Y values used for a TaskGrind to be used for either a TaskScoopLinear or TaskScoopCircular without adjustment (see Caveat).
* Default action client script values updated to work with new semantics. 

## Caveat
The `length` value used for a TaskGrind cannot in general be used for a TaskScoopLinear in the same spot. This is because the TaskGrind `length` is the distance between the grinder entry point and its exit point, but the TaskScoopLinear `length` is the distance between the end of it's entry circular trajectory, and the start of the exit circular trajectory. This means a TaskScoopLinear `length` value must be slightly shorter than the TaskGrind length that processed the trench it digs into. Empirically the TaskScoopLinear `length` should be about 3 cm less than the TaskGrind `length`, but can be less if only shallow digs are desired. Default trench lengths have been changed based on this heuristic.

## Test
All of the following should succeed and look nominal.
1.  Launch Atacama_y1a
2. Command a grind `rosrun ow_lander task_grind.py -x 1.7 -y 0.6`
3. Command a linear scoop using the same coordinates `rosrun ow_lander task_scoop_linear.py -x 1.7 -y 0.6`
4. Sample the surface height of mound near the lander 
`rosrun ow_lander arm_find_surface.py -x 1.65 -y -0.4 -z 0.1`
here is my result
```
[INFO:/lander_action_servers] ArmFindSurface: Succeeded - ArmFindSurface trajectory stopped by a force of 206.46 N. Surface found at (1.660, -0.404, -0.070)
```
6. Use the resulting z-value to grind that spot `rosrun ow_lander task_grind.py -x 1.65 -y -0.4 -z -0.07`
7. Perform a circular scoop on that spot `rosrun ow_lander task_scoop_circular.py -x 1.65 -y -0.4 -z -0.07`

