### PR TITLE
Oceanwater-1140: Re-sync topic publication rate

### DIFF
--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -41,7 +41,7 @@ gsap_rate: 0.5              # hz
 # where N = profile interval/gsap_rate. For now, we avoid additional
 # user specification and computation by providing the required value
 # of N here.
-profile_increment: 2
+profile_increment: 10
 
 # Similarly, since the inputs used to compute power consumption come
 # from the /joint_states topic published at 50Hz, we multiply this by

--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -41,7 +41,7 @@ gsap_rate: 0.5              # hz
 # where N = profile interval/gsap_rate. For now, we avoid additional
 # user specification and computation by providing the required value
 # of N here.
-profile_increment: 10
+profile_increment: 2
 
 # Similarly, since the inputs used to compute power consumption come
 # from the /joint_states topic published at 50Hz, we multiply this by

--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -1,11 +1,6 @@
 # configuration
 efficiency: 0.9
 
-# If true, prints battery status each cycle to terminal.
-# WARNING: Will inundate the console with printouts if enabled. Not
-# ideal outside of debugging purposes.
-print_debug: true
-
 # Maximum RUL estimation for prognoser predictions (seconds).
 max_horizon: 10000
 
@@ -57,3 +52,24 @@ power_average_size: 25
 # workaround to prevent this, we cap its power input.
 max_gsap_power_input: 20    # watts
 
+# DEBUG CUSTOMIZATION
+# This flag disables all power-related debug output from printing if false.
+# The other flags allow filtering of specific messages.
+print_debug: false
+
+# Prints the timestamp of each cycle to the terminal.
+# Output: 1 line per cycle.
+timestamp_print_debug: true
+
+# Prints the input data sent to GSAP's asynchronous prognosers each cycle.
+# Output: Up to NUM_NODES lines per cycle, less if a given node is waiting for
+# others to finish.
+inputs_print_debug: true
+
+# Prints the information currently stored in all nodes each cycle.
+# Output: NUM_NODES lines per cycle.
+outputs_print_debug: true
+
+# Prints the information that will be published via rostopics each cycle.
+# Output: 1 line per cycle.
+topics_print_debug: true

--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -2,6 +2,8 @@
 efficiency: 0.9
 
 # If true, prints battery status each cycle to terminal.
+# WARNING: Will inundate the console with printouts if enabled. Not
+# ideal outside of debugging purposes.
 print_debug: true
 
 # Maximum RUL estimation for prognoser predictions (seconds).
@@ -14,6 +16,8 @@ num_samples: 100
 initial_power: 0.0          # watts
 initial_voltage: 4.1        # volts
 initial_temperature: 20.0   # deg. C
+
+initial_soc: 0.95           # % (used for first placeholder publication)
 
 # voltage
 base_voltage: 2.8           # volts

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -34,6 +34,8 @@ public:
   void GetPowerStats(double &time, double &power, double &volts, double &tmp);
   double GetRawMechanicalPower();
   double GetAvgMechanicalPower();
+  double GetTimestamp();
+  void TickTime();
   void SetHighPowerDraw(double draw);
   void SetCustomPowerDraw(double draw);
   void SetCustomVoltageFault(double volts);

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -35,7 +35,6 @@ public:
   double GetRawMechanicalPower();
   double GetAvgMechanicalPower();
   double GetTimestamp();
-  void TickTime();
   void SetHighPowerDraw(double draw);
   void SetCustomPowerDraw(double draw);
   void SetCustomVoltageFault(double volts);

--- a/ow_power_system/include/PowerSystemPack.h
+++ b/ow_power_system/include/PowerSystemPack.h
@@ -104,13 +104,17 @@ private:
   ros::Publisher m_battery_temperature_pub;    // Battery Temperature Publisher
   ros::Subscriber m_joint_states_sub;          // Mechanical Power Subscriber
 
-  // Flag that determines if debug output is printed regarding battery status
+  // Flags that determine if debug output is printed regarding battery status
   // during runtime. Overridden by system.cfg on startup.
   // NOTE: This is a string because of limitations with ConfigMap. There's no
   // function to get boolean variables from a config. Could benefit from an
   // update if such a function is added in the future.
   std::string m_print_debug_val = "false";
   bool m_print_debug = false;
