### PR TITLE
Oceanwaters-1151: Pack-model mechanical power handling

### DIFF
--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -62,8 +62,7 @@ print_debug: false
 timestamp_print_debug: true
 
 # Prints the input data sent to GSAP's asynchronous prognosers each cycle.
-# Output: Up to NUM_NODES lines per cycle, less if a given node is waiting for
-# others to finish.
+# Output: NUM_NODES lines per cycle.
 inputs_print_debug: true
 
 # Prints the information currently stored in all nodes each cycle.
@@ -73,3 +72,7 @@ outputs_print_debug: true
 # Prints the information that will be published via rostopics each cycle.
 # Output: 1 line per cycle.
 topics_print_debug: true
+
+# Prints the mechanical power calculated during jointStatesCb each cycle.
+# Output: 3 lines per cycle.
+mech_power_print_debug: true

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -30,7 +30,7 @@ public:
   PowerSystemNode(const PowerSystemNode&) = default;
   PowerSystemNode& operator=(const PowerSystemNode&) = default;
   bool Initialize(int num_nodes);
-  void RunOnce();
+  double RunOnce();
   void GetPowerStats(double &time, double &power, double &volts, double &tmp);
   double GetRawMechanicalPower();
   double GetAvgMechanicalPower();
@@ -46,7 +46,7 @@ private:
   double generateVoltageEstimate();
   void applyValueMods(double& power, double& voltage, double& temperature);
 
-  void runPrognoser(double electrical_power);
+  double runPrognoser(double electrical_power);
 
   ros::NodeHandle m_nh;                        // Node Handle Initialization
   ros::Subscriber m_joint_states_sub;          // Mechanical Power Subscriber
@@ -82,7 +82,7 @@ private:
   // model is implemented and can handle any envisioned power draw.
   // This initial value is overriden by the system config.
   //
-  double m_max_gsap_input_watts = 30;
+  double m_max_gsap_input_watts = 20;
 
   // Number of lines in power fault profiles to skip, in order to
   // synchonize the consumption of the profile with GSAP's cycle rate

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -29,7 +29,7 @@ public:
   ~PowerSystemNode() = default;
   PowerSystemNode(const PowerSystemNode&) = default;
   PowerSystemNode& operator=(const PowerSystemNode&) = default;
-  bool Initialize();
+  bool Initialize(int num_nodes);
   void RunOnce();
   void GetPowerStats(double &time, double &power, double &volts, double &tmp);
   double GetRawMechanicalPower();
@@ -72,6 +72,8 @@ private:
   double m_gsap_rate_hz = 0.5;          // GSAP's cycle time
 
   double m_current_timestamp = 0.0;
+  int m_num_nodes = -1;                 // Number of async nodes running at once
+                                        // (overwritten during Initialize())
 
   // Baseline value for power drawn by continuously-running systems.
   // This initial value is overriden by the system config.

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -35,14 +35,15 @@ public:
   double GetRawMechanicalPower();
   double GetAvgMechanicalPower();
   double GetTimestamp();
+  void applyMechanicalPower(double mechanical_power);
   void SetHighPowerDraw(double draw);
   void SetCustomPowerDraw(double draw);
   void SetCustomVoltageFault(double volts);
   void SetCustomTemperatureFault(double tmp);
 private:
   bool loadSystemConfig();
-  bool initCallback();
-  void jointStatesCb(const sensor_msgs::JointStateConstPtr& msg);
+  //bool initCallback(); TEST
+  //void jointStatesCb(const sensor_msgs::JointStateConstPtr& msg); TEST
   double generateTemperatureEstimate();
   double generateVoltageEstimate();
   void applyValueMods(double& power, double& voltage, double& temperature);

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -42,8 +42,6 @@ public:
   void SetCustomTemperatureFault(double tmp);
 private:
   bool loadSystemConfig();
-  //bool initCallback(); TEST
-  //void jointStatesCb(const sensor_msgs::JointStateConstPtr& msg); TEST
   double generateTemperatureEstimate();
   double generateVoltageEstimate();
   void applyValueMods(double& power, double& voltage, double& temperature);
@@ -52,10 +50,6 @@ private:
 
   ros::NodeHandle m_nh;                        // Node Handle Initialization
   ros::Subscriber m_joint_states_sub;          // Mechanical Power Subscriber
-
-  int m_moving_average_window = 25;
-  std::vector<double> m_power_values;
-  size_t m_power_values_index = 0;
 
   std::chrono::time_point<std::chrono::system_clock> m_init_time;
 

--- a/ow_power_system/include/PowerSystemPack.h
+++ b/ow_power_system/include/PowerSystemPack.h
@@ -93,7 +93,7 @@ private:
   void jointStatesCb(const sensor_msgs::JointStateConstPtr& msg);
   PrognoserVector loadPowerProfile(const std::string& filename, std::string custom_file);
   bool loadCustomFaultPowerProfile(std::string path, std::string custom_file);
-  void publishPredictions(bool update);
+  void publishPredictions();
   std::string setNodeName(int node_num);
 
   ros::NodeHandle m_nh;                        // Node Handle Initialization
@@ -147,6 +147,12 @@ private:
   // The matrix used to store EoD events.
   EoDValues m_EoD_events[NUM_NODES];
 
+  // Vector w/ supporting variables that stores the moving average of the
+  // past mechanical power values.
+  int m_moving_average_window = 25;
+  std::vector<double> m_power_values;
+  size_t m_power_values_index = 0;
+
   // GSAP's cycle time
   double m_gsap_rate_hz = 0.5;
 
@@ -173,12 +179,6 @@ private:
 
   // Track the prognosers waiting for new data.
   bool m_waiting_buses[NUM_NODES];
-
-  // Values to be re-published during intervals where GSAP has not returned
-  // predictions yet.
-  int m_prev_rul;
-  double m_prev_soc;
-  double m_prev_tmp;
 };
 
 #endif

--- a/ow_power_system/include/PowerSystemPack.h
+++ b/ow_power_system/include/PowerSystemPack.h
@@ -114,6 +114,7 @@ private:
   bool m_inputs_print_debug = false;
   bool m_outputs_print_debug = false;
   bool m_topics_print_debug = false;
+  bool m_mech_power_print_debug = false;
 
   // The maximum RUL estimation output from the Monte Carlo prediction process.
   // Lower values mean faster performance in the event a RUL prediction would

--- a/ow_power_system/include/PowerSystemPack.h
+++ b/ow_power_system/include/PowerSystemPack.h
@@ -116,6 +116,15 @@ private:
   bool m_topics_print_debug = false;
   bool m_mech_power_print_debug = false;
 
+  // HACK ALERT.  The prognoser produced erratic/erroneous output when
+  // given too high a power input.  This made-up value protects
+  // against this, but is a temporary hack until a circuit breaker
+  // model is added to the power system, and/or the multi-pack battery
+  // model is implemented and can handle any envisioned power draw.
+  // This initial value is overriden by the system config.
+  //
+  double m_max_gsap_input_watts = 20;
+
   // The maximum RUL estimation output from the Monte Carlo prediction process.
   // Lower values mean faster performance in the event a RUL prediction would
   // exceed the horizon value, but it also means the prognoser can't return RUL

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -29,9 +29,6 @@ bool PowerSystemNode::Initialize(int num_nodes)
     return false;
   }
 
-  m_power_values.resize(m_moving_average_window);
-  std::fill(m_power_values.begin(), m_power_values.end(), 0.0);
-
   m_init_time = system_clock::now(); // Taken from initPrognoser()
 
   return true;
@@ -57,7 +54,6 @@ bool PowerSystemNode::loadSystemConfig()
   m_baseline_wattage = system_config.getDouble("baseline_power");
   m_max_gsap_input_watts = system_config.getDouble("max_gsap_power_input");
   m_profile_increment = system_config.getInt32("profile_increment");
-  m_moving_average_window = system_config.getInt32("power_average_size");
 
   // The following variables are not used in PowerSystemNode anymore, but are 
   // left in as part of loading the full system config.
@@ -183,10 +179,6 @@ void PowerSystemNode::RunOnce()
     m_processing_power_batch = true;
     runPrognoser(m_mechanical_power_to_be_processed / m_efficiency);
     m_processing_power_batch = false;
-  }
-  else
-  {
-    ROS_ERROR_STREAM("Node m_trigger was false!");
   }
 }
 

--- a/ow_power_system/src/PowerSystemPack.cpp
+++ b/ow_power_system/src/PowerSystemPack.cpp
@@ -49,6 +49,7 @@ void PowerSystemPack::InitAndRun()
     m_inputs_print_debug = (system_config.getString("inputs_print_debug") == "true");
     m_outputs_print_debug = (system_config.getString("outputs_print_debug") == "true");
     m_topics_print_debug = (system_config.getString("topics_print_debug") == "true");
+    m_mech_power_print_debug = (system_config.getString("mech_power_print_debug") == "true");
   }
   // If print_debug was false, then all flags remain false as initialized.
 
@@ -524,6 +525,16 @@ void PowerSystemPack::jointStatesCb(const sensor_msgs::JointStateConstPtr& msg)
   mechanical_power_avg_msg.data = mean_mechanical_power;
   m_mechanical_power_raw_pub.publish(mechanical_power_raw_msg);
   m_mechanical_power_avg_pub.publish(mechanical_power_avg_msg);
