### PR TITLE
Oceanwater 1162 camera sync warning

### DIFF
--- a/ow/launch/common.launch
+++ b/ow/launch/common.launch
@@ -5,7 +5,7 @@
   <arg name="world_name" default="$(find ow_europa)/worlds/terminator.world"/>
   <arg name="arm_sim_enable" default="false" />
   <arg name="gazebo" default="true"/>
-  <arg name="extra_gazebo_args" default="joint_states:=/_original/joint_states StereoCamera/left/image_raw:=/_original/StereoCamera/left/image_raw" />
+  <arg name="extra_gazebo_args" default="joint_states:=/_original/joint_states StereoCamera/left/image_raw:=/_original/StereoCamera/left/image_raw StereoCamera/left/camera_info:=/_original/StereoCamera/left/camera_info"/>
   <arg name="gzclient" default="true"/>  <!-- Only has effect if gazebo = true -->
   <arg name="record_bag" default="false"/>
   <arg name="rqt_gui" default="true" />

--- a/ow_faults_injection/include/ow_faults_injection/FaultInjector.h
+++ b/ow_faults_injection/include/ow_faults_injection/FaultInjector.h
@@ -18,6 +18,7 @@
 #include <ow_lander/lander_joints.h>
 #include <sensor_msgs/JointState.h>
 #include <sensor_msgs/Image.h>
+#include <sensor_msgs/CameraInfo.h>
 #include <geometry_msgs/WrenchStamped.h>
 #include <unordered_map>
 #include <random>
@@ -64,8 +65,10 @@ private:
   // true. Otherwise, return false.
   bool findJointIndex(unsigned int joint, unsigned int& out_index);
 
-  // Camera functions
-  void cameraFaultRepublishCb(const sensor_msgs::Image& msg);
+  // Camera functions. Complimentary camera topics are handled separately, providing
+  //  a baseline for expanding fault injection to handle more specific camera faults
+  void cameraFaultRawRepublishCb(const sensor_msgs::Image& msg);
+  void cameraFaultInfoRepublishCb(const sensor_msgs::CameraInfo& msg);
   void checkCameraFaults();
 
   // Publishers and subscribers
@@ -80,7 +83,10 @@ private:
 
   // Camera
   ros::Subscriber m_camera_raw_sub;
-  ros::Publisher m_camera_trigger_remapped_pub;
+  ros::Subscriber m_camera_info_sub;
+  ros::Publisher m_camera_raw_remapped_pub;
+  ros::Publisher m_camera_info_remapped_pub;
+
 
   // Antenna
   ros::Subscriber m_fault_ant_pan_sub;

--- a/ow_faults_injection/src/FaultInjector.cpp
+++ b/ow_faults_injection/src/FaultInjector.cpp
@@ -40,7 +40,7 @@ FaultInjector::FaultInjector(ros::NodeHandle& nh)
                                    10, 
                                    &FaultInjector::cameraFaultInfoRepublishCb, 
                                    this);
-  m_camera_info_remapped_pub = nh.advertise<sensor_msgs::Image>(camera_info_str, 10);
+  m_camera_info_remapped_pub = nh.advertise<sensor_msgs::CameraInfo>(camera_info_str, 10);
 
   srand (static_cast <unsigned> (time(0)));
 }


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️ | [OCEANWATER-1162](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1162) |

## Summary of Changes
The `/StereoCamera/left/camera_info` and `/StereoCamera/left/image_raw` topics were previously not synchronized, resulting in  fault injection only suppressing the image_raw topic and causing a repeated ros warning. Fault injection 
has been updated to also suppress camera_info when during a trigger fault.


## Test
* Launch a sim in a terminal
* Monitor the fault topics in other terminal/s (ie: `rostopic echo /system_faults_status`)
* In rqt, activate the /StereoCamera/left/image_trigger topic
* In rqt's Dynamic Reconfigure pane, under Faults, activate the camera_left_trigger_failure fault.
* Observe, for a minute or two, the console output of the simulation terminal.
  * Observe that the warning does not appear as it normally would.
 
Additionally, changes can be observed by monitoring the various camera topics with `rqt_bag` and observing the `/StereoCamera/left/camera_info` and `/StereoCamera/left/image_raw topics` now are approximately synchronized in time and synchronized in suppression.