### PR TITLE
Oceanwater 1166 update action rostests

### DIFF
--- a/ow_sim_tests/test/action_testing.py
+++ b/ow_sim_tests/test/action_testing.py
@@ -142,7 +142,7 @@ def test_arm_action_noyaml(test_object, action_name, action, goal, max_duration,
     test_object, action_name, action, goal, max_duration, **kwargs
   )
     # verify action ended where we expected
-  if expected_final:
+  if expected_final and hasattr(result, 'final'):
     assert_point_is_within_deviation(test_object,
       result.final, expected_final, expected_final_tolerance
     )
@@ -304,5 +304,6 @@ def test_arm_action(test_object, action_name, action, goal,
       expected_final_tolerance = final_tolerance,
       **kwargs
     )
-  print_arm_action_final(unit_name, result.final)
+  if hasattr(result, 'final'):
+    print_arm_action_final(unit_name, result.final)
   print_action_complete(unit_name, elapsed)

--- a/ow_sim_tests/test/arm_check_action.py
+++ b/ow_sim_tests/test/arm_check_action.py
@@ -8,7 +8,9 @@ import sys
 import rospy
 import roslib
 import unittest
+import ow_lander.constants
 import ow_lander.msg
+import owl_msgs.msg
 import argparse
 
 from action_testing import *
@@ -32,11 +34,11 @@ class ArmCheckAction(unittest.TestCase):
     while rospy.get_time() == 0:
       rospy.sleep(0.1)
 
-  def test_01_unstow(self):
-    unstow_result = test_arm_action(self,
-      'Unstow', ow_lander.msg.UnstowAction,
-      ow_lander.msg.UnstowGoal(),
-      TEST_NAME, "test_01_unstow",
+  def test_01_arm_unstow(self):
+    arm_unstow_result = test_arm_action(self,
+      'ArmUnstow', owl_msgs.msg.ArmUnstowAction,
+      owl_msgs.msg.ArmUnstowGoal(),
+      TEST_NAME, "test_01_arm_unstow",
       server_timeout = 50.0 # (seconds) first action call needs longer timeout
     )
 
@@ -52,10 +54,10 @@ class ArmCheckAction(unittest.TestCase):
       server_timeout = 15.0
     )
 