+
+  // /* DEBUG PRINT
+  if (m_mech_power_print_debug)
+  {
+    ROS_INFO_STREAM("Raw mechanical power: " << std::to_string(power_watts));
+    ROS_INFO_STREAM("Applied power (with moving average): " << std::to_string(mean_mechanical_power));
+    ROS_INFO_STREAM("Result: " << std::to_string(mean_mechanical_power / NUM_NODES)
+                    << " power distributed to each node.");
+  }
+  // */
 
   // Send in mechanical power to each node, distributed evenly, to be converted
   // into power draw.

--- a/ow_power_system/src/PowerSystemPack.cpp
+++ b/ow_power_system/src/PowerSystemPack.cpp
@@ -268,7 +268,7 @@ bool PowerSystemPack::initNodes()
   for (int i = 0; i < NUM_NODES; i++)
   {
     m_nodes[i].name = setNodeName(i);
-    if (!m_nodes[i].node.Initialize())
+    if (!m_nodes[i].node.Initialize(NUM_NODES))
     {
         return false;
     }
@@ -487,6 +487,9 @@ void PowerSystemPack::jointStatesCb(const sensor_msgs::JointStateConstPtr& msg)
   //       I don't know why exactly this is the case. If they should happen
   //       to stop calling in this order, it could potentially cause problems.
   //       (~Liam, Summer 2022)
+
+  // DEBUG
+  ROS_INFO_STREAM("Pack cB called!");
   
   // Get the mechanical power values from each node.
   double raw_mechanical_values[NUM_NODES];


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-994](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-994) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1151](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1151) |
| Github :octocat:  | # |


## Summary of Changes
* [OW-994](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-994) currently does not properly handle the mechanical power conversion when arm operations induce a power draw on the battery.
  * It duplicates the mechanical power across every node, i.e. a 10W draw as a result of mechanical power applies a 10W draw to each node in the pack, regardless of the number of nodes. For example, a 24-node pack would have the equivalent of a 240W draw applied to it.
* This PR fixes the mechanical power handling primarily, though it also removes the prognoser synchronization implemented as of [OW-1140](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1140).
  * OW-1140's loop had a catch to withhold input data from being sent into any GSAP prognoser that had already completed its prediction before all other prognosers were complete. This way, all prognosers started their predictions at the same time. However, this stipulation would not work with mechanical power handling; any node with input data withheld during an arm operation would not receive the increased power draw and thus de-sync from other nodes that had not finished their predictions yet.
  * After testing and correspondence with Chris of the GSAP team, it appears the original reason to sync the predictions of each prognoser was unnecessary. As long as all prognosers are receiving similar data at similar rates, there shouldn't be a problem if one prognoser completes predictions faster than others.
* The main loop no longer stores the previous publication values, and simply recalculates them every loop since prognosers may be returning predictions at any time and thus an update each loop is necessary.
* Individual nodes no longer have a ``jointStatesCb`` function; mechanical power calculations are now solely handled in the pack class's ``jointStatesCb``, which then calls a function in each node to apply the calculated power. There was a lot of duplicated work in the node callbacks, which should be addressed now.
## Test
* Check ``ow_power_system/config/system.cfg`` and ensure the ``print_debug`` flag is set to ``true`` while testing so that battery stats are printed to the terminal during runtime. It is ``false`` by default to prevent flooding the terminal with statements outside of when it is necessary.
  * The ``inputs_print_debug`` and ``mech_power_print_debug`` flags are important for this test and should be ``true`` at the same time so their values can be compared. The ``outputs_print_debug`` flag will also need to be ``true`` for an independent test, which can be done at the same time but is recommended to do it on a second run (as otherwise the terminal will flood with printouts).
* Open up 2 separate terminals:
  * In the 1st terminal, build and run the simulation. Environment shouldn't matter, though I use the ``atacama`` world (``roslaunch ow atacama_y1a.launch``).
  * In the 2nd terminal, run PLEXIL (``roslaunch ow_plexil ow_exec.launch``).
* Run both ``ReferenceMission1.plx`` and ``TestActions.plx`` in the PLEXIL window.
  * While a plan is running, the main terminal should display an increase in the raw/applied mechanical power each cycle. **The applied power is simply a moving average of the last 25 raw mechanical power values, and this is the value applied to the battery.**
  * **The distributed power should be the applied power divided by the number of nodes, and the inputs to each node for the cycle should be around 1W plus the distributed power.** E.g. if the applied power is 48W for the cycle, each node in a 24-node pack should display an input of ``1 + (48 / 24) = 3W`` draw. There may be slight variations in the displayed power draw, but they should be minor.
  * **If there are any errors in the plan executions, confirm that they are distinct from the errors seen on the ``noetic-devel`` branch.** This PR should not have changed anything that affects plan execution.
* Independently, check the printouts as a result of ``outputs_print_debug`` being ``true``.
  * **These outputs should display ``PREDICTING`` most cycles, but  ``COMPLETE`` on the cycle their prediction completed. A node that was ``COMPLETE`` the last cycle should immediately start a new prediction as of the next cycle.**