### PR TITLE
modernized arm_move_joint* action client interfaces

### DIFF
--- a/ow_lander/scripts/arm_move_joint.py
+++ b/ow_lander/scripts/arm_move_joint.py
@@ -9,14 +9,9 @@ from ow_lander import node_helper
 
 import argparse
 
-from distutils.util import strtobool
-
 parser = argparse.ArgumentParser(
   formatter_class=argparse.ArgumentDefaultsHelpFormatter,
   description="Move an arm joint to either an absolute or relative position.")
-parser.add_argument('relative', type=strtobool, nargs='?', default='False',
-  help="Joint will move to the provided position relative to its current "
-       "position.")
 parser.add_argument('joint', type=int, nargs='?', default=0, choices=range(6),
   help="Index of joint that will be moved be moved" \
        "\n0 : shoulder yaw" \
@@ -26,7 +21,10 @@ parser.add_argument('joint', type=int, nargs='?', default=0, choices=range(6),
        "\n4 : hand yaw" \
        "\n5 : scoop yaw")
 parser.add_argument('angle', type=float, nargs='?', default=-0.5,
-  help="Absolute/relative angle position in radians")
+  help="Position/rotation in position in radians")
+parser.add_argument('--relative', '-r', action='store_true', default=False,
+  help="Joints will move to the provided positions relative to their current "
+       "positions.")
 args = parser.parse_args()
 
 node_helper.call_single_use_action_client(actions.ArmMoveJointServer,

--- a/ow_lander/scripts/arm_move_joints.py
+++ b/ow_lander/scripts/arm_move_joints.py
@@ -9,26 +9,24 @@ from ow_lander import node_helper
 
 import argparse
 
-from distutils.util import strtobool
-
 parser = argparse.ArgumentParser(
   formatter_class=argparse.ArgumentDefaultsHelpFormatter,
   description="Move all arm joints to either absolute or relative positions.")
-parser.add_argument('relative', type=strtobool, nargs='?', default='False',
+parser.add_argument('j_shou_yaw', type=float,
+  help="Shoulder yaw joint position/rotation in radians")
+parser.add_argument('j_shou_pitch', type=float,
+  help="Shoulder pitch joint position/rotation in radians")
+parser.add_argument('j_prox_pitch', type=float,
+  help="Proximal pitch joint position/rotation in radians")
+parser.add_argument('j_dist_pitch', type=float,
+  help="Distal pitch joint position/rotation in radians")
+parser.add_argument('j_hand_yaw', type=float,
+  help="Hand yaw joint position/rotation in radians")
+parser.add_argument('j_scoop_yaw', type=float,
+  help="Scoop yaw joint position/rotation in radians")
+parser.add_argument('--relative', '-r', action='store_true', default=False,
   help="Joints will move to the provided positions relative to their current "
        "positions.")
-parser.add_argument('j_shou_yaw', type=float, nargs='?', default=0.1,
-  help="Shoulder yaw joint angle")
-parser.add_argument('j_shou_pitch', type=float, nargs='?', default=0.1,
-  help="Shoulder pitch joint angle")
-parser.add_argument('j_prox_pitch', type=float, nargs='?', default=0.1,
-  help="Proximal pitch joint angle")
-parser.add_argument('j_dist_pitch', type=float, nargs='?', default=0.1,
-  help="Distal pitch joint angle")
-parser.add_argument('j_hand_yaw', type=float, nargs='?', default=0.1,
-  help="Hand yaw joint angle")
-parser.add_argument('j_scoop_yaw', type=float, nargs='?', default=0.1,
-  help="Scoop yaw joint angle")
 args = parser.parse_args()
 
 angles_arg = [args.j_shou_yaw, args.j_shou_pitch, args.j_prox_pitch,

--- a/ow_lander/src/ow_lander/trajectory_sequence.py
+++ b/ow_lander/src/ow_lander/trajectory_sequence.py
@@ -1,5 +1,6 @@
 import rospy
 import time
+import moveit_commander
 from moveit_msgs.srv import GetPositionFK
 from moveit_msgs.msg import RobotTrajectory, MoveItErrorCodes
 from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
@@ -111,7 +112,11 @@ class TrajectorySequence:
     if len(joint_positions) != self._joints_count:
       raise ArmPlanningError("Incorrect number of joints for arm move group")
     self._group.set_start_state(self._most_recent_state)
-    self._group.set_joint_value_target(joint_positions)
+    try:
+      self._group.set_joint_value_target(joint_positions)
+    except moveit_commander.exception.MoveItCommanderException as err:
+      raise ArmPlanningError(
+        f"MoveIt planning failed with the following exception: {err}")
     self._plan()
 
   def plan_to_joint_translations(self, joint_translations):


### PR DESCRIPTION
## Linked Issues:
Jira Ticket 🎟️ | [OCEANWATER-1110](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1110)

## Summary of Changes
* Modernized action client interfaces of `arm_move_joint.py` and `arm_move_joints.py`
  * Similar to `arm_move_joints_guarded.py`, relative motion is now set by a command line flag for both actions.
  * Similar to `arm_move_joints_guarded.py`, all 6 joint values are required for `arm_move_joints.py`.
* Added a catch statement for a MoveIt exception. It was caught in the old version of the trajectory planner, which means it does not impact the master branch. _If these exceptions go uncaught they will cause the lander action servers to break until simulation is restarted._ 

## Release Test Updates
* Release 12 - Test 4 - ROS Actions

## Documentation Updates
No documentation updates required for these changes as best as I can tell. 

## Test
1. Perform steps 4.10 to 4.14 in the [ROS Actions release test](https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/draft+OW-TEST-012-4+ROS+Actions). They should all pass according to the outcome column.
2. Verify the exception handling works by requesting an impossible angle. 
   `rosrun ow_lander arm_move_joint.py 0 1.8`
Simulation output should be
```
[INFO:/lander_action_servers] ArmMoveJoint action started
[ERROR:/lander_action_servers] ArmMoveJoint: Aborted - MoveIt planning failed with the following exception: Error setting joint target. Is the target within bounds?
[INFO:/lander_action_servers] ArmMoveJoint action complete
```