-  def test_03_grind(self):
-    grind_result = test_arm_action(self,
-      'Grind', ow_lander.msg.GrindAction,
-      ow_lander.msg.GrindGoal(
+  def test_03_task_grind(self):
+    task_grind_result = test_arm_action(self,
+      'TaskGrind', owl_msgs.msg.TaskGrindAction,
+      owl_msgs.msg.TaskGrindGoal(
         x_start = 1.65,
         y_start = 0.0,
         depth = 0.05,
@@ -63,56 +65,59 @@ class ArmCheckAction(unittest.TestCase):
         parallel = True,
         ground_position = DEFAULT_GROUND_HEIGHT
       ),
-      TEST_NAME, "test_03_grind"
+      TEST_NAME, "test_03_task_grind"
     )
 
-  def test_04_dig_circular(self):
-    dig_circular_result = test_arm_action(self,
-      'DigCircular', ow_lander.msg.DigCircularAction,
-      ow_lander.msg.DigCircularGoal(
-        x_start = 1.65,
-        y_start = 0.0,
-        depth = 0.01,
+  def test_04_task_scoop_circular(self):
+    task_scoop_circular_result = test_arm_action(self,
+      'TaskScoopCircular', owl_msgs.msg.TaskScoopCircularAction,
+      owl_msgs.msg.TaskScoopCircularGoal(
+        frame = 0,
+        relative =False,
+        point = Point(1.65, 0.0, ow_lander.constants.DEFAULT_GROUND_HEIGHT),
+        depth = 0.1,
         parallel = True,
-        ground_position = DEFAULT_GROUND_HEIGHT
       ),
-      TEST_NAME, 'test_04_dig_circular'
+      TEST_NAME, 'test_04_task_scoop_circular'
     )
 
-  def test_05_discard(self):
-    discard_result = test_arm_action(self,
-      'Discard', ow_lander.msg.DiscardAction,
-      ow_lander.msg.DiscardGoal(
-        discard = Point(1.5, 0.8, 0.65)
+  def test_05_task_discard_sample(self):
+    task_discard_sample_result = test_arm_action(self,
+      'TaskDiscardSample', owl_msgs.msg.TaskDiscardSampleAction,
+      owl_msgs.msg.TaskDiscardSampleGoal(
+        frame = 0,
+        relative = False,
+        point = Point(1.5, 0.8, 0.65),
+        height = 0.0,
       ),
-      TEST_NAME, 'test_05_discard'
+      TEST_NAME, 'test_05_task_discard_sample'
     )
 
-  def test_06_dig_linear(self):
-    dig_linear_result = test_arm_action(self,
-      'DigLinear', ow_lander.msg.DigLinearAction,
-      ow_lander.msg.DigLinearGoal(
-        x_start = 1.46,
-        y_start = 0.0,
+  def test_06_task_scoop_linear(self):
+    task_scoop_linear_result = test_arm_action(self,
+      'TaskScoopLinear', owl_msgs.msg.TaskScoopLinearAction,
+      owl_msgs.msg.TaskScoopLinearGoal(
+        frame = 0,
+        relative = False,
+        point = Point(1.46, 0.0, ow_lander.constants.DEFAULT_GROUND_HEIGHT),
         depth = 0.01,
         length = 0.1,
-        ground_position = DEFAULT_GROUND_HEIGHT
       ),
-      TEST_NAME, 'test_06_dig_linear'
+      TEST_NAME, 'test_06_task_scoop_linear'
     )
 
-  def test_07_deliver_sample(self):
-    deliver_result = test_arm_action(self,
-      'Deliver', ow_lander.msg.DeliverAction,
-      ow_lander.msg.DeliverGoal(),
-      TEST_NAME, 'test_07_deliver_sample'
+  def test_07_task_deliver_sample(self):
+    task_deliver_sample_result = test_arm_action(self,
+      'TaskDeliverSample', owl_msgs.msg.TaskDeliverSampleAction,
+      owl_msgs.msg.TaskDeliverSampleGoal(),
+      TEST_NAME, 'test_07_task_deliver_sample'
     )
 
-  def test_08_stow(self):
-    stow_result = test_arm_action(self,
-      'Stow', ow_lander.msg.StowAction,
-      ow_lander.msg.StowGoal(),
-      TEST_NAME, 'test_08_stow'
+  def test_08_arm_stow(self):
+    arm_stow_result = test_arm_action(self,
+      'ArmStow', owl_msgs.msg.ArmStowAction,
+      owl_msgs.msg.ArmStowGoal(),
+      TEST_NAME, 'test_08_arm_stow'
     )
 
 if __name__ == '__main__':

--- a/ow_sim_tests/test/arm_check_action.py
+++ b/ow_sim_tests/test/arm_check_action.py
@@ -8,14 +8,12 @@ import sys
 import rospy
 import roslib
 import unittest
-import ow_lander.constants
 import ow_lander.msg
 import owl_msgs.msg
 import argparse
 
 from action_testing import *
-
-DEFAULT_GROUND_HEIGHT  = -0.155
+from ow_lander import constants
 
 PKG = 'ow_sim_tests'
 TEST_NAME = 'arm_check_action'
@@ -63,7 +61,7 @@ class ArmCheckAction(unittest.TestCase):
         depth = 0.05,
         length = 0.6,
         parallel = True,
-        ground_position = DEFAULT_GROUND_HEIGHT
+        ground_position = constants.DEFAULT_GROUND_HEIGHT
       ),
       TEST_NAME, "test_03_task_grind"
     )
@@ -74,9 +72,9 @@ class ArmCheckAction(unittest.TestCase):
       owl_msgs.msg.TaskScoopCircularGoal(
         frame = 0,
         relative =False,
-        point = Point(1.65, 0.0, ow_lander.constants.DEFAULT_GROUND_HEIGHT),
+        point = Point(1.65, 0.0, constants.DEFAULT_GROUND_HEIGHT),
         depth = 0.1,
-        parallel = True,
+        parallel = True
       ),
       TEST_NAME, 'test_04_task_scoop_circular'
     )
@@ -87,8 +85,8 @@ class ArmCheckAction(unittest.TestCase):
       owl_msgs.msg.TaskDiscardSampleGoal(
         frame = 0,
         relative = False,
-        point = Point(1.5, 0.8, 0.65),
-        height = 0.0,
+        point = Point(1.5, 0.8, constants.DEFAULT_GROUND_HEIGHT),
+        height = 0.7
       ),
       TEST_NAME, 'test_05_task_discard_sample'
     )
@@ -99,9 +97,9 @@ class ArmCheckAction(unittest.TestCase):
       owl_msgs.msg.TaskScoopLinearGoal(
         frame = 0,
         relative = False,
-        point = Point(1.46, 0.0, ow_lander.constants.DEFAULT_GROUND_HEIGHT),
+        point = Point(1.46, 0.0, constants.DEFAULT_GROUND_HEIGHT),
         depth = 0.01,
-        length = 0.1,
+        length = 0.1
       ),
       TEST_NAME, 'test_06_task_scoop_linear'
     )

--- a/ow_sim_tests/test/sample_collection.py
+++ b/ow_sim_tests/test/sample_collection.py
@@ -17,8 +17,8 @@ from gazebo_msgs.msg import LinkStates
 from geometry_msgs.msg import Point
 
 import owl_msgs.msg
-import ow_lander.constants
 import ow_lander.msg
+from ow_lander import constants
 
 from action_testing import *
 
@@ -26,8 +26,7 @@ PKG = 'ow_sim_tests'
 TEST_NAME = 'sample_collection'
 roslib.load_manifest(PKG)
 
-GROUND_POSITION = -0.155
-DISCARD_POSITION = Point(1.5, 0.8, GROUND_POSITION) # default for discard action
+DISCARD_POSITION = Point(1.5, 0.8, constants.DEFAULT_GROUND_HEIGHT) # default for discard action
 REGOLITH_CLEANUP_DELAY = 5.0 # seconds
 
 SCOOP_LINK_NAME = 'lander::l_scoop'
@@ -252,7 +251,7 @@ class SampleCollection(unittest.TestCase):
         depth           = 0.15, # grind deep so terrain is modified
         length          = 0.7,
         parallel        = True,
-        ground_position = GROUND_POSITION
+        ground_position = constants.DEFAULT_GROUND_HEIGHT
       ),
       TEST_NAME, "test_02_task_grind",
       condition_check = self._assert_regolith_not_present
@@ -268,7 +267,7 @@ class SampleCollection(unittest.TestCase):
       owl_msgs.msg.TaskScoopLinearGoal(
         frame     = 0,
         relative  = False,
-        point     = Point(1.46, 0, ow_lander.constants.DEFAULT_GROUND_HEIGHT),
+        point     = Point(1.46, 0, constants.DEFAULT_GROUND_HEIGHT),
         depth     = 0.01,
         length    = 0.1
       ),
@@ -315,7 +314,7 @@ class SampleCollection(unittest.TestCase):
         depth           = 0.05,
         length          = 0.6,
         parallel        = True,
-        ground_position = GROUND_POSITION
+        ground_position = constants.DEFAULT_GROUND_HEIGHT
       ),
       TEST_NAME, "test_05_task_grind",
       condition_check = self._assert_regolith_not_present
@@ -331,9 +330,9 @@ class SampleCollection(unittest.TestCase):
       owl_msgs.msg.TaskScoopCircularGoal(
         frame    = 0,
         relative = False,
-        point    = Point(1.65, 0.5, ow_lander.constants.DEFAULT_GROUND_HEIGHT),
+        point    = Point(1.65, 0.5, constants.DEFAULT_GROUND_HEIGHT),
         depth    = 0.01,
-        parallel = True,
+        parallel = True
       ),
       TEST_NAME, "test_06_task_scoop_circular",
       condition_check = self._assert_scoop_regolith_containment

--- a/ow_sim_tests/test/sample_collection.py
+++ b/ow_sim_tests/test/sample_collection.py
@@ -17,6 +17,8 @@ from gazebo_msgs.msg import LinkStates
 from geometry_msgs.msg import Point
 
 import owl_msgs.msg
+import ow_lander.constants
+import ow_lander.msg
 
 from action_testing import *
 
@@ -229,11 +231,11 @@ class SampleCollection(unittest.TestCase):
   """
   Test the unstow action. Calling this first is standard operating procedure.
   """
-  def test_01_unstow(self):
+  def test_01_arm_unstow(self):
     unstow_result = test_arm_action(self,
       'ArmUnstow', owl_msgs.msg.ArmUnstowAction,
       owl_msgs.msg.ArmUnstowGoal(),
-      TEST_NAME, "test_01_unstow",
+      TEST_NAME, "test_01_arm_unstow",
       server_timeout = 50.0 # (seconds) first action call needs longer timeout
     )
 
@@ -241,7 +243,7 @@ class SampleCollection(unittest.TestCase):
   Tests an extra deep grind action and asserts no regolith is spawned during the
   operation.
   """
-  def test_02_grind(self):
+  def test_02_task_grind(self):
     grind_result = test_arm_action(self,
       'TaskGrind', owl_msgs.msg.TaskGrindAction,
       owl_msgs.msg.TaskGrindGoal(
@@ -252,7 +254,7 @@ class SampleCollection(unittest.TestCase):
         parallel        = True,
         ground_position = GROUND_POSITION
       ),
-      TEST_NAME, "test_02_grind",
+      TEST_NAME, "test_02_task_grind",
       condition_check = self._assert_regolith_not_present
     )
 
@@ -260,17 +262,17 @@ class SampleCollection(unittest.TestCase):
   Tests a default dig linear action and asserts regolith does spawn during the
   operation and remains in the scoop until the end of it.
   """
-  def test_03_dig_linear(self):
-    dig_linear_result = test_arm_action(self,
+  def test_03_task_scoop_linear(self):
+    task_scoop_linear_result = test_arm_action(self,
       'TaskScoopLinear', owl_msgs.msg.TaskScoopLinearAction,
       owl_msgs.msg.TaskScoopLinearGoal(
         frame     = 0,
         relative  = False,
-        point     = Point(1.46, 0, 0),
+        point     = Point(1.46, 0, ow_lander.constants.DEFAULT_GROUND_HEIGHT),
         depth     = 0.01,
         length    = 0.1
       ),
-      TEST_NAME, "test_03_dig_linear",
+      TEST_NAME, "test_03_task_scoop_linear",
       condition_check = self._assert_scoop_regolith_containment
     )
 
@@ -281,16 +283,16 @@ class SampleCollection(unittest.TestCase):
   Discards material over the default discard position and asserts it leaves
   scoop and is cleaned up shortly after hitting the terrain.
   """
-  def test_04_discard(self):
-    discard_result = test_arm_action(self,
+  def test_04_task_discard_sample(self):
+    task_discard_result = test_arm_action(self,
       'TaskDiscardSample', owl_msgs.msg.TaskDiscardSampleAction,
-      owl_msgs.msg.TaskDiscardSampleAction(
+      owl_msgs.msg.TaskDiscardSampleGoal(
         frame = 0,
         relative = False,
         point = DISCARD_POSITION,
         height = 0.7
       ),
-      TEST_NAME, "test_04_discard",
+      TEST_NAME, "test_04_task_discard_sample",
       condition_check = self._assert_regolith_transports_and_discards
     )
 
@@ -304,10 +306,10 @@ class SampleCollection(unittest.TestCase):
   """
   Grind a new trench in a different location on the terrain.
   """
-  def test_05_grind(self):
-    grind_result = test_arm_action(self,
+  def test_05_task_grind(self):
+    task_grind_result = test_arm_action(self,
       'TaskGrind', owl_msgs.msg.TaskGrindAction,
-      owl_msgs.msg.GrindGoal(
+      owl_msgs.msg.TaskGrindGoal(
         x_start         = 1.65,
         y_start         = 0.5,
         depth           = 0.05,
@@ -315,7 +317,7 @@ class SampleCollection(unittest.TestCase):
         parallel        = True,
         ground_position = GROUND_POSITION
       ),
-      TEST_NAME, "test_05_grind",
+      TEST_NAME, "test_05_task_grind",
       condition_check = self._assert_regolith_not_present
     )
 
@@ -323,17 +325,17 @@ class SampleCollection(unittest.TestCase):
   Dig for more material in the new trench, so we can then test delivery into
   the sample dock.
   """
-  def test_06_dig_circular(self):
-    dig_circular_result = test_arm_action(self,
+  def test_06_task_scoop_circular(self):
+    task_scoop_circular_result = test_arm_action(self,
       'TaskScoopCircular', owl_msgs.msg.TaskScoopCircularAction,
       owl_msgs.msg.TaskScoopCircularGoal(
         frame    = 0,
         relative = False,
-        point    = Point(1.65, 0.5, 0.01),
+        point    = Point(1.65, 0.5, ow_lander.constants.DEFAULT_GROUND_HEIGHT),
         depth    = 0.01,
-        parallel = True
+        parallel = True,
       ),
-      TEST_NAME, "test_06_dig_circular",
+      TEST_NAME, "test_06_task_scoop_circular",
       condition_check = self._assert_scoop_regolith_containment
     )
 
@@ -361,22 +363,22 @@ class SampleCollection(unittest.TestCase):
   Test the unstow action.
   Calling this after an optertion is standard operating procedure.
   """
-  def test_08_unstow(self):
-    unstow_result = test_arm_action(self,
+  def test_08_arm_unstow(self):
+    arm_unstow_result = test_arm_action(self,
       'ArmUnstow', owl_msgs.msg.ArmUnstowAction,
       owl_msgs.msg.ArmUnstowGoal(),
-      TEST_NAME, "test_08_unstow"
+      TEST_NAME, "test_08_arm_unstow"
     )
 
   """
   Test the stow action.
   Calling this after an optertion is standard operating procedure.
   """
-  def test_09_stow(self):
-    stow_result = test_arm_action(self,
+  def test_09_arm_stow(self):
+    arm_stow_result = test_arm_action(self,
       'ArmStow', owl_msgs.msg.ArmStowAction,
       owl_msgs.msg.ArmStowGoal(),
-      TEST_NAME, "test_09_stow"
+      TEST_NAME, "test_09_arm_stow"
     )
 
   """
@@ -384,11 +386,11 @@ class SampleCollection(unittest.TestCase):
   the simulation.
   """
   @unittest.expectedFailure
-  def test_10_ingest_sample(self):
-    ingest_result = test_action(self,
-      'DockIngestSampleAction', owl_msgs.msg.DockIngestSampleAction,
+  def test_10_dock_ingest_sample(self):
+    dock_ingest_result = test_action(self,
+      'DockIngestSample', owl_msgs.msg.DockIngestSampleAction,
       owl_msgs.msg.DockIngestSampleGoal(),
-      TEST_NAME, "test_10_ingest_sample"
+      TEST_NAME, "test_10_dock_ingest_sample"
     )
 
     rospy.sleep(REGOLITH_CLEANUP_DELAY)


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-983](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-983) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1166](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1166) |


## Summary of Changes

- The old command names were incompatible with the new action interface in Release 11 and were causing functional issues. The update fixed the action name issue and transferred all goal parameters to new format. The changes should ensure the same test, arm_check_action.test and sample_collection.test which support the old version and now work for Release 11.



## Test
* rostest ow_sim_tests arm_check_action.test ignore_action_checks:=true

- rostest ow_sim_tests sample_collection.test ignore_action_checks:=true
test_06_task_scoop_circular in sample_collection.test might result failure with a very small chance, please try one more time for the rostest if that happen.