+  bool m_timestamp_print_debug = false;
+  bool m_inputs_print_debug = false;
+  bool m_outputs_print_debug = false;
+  bool m_topics_print_debug = false;
 
   // The maximum RUL estimation output from the Monte Carlo prediction process.
   // Lower values mean faster performance in the event a RUL prediction would

--- a/ow_power_system/include/PowerSystemPack.h
+++ b/ow_power_system/include/PowerSystemPack.h
@@ -106,10 +106,9 @@ private:
 
   // Flags that determine if debug output is printed regarding battery status
   // during runtime. Overridden by system.cfg on startup.
-  // NOTE: This is a string because of limitations with ConfigMap. There's no
-  // function to get boolean variables from a config. Could benefit from an
+  // NOTE: There's no function to get boolean variables from a config, so
+  // these bools have to be set via string comparisons. Could benefit from an
   // update if such a function is added in the future.
-  std::string m_print_debug_val = "false";
   bool m_print_debug = false;
   bool m_timestamp_print_debug = false;
   bool m_inputs_print_debug = false;

--- a/ow_power_system/include/PowerSystemPack.h
+++ b/ow_power_system/include/PowerSystemPack.h
@@ -39,7 +39,7 @@ using PrognoserVector = std::vector<PrognoserMap>;
 //                        around the ~300s mark with 16 nodes, but did not occur at all
 //                        over a 45-minute test at 15 nodes or less.
 //                        No idea what the issue is yet.
-const int NUM_NODES = 8;
+const int NUM_NODES = 24;
 
 const std::string FAULT_NAME_HPD           = "high_power_draw";
 const std::string FAULT_NAME_HPD_ACTIVATE  = "activate_high_power_draw";
@@ -154,10 +154,11 @@ private:
   int m_profile_increment = 2;
 
   // The initial power/temperature/voltage readings used as the start values for
-  // the GSAP prognosers.
+  // the GSAP prognosers. Overwritten by the values in system.cfg.
   double m_initial_power = 0.0;
   double m_initial_temperature = 20.0;
   double m_initial_voltage = 4.1;
+  double m_initial_soc = 0.95;
 
   // End main system configuration.
   
@@ -166,11 +167,8 @@ private:
   PrognoserVector m_custom_power_fault_sequence;
   size_t m_custom_power_fault_sequence_index = 0;
 
-  // Track the number of prognosers waiting for new data.
-  int m_waiting_buses = 0;
-
-  // Tracks if at least one set of predictions has returned.
-  bool m_publishing_ready = false;
+  // Track the prognosers waiting for new data.
+  bool m_waiting_buses[NUM_NODES];
 
   // Values to be re-published during intervals where GSAP has not returned
   // predictions yet.

--- a/ow_power_system/include/PredictionHandler.h
+++ b/ow_power_system/include/PredictionHandler.h
@@ -25,7 +25,7 @@ class PredictionHandler : public IMessageProcessor
 {
 public:
   PredictionHandler(double& rul, double& soc, double& temp, MessageBus& bus,
-                    const std::string& src, int node_num);
+                    const std::string& src, int node_num, int& waiting_buses);
   ~PredictionHandler();
   // Copy constructor & assignment operator. Neither should be allowed given
   // how PredictionHandler uses references.
@@ -40,6 +40,7 @@ private:
   double& m_soc_ref;
   double& m_temp_ref;
   MessageBus& m_bus;
+  int& m_bus_wait_count;
 
   std::string m_identifier;
   int m_node_number;

--- a/ow_power_system/include/PredictionHandler.h
+++ b/ow_power_system/include/PredictionHandler.h
@@ -25,7 +25,7 @@ class PredictionHandler : public IMessageProcessor
 {
 public:
   PredictionHandler(double& rul, double& soc, double& temp, MessageBus& bus,
-                    const std::string& src, int node_num, int& waiting_buses);
+                    const std::string& src, int node_num, bool& bus_status);
   ~PredictionHandler();
   // Copy constructor & assignment operator. Neither should be allowed given
   // how PredictionHandler uses references.
@@ -40,7 +40,7 @@ private:
   double& m_soc_ref;
   double& m_temp_ref;
   MessageBus& m_bus;
-  int& m_bus_wait_count;
+  bool& m_bus_status;
 
   std::string m_identifier;
   int m_node_number;

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -198,7 +198,7 @@ void PowerSystemNode::applyValueMods(double& power, double& voltage, double& tem
 void PowerSystemNode::runPrognoser(double electrical_power)
 {
   // Temperature estimate based on pseudorandom noise and fixed range
-  m_current_timestamp += m_profile_increment;
+  TickTime();
   m_temperature_estimate = generateTemperatureEstimate();
   m_voltage_estimate = generateVoltageEstimate();
   m_wattage_estimate = electrical_power + m_baseline_wattage;
@@ -246,6 +246,16 @@ double PowerSystemNode::GetRawMechanicalPower()
 double PowerSystemNode::GetAvgMechanicalPower()
 {
   return m_mechanical_power_avg;
+}
+
+double PowerSystemNode::GetTimestamp()
+{
+  return m_current_timestamp;
+}
+
+void PowerSystemNode::TickTime()
+{
+  m_current_timestamp += m_profile_increment;
 }
 
 void PowerSystemNode::SetHighPowerDraw(double draw)

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -198,7 +198,7 @@ void PowerSystemNode::applyValueMods(double& power, double& voltage, double& tem
 void PowerSystemNode::runPrognoser(double electrical_power)
 {
   // Temperature estimate based on pseudorandom noise and fixed range
-  TickTime();
+  m_current_timestamp += m_profile_increment;
   m_temperature_estimate = generateTemperatureEstimate();
   m_voltage_estimate = generateVoltageEstimate();
   m_wattage_estimate = electrical_power + m_baseline_wattage;
@@ -251,11 +251,6 @@ double PowerSystemNode::GetAvgMechanicalPower()
 double PowerSystemNode::GetTimestamp()
 {
   return m_current_timestamp;
-}
-
-void PowerSystemNode::TickTime()
-{
-  m_current_timestamp += m_profile_increment;
 }
 
 void PowerSystemNode::SetHighPowerDraw(double draw)

--- a/ow_power_system/src/PredictionHandler.cpp
+++ b/ow_power_system/src/PredictionHandler.cpp
@@ -26,8 +26,11 @@ static constexpr int MODEL_TEMPERATURE_INDEX = 1;
  * bus.
  **/
 PredictionHandler::PredictionHandler(double& rul, double& soc, double& temp,
-                                     MessageBus& bus, const std::string& src, int node_num) :
-                                     m_rul_ref(rul), m_soc_ref(soc), m_temp_ref(temp), m_bus(bus)
+                                     MessageBus& bus, const std::string& src,
+                                     int node_num, int& waiting_buses) :
+                                     m_rul_ref(rul), m_soc_ref(soc),
+                                     m_temp_ref(temp), m_bus(bus),
+                                     m_bus_wait_count(waiting_buses)
 {
   m_bus.subscribe(this, src, MessageId::BatteryEod);
   m_identifier = src;
@@ -115,6 +118,10 @@ void PredictionHandler::processMessage(const std::shared_ptr<Message>& message)
   m_rul_ref = rul_median;
   m_soc_ref = soc_median;
   m_temp_ref = model_output[MODEL_TEMPERATURE_INDEX];
+
+  // Increment the number of waiting buses, now that the prediction for this
+  // bus has completed
+  m_bus_wait_count++;
 }
 
 double PredictionHandler::findMedian(std::vector<double> samples)

--- a/ow_power_system/src/PredictionHandler.cpp
+++ b/ow_power_system/src/PredictionHandler.cpp
@@ -27,10 +27,10 @@ static constexpr int MODEL_TEMPERATURE_INDEX = 1;
  **/
 PredictionHandler::PredictionHandler(double& rul, double& soc, double& temp,
                                      MessageBus& bus, const std::string& src,
-                                     int node_num, int& waiting_buses) :
+                                     int node_num, bool& bus_status) :
                                      m_rul_ref(rul), m_soc_ref(soc),
                                      m_temp_ref(temp), m_bus(bus),
-                                     m_bus_wait_count(waiting_buses)
+                                     m_bus_status(bus_status)
 {
   m_bus.subscribe(this, src, MessageId::BatteryEod);
   m_identifier = src;
@@ -119,9 +119,8 @@ void PredictionHandler::processMessage(const std::shared_ptr<Message>& message)
   m_soc_ref = soc_median;
   m_temp_ref = model_output[MODEL_TEMPERATURE_INDEX];
 
-  // Increment the number of waiting buses, now that the prediction for this
-  // bus has completed
-  m_bus_wait_count++;
+  // Set the waiting status of this bus to true.
+  m_bus_status = true;
 }
 
 double PredictionHandler::findMedian(std::vector<double> samples)


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-994](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-994) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1140](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1140) |
| Github :octocat:  | # |


## Summary of Changes
* The current iteration of OW-994 does not publish prediction data in a timely manner due to the way its main power system loop operates.
  * It sends input data to all asynchronous prognosers at once, but then waits until all prognosers return predictions to continue the loop. This is infeasible when publications are expected at a rate of 0.5Hz, as the return time for 24 prognoser predictions can surpass 20 seconds.
* This PR fully reworks the power system loop so that data is published via rostopics at a rate of 0.5Hz, consistent with the rate of publication in the current single-cell model in _noetic_devel_, even if the prognosers are unable to complete predictions at the same rate.
  * The loop sends input data to the prognosers every cycle, even if they are already generating a prediction, in order to update the state estimate.
  * If a given prognoser has completed its prediction in a cycle before the others, input data is temporarily withheld from that prognoser to prevent triggering another prediction before the others (and thus de-syncing).
  * When all prognosers have completed their predictions, their data is used collectively to update the stored publication values.
  * These stored publication values are published every cycle, so the same values are re-published at a rate of 0.5Hz while waiting for the prognosers to return new predictions.
* Since this change introduces an edge case at the start of the simulation where there is no data to publish for the first several cycles of waiting for prognosers, there are now initial output values published until the prognosers return their first predictions for the simulation. They are as follows:
  * RUL: ``MAX_HORIZON_SECS``. This is the maximum possible published value for RUL, which the prognosers should output for their first predictions at the moment anyways. May need re-evaluation if the max horizon is greatly increased.
  * SoC: ``0.95`` (or 95%). Value was suggested by Chetan.
  * TMP: ``m_initial_temperature``, the same value passed into the prognosers for their first cycle. Currently set to 20C in ``system.cfg``.


## Test
* Check ``ow_power_system/config/system.cfg`` and ensure the ``print_debug`` flag is set to ``true`` while testing so that battery stats are printed to the terminal during runtime. It is ``false`` by default.
  * The subsequent debug flags in the config file can be used to filter out specific parts of the debug statements as long as ``print_debug`` is ``true``. While having all set to ``true`` will create a wall of outputs every 2 seconds, they are important for this test.
* Open up 4 separate terminals
  * In the 1st terminal, build and run the simulator. Environment shouldn't matter, though I use the ``atacama`` world (``roslaunch ow atacama_y1a.launch``).
  * In the other 3 terminals, ``echo`` each one of the published power system topics:
    * ``rostopic echo /battery_remaining_useful_life``
    * ``rostopic echo /battery_state_of_charge``
    * ``rostopic echo /battery_temperature``
  * A very large amount of statements will continually print to the first terminal, assuming the debug flags in ``system.cfg`` were set to ``true``. These statements print on a per-cycle basis, displaying the following in order:
    * The timestamp of the current cycle
    * The input power/voltage/temperature data set to GSAP's asynchronous prognosers
      * Note that if input to a given prognoser is withheld for the cycle, it will not display here. E.g. If there is no line for ``N02``'s inputs here, that means ``N02`` has completed its prediction and is waiting for other prognosers to finish their
    * The values of ``min_rul``, ``min_soc``, and ``max_tmp``. **These are the values that should be published via rostopics for the cycle.**
    * The currently stored output prediction data of RUL/SoC/TMP from GSAP's prognosers, as well as the node's status. It will either be ``PREDICTING``, meaning its prognoser is still generating a prediction, or ``COMPLETE``, meaning it is waiting for the other prognosers to finish their predictions.
* **If everything is running smoothly, the debug statements in the primary terminal will output at a rate of 0.5Hz, and the values seen via rostopics should match the ``min_rul``, ``min_soc``, & ``max_tmp`` values seen in the debug statements.**
* **The loop should follow a pattern of waiting for all nodes to complete their predictions, then updating ``min_rul``/``min_soc``/``max_tmp``, then starting new predictions for each node at the same time. The values reported by ``rostopic echo`` should repeat until a new batch of predictions completes, and they should be receiving values at a rate of 0.5Hz.**
  * **The very first published values (before a set of GSAP predictions completes) should be the same as the initial values provided for RUL/SoC/TMP.**