### PR TITLE
Oceanwater 1175 additional rostests

### DIFF
--- a/ow_sim_tests/scripts/test_camera_set_exposure.py
+++ b/ow_sim_tests/scripts/test_camera_set_exposure.py
@@ -25,12 +25,14 @@ class TestCameraSetExposure(unittest.TestCase):
     # proceed with test only when ros clock has been initialized
     while rospy.get_time() == 0:
       rospy.sleep(0.1)
-  
+      # NOTE: additional sleep is required due to CameraCapture failing if called too early (see OW-1186)
+    rospy.sleep(10.0)
+    
   def test_01_camera_set_exposure(self):
     camera_set_exposure_result = test_action(self,
       'CameraSetExposure', owl_msgs.msg.CameraSetExposureAction,
       owl_msgs.msg.CameraSetExposureGoal(
-        automatic = True,
+        automatic = False,
         exposure = -1
       ),
       TEST_NAME, 'test_01_camera_set_exposure',
@@ -54,6 +56,7 @@ class TestCameraSetExposure(unittest.TestCase):
       owl_msgs.msg.CameraCaptureGoal(),
       TEST_NAME, 'test_03_camera_capture'
     )
+    rospy.sleep(3.0)
 
   def test_04_camera_set_exposure(self):
     camera_set_exposure_result = test_action(self,
@@ -71,6 +74,7 @@ class TestCameraSetExposure(unittest.TestCase):
       owl_msgs.msg.CameraCaptureGoal(),
       TEST_NAME, 'test_05_camera_capture'
     )
+    rospy.sleep(3.0)
 
   def test_06_camera_set_exposure(self):
     camera_set_exposure_result = test_action(self,
@@ -88,6 +92,7 @@ class TestCameraSetExposure(unittest.TestCase):
       owl_msgs.msg.CameraCaptureGoal(),
       TEST_NAME, 'test_07_camera_capture'
     )
+    rospy.sleep(3.0)
 
   def test_08_camera_set_exposure(self):
     camera_set_exposure_result = test_action(self,
@@ -105,6 +110,7 @@ class TestCameraSetExposure(unittest.TestCase):
       owl_msgs.msg.CameraCaptureGoal(),
       TEST_NAME, 'test_09_camera_capture'
     )
+    rospy.sleep(3.0)
 
   def test_10_camera_set_exposure(self):
     camera_set_exposure_result = test_action(self,
@@ -115,6 +121,14 @@ class TestCameraSetExposure(unittest.TestCase):
       ),
       TEST_NAME, 'test_10_camera_set_exposure'
     )
+
+  def test_11_camera_capture(self):
+    camera_capture_result = test_action(self,
+      'CameraCapture', owl_msgs.msg.CameraCaptureAction,
+      owl_msgs.msg.CameraCaptureGoal(),
+      TEST_NAME, 'test_11_camera_capture'
+    )
+    rospy.sleep(3.0)
 
 if __name__ == '__main__':
   import rostest

--- a/ow_sim_tests/scripts/test_camera_set_exposure.py
+++ b/ow_sim_tests/scripts/test_camera_set_exposure.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import rospy
+import roslib
+import unittest
+import owl_msgs.msg
+
+from action_testing import *
+
+PKG = 'ow_sim_tests'
+TEST_NAME = 'camera_set_exposure'
+roslib.load_manifest(PKG)
+
+class TestCameraSetExposure(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    rospy.init_node("test_camera_set_exposure")
+
+    set_ignore_action_checks(True)
+    # proceed with test only when ros clock has been initialized
+    while rospy.get_time() == 0:
+      rospy.sleep(0.1)
+  
+  def test_01_camera_set_exposure(self):
+    camera_set_exposure_result = test_action(self,
+      'CameraSetExposure', owl_msgs.msg.CameraSetExposureAction,
+      owl_msgs.msg.CameraSetExposureGoal(
+        automatic = True,
+        exposure = -1
+      ),
+      TEST_NAME, 'test_01_camera_set_exposure',
+      server_timeout = 50.0 # (seconds) first action call needs longer timeout
+    )
+
+  # Move the antenna so the camera can see the robot arm.
+  def test_02_pan_tilt_move_cartesian(self):
+    pan_tilt_move_cartesian_result = test_action(self,
+      'PanTiltMoveCartesian', owl_msgs.msg.PanTiltMoveCartesianAction,
+      owl_msgs.msg.PanTiltMoveCartesianGoal(
+        frame = 1,
+        point = Point(0, 0, 0)
+      ),
+      TEST_NAME, "test_02_pan_tilt_move_cartesian"
+    )
+  
+  def test_03_camera_capture(self):
+    camera_capture_result = test_action(self,
+      'CameraCapture', owl_msgs.msg.CameraCaptureAction,
+      owl_msgs.msg.CameraCaptureGoal(),
+      TEST_NAME, 'test_03_camera_capture'
+    )
+
+  def test_04_camera_set_exposure(self):
+    camera_set_exposure_result = test_action(self,
+      'CameraSetExposure', owl_msgs.msg.CameraSetExposureAction,
+      owl_msgs.msg.CameraSetExposureGoal(
+        automatic = False,
+        exposure = 0.01
+      ),
+      TEST_NAME, 'test_04_camera_set_exposure'
+    )
+
+  def test_05_camera_capture(self):
+    camera_capture_result = test_action(self,
+      'CameraCapture', owl_msgs.msg.CameraCaptureAction,
+      owl_msgs.msg.CameraCaptureGoal(),
+      TEST_NAME, 'test_05_camera_capture'
+    )
+
+  def test_06_camera_set_exposure(self):
+    camera_set_exposure_result = test_action(self,
+      'CameraSetExposure', owl_msgs.msg.CameraSetExposureAction,
+      owl_msgs.msg.CameraSetExposureGoal(
+        automatic = False,
+        exposure = 0.02
+      ),
+      TEST_NAME, 'test_06_camera_set_exposure'
+    )
+
+  def test_07_camera_capture(self):
+    camera_capture_result = test_action(self,
+      'CameraCapture', owl_msgs.msg.CameraCaptureAction,
+      owl_msgs.msg.CameraCaptureGoal(),
+      TEST_NAME, 'test_07_camera_capture'
+    )
+
+  def test_08_camera_set_exposure(self):
+    camera_set_exposure_result = test_action(self,
+      'CameraSetExposure', owl_msgs.msg.CameraSetExposureAction,
+      owl_msgs.msg.CameraSetExposureGoal(
+        automatic = False,
+        exposure = 0.04
+      ),
+      TEST_NAME, 'test_08_camera_set_exposure'
+    )
+
+  def test_09_camera_capture(self):
+    camera_capture_result = test_action(self,
+      'CameraCapture', owl_msgs.msg.CameraCaptureAction,
+      owl_msgs.msg.CameraCaptureGoal(),
+      TEST_NAME, 'test_09_camera_capture'
+    )
+
+  def test_10_camera_set_exposure(self):
+    camera_set_exposure_result = test_action(self,
+      'CameraSetExposure', owl_msgs.msg.CameraSetExposureAction,
+      owl_msgs.msg.CameraSetExposureGoal(
+        automatic = False,
+        exposure = 0.05
+      ),
+      TEST_NAME, 'test_10_camera_set_exposure'
+    )
+
+if __name__ == '__main__':
+  import rostest
+  rostest.rosrun(PKG, TEST_NAME, TestCameraSetExposure)

--- a/ow_sim_tests/scripts/test_light_set_intensity.py
+++ b/ow_sim_tests/scripts/test_light_set_intensity.py
@@ -67,6 +67,7 @@ class TestLightSetIntensity(unittest.TestCase):
       ),
       TEST_NAME, 'test_04_light_set_intensity'
     )
+    rospy.sleep(3.0)
 
   def test_05_light_set_intensity(self):
     light_set_intensity_result = test_action(self,
@@ -77,6 +78,7 @@ class TestLightSetIntensity(unittest.TestCase):
       ),
       TEST_NAME, 'test_05_light_set_intensity'
     )
+    rospy.sleep(3.0)
   
   def test_06_light_set_intensity(self):
     light_set_intensity_result = test_action(self,
@@ -87,6 +89,7 @@ class TestLightSetIntensity(unittest.TestCase):
       ),
       TEST_NAME, 'test_06_light_set_intensity'
     )
+    rospy.sleep(3.0)
 
   def test_07_light_set_intensity(self):
     light_set_intensity_result = test_action(self,
@@ -97,6 +100,7 @@ class TestLightSetIntensity(unittest.TestCase):
       ),
       TEST_NAME, 'test_07_light_set_intensity'
     )
+    rospy.sleep(3.0)
 
   def test_08_light_set_intensity(self):
     light_set_intensity_result = test_action(self,
@@ -107,6 +111,7 @@ class TestLightSetIntensity(unittest.TestCase):
       ),
       TEST_NAME, 'test_08_light_set_intensity'
     )
+    rospy.sleep(3.0)
 
   def test_09_light_set_intensity(self):
     light_set_intensity_result = test_action(self,
@@ -117,6 +122,7 @@ class TestLightSetIntensity(unittest.TestCase):
       ),
       TEST_NAME, 'test_09_light_set_intensity'
     )
+    rospy.sleep(3.0)
   
   def test_10_light_set_intensity(self):
     light_set_intensity_result = test_action(self,
@@ -127,6 +133,7 @@ class TestLightSetIntensity(unittest.TestCase):
       ),
       TEST_NAME, 'test_10_light_set_intensity'
     )
+    rospy.sleep(3.0)
 
   def test_11_light_set_intensity(self):
     light_set_intensity_result = test_action(self,
@@ -137,6 +144,29 @@ class TestLightSetIntensity(unittest.TestCase):
       ),
       TEST_NAME, 'test_11_light_set_intensity'
     )
+    rospy.sleep(3.0)
+
+  def test_12_light_set_intensity(self):
+    light_set_intensity_result = test_action(self,
+      'LightSetIntensity', owl_msgs.msg.LightSetIntensityAction,
+      owl_msgs.msg.LightSetIntensityGoal(
+        name = 'left',
+        intensity = 0.0
+      ),
+      TEST_NAME, 'test_12_light_set_intensity'
+    )
+    rospy.sleep(3.0)
+
+  def test_13_light_set_intensity(self):
+    light_set_intensity_result = test_action(self,
+      'LightSetIntensity', owl_msgs.msg.LightSetIntensityAction,
+      owl_msgs.msg.LightSetIntensityGoal(
+        name = 'right',
+        intensity = 0.0
+      ),
+      TEST_NAME, 'test_13_light_set_intensity'
+    )
+    rospy.sleep(3.0)
     
 if __name__ == '__main__':
   import rostest

--- a/ow_sim_tests/scripts/test_light_set_intensity.py
+++ b/ow_sim_tests/scripts/test_light_set_intensity.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import rospy
+import roslib
+import unittest
+import owl_msgs.msg
+
+from action_testing import *
+
+PKG = 'ow_sim_tests'
+TEST_NAME = 'light_set_intensity'
+roslib.load_manifest(PKG)
+
+class TestLightSetIntensity(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    rospy.init_node("test_light_set_intensity")
+
+    set_ignore_action_checks(True)
+    # proceed with test only when ros clock has been initialized
+    while rospy.get_time() == 0:
+      rospy.sleep(0.1)
+
+  def test_01_light_set_intensity(self):
+    light_set_intensity_result = test_action(self,
+      'LightSetIntensity', owl_msgs.msg.LightSetIntensityAction,
+      owl_msgs.msg.LightSetIntensityGoal(
+        name = 'left',
+        intensity = 0.2
+      ),
+      TEST_NAME, 'test_01_light_set_intensity',
+      server_timeout = 50.0 # (seconds) first action call needs longer timeout
+    )
+
+  def test_02_light_set_intensity(self):
+    light_set_intensity_result = test_action(self,
+      'LightSetIntensity', owl_msgs.msg.LightSetIntensityAction,
+      owl_msgs.msg.LightSetIntensityGoal(
+        name = 'right',
+        intensity = 0.2
+      ),
+      TEST_NAME, 'test_01_light_set_intensity'
+    )
+
+  # Move the antenna pointing to the base_link for light intensity visualization
+  def test_03_pan_tilt_move_cartesian(self):
+    pan_tilt_move_cartesian_result = test_action(self,
+      'PanTiltMoveCartesian', owl_msgs.msg.PanTiltMoveCartesianAction,
+      owl_msgs.msg.PanTiltMoveCartesianGoal(
+        frame = 0,
+        point = Point(0, 0, 0)
+      ),
+      TEST_NAME, "test_03_pan_tilt_move_cartesian",
+    )
+  
+  def test_04_light_set_intensity(self):
+    light_set_intensity_result = test_action(self,
+      'LightSetIntensity', owl_msgs.msg.LightSetIntensityAction,
+      owl_msgs.msg.LightSetIntensityGoal(
+        name = 'left',
+        intensity = 0.4
+      ),
+      TEST_NAME, 'test_04_light_set_intensity'
+    )
+
+  def test_05_light_set_intensity(self):
+    light_set_intensity_result = test_action(self,
+      'LightSetIntensity', owl_msgs.msg.LightSetIntensityAction,
+      owl_msgs.msg.LightSetIntensityGoal(
+        name = 'left',
+        intensity = 0.6
+      ),
+      TEST_NAME, 'test_05_light_set_intensity'
+    )
+  
+  def test_06_light_set_intensity(self):
+    light_set_intensity_result = test_action(self,
+      'LightSetIntensity', owl_msgs.msg.LightSetIntensityAction,
+      owl_msgs.msg.LightSetIntensityGoal(
+        name = 'left',
+        intensity = 0.8
+      ),
+      TEST_NAME, 'test_06_light_set_intensity'
+    )
+
+  def test_07_light_set_intensity(self):
+    light_set_intensity_result = test_action(self,
+      'LightSetIntensity', owl_msgs.msg.LightSetIntensityAction,
+      owl_msgs.msg.LightSetIntensityGoal(
+        name = 'left',
+        intensity = 1.0
+      ),
+      TEST_NAME, 'test_07_light_set_intensity'
+    )
+
+  def test_08_light_set_intensity(self):
+    light_set_intensity_result = test_action(self,
+      'LightSetIntensity', owl_msgs.msg.LightSetIntensityAction,
+      owl_msgs.msg.LightSetIntensityGoal(
+        name = 'right',
+        intensity = 0.4
+      ),
+      TEST_NAME, 'test_08_light_set_intensity'
+    )
+
+  def test_09_light_set_intensity(self):
+    light_set_intensity_result = test_action(self,
+      'LightSetIntensity', owl_msgs.msg.LightSetIntensityAction,
+      owl_msgs.msg.LightSetIntensityGoal(
+        name = 'right',
+        intensity = 0.6
+      ),
+      TEST_NAME, 'test_09_light_set_intensity'
+    )
+  
+  def test_10_light_set_intensity(self):
+    light_set_intensity_result = test_action(self,
+      'LightSetIntensity', owl_msgs.msg.LightSetIntensityAction,
+      owl_msgs.msg.LightSetIntensityGoal(
+        name = 'right',
+        intensity = 0.8
+      ),
+      TEST_NAME, 'test_10_light_set_intensity'
+    )
+
+  def test_11_light_set_intensity(self):
+    light_set_intensity_result = test_action(self,
+      'LightSetIntensity', owl_msgs.msg.LightSetIntensityAction,
+      owl_msgs.msg.LightSetIntensityGoal(
+        name = 'right',
+        intensity = 1.0
+      ),
+      TEST_NAME, 'test_11_light_set_intensity'
+    )
+    
+if __name__ == '__main__':
+  import rostest
+  rostest.rosrun(PKG, TEST_NAME, TestLightSetIntensity)

--- a/ow_sim_tests/scripts/test_task_deliver_sample.py
+++ b/ow_sim_tests/scripts/test_task_deliver_sample.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import rospy
+import roslib
+import unittest
+import owl_msgs.msg
+
+from action_testing import *
+from geometry_msgs.msg import Pose, Quaternion
+
+PKG = 'ow_sim_tests'
+TEST_NAME = 'task_deliver_sample'
+roslib.load_manifest(PKG)
+
+class TestTaskDeliverSample(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    rospy.init_node("test_task_deliver_sample")
+
+    set_ignore_action_checks(True)
+    # proceed with test only when ros clock has been initialized
+    while rospy.get_time() == 0:
+      rospy.sleep(0.1)
+
+  def test_01_task_deliver_sample(self):
+    task_deliver_sample_result = test_arm_action(self,
+      'TaskDeliverSample', owl_msgs.msg.TaskDeliverSampleAction,
+      owl_msgs.msg.TaskDeliverSampleGoal(),
+      TEST_NAME, "test_01_task_deliver_sample",
+      server_timeout = 50.0 # (seconds) first action call needs longer timeout
+    )
+  
+  # Move the arm to other location and test again
+  def test_02_arm_unstow(self):
+    arm_unstow_result = test_arm_action(self,
+      'ArmUnstow', owl_msgs.msg.ArmUnstowAction,
+      owl_msgs.msg.ArmUnstowGoal(),
+      TEST_NAME, 'test_02_arm_unstow'
+    )
+  
+  def test_03_task_deliver_sample(self):
+    task_deliver_sample_result = test_arm_action(self,
+      'TaskDeliverSample', owl_msgs.msg.TaskDeliverSampleAction,
+      owl_msgs.msg.TaskDeliverSampleGoal(),
+      TEST_NAME, "test_03_task_deliver_sample",
+    )
+
+  def test_04_arm_move_cartesian(self):
+    arm_move_cartesian_result = test_arm_action(self,
+      'ArmMoveCartesian', owl_msgs.msg.ArmMoveCartesianAction,
+      owl_msgs.msg.ArmMoveCartesianGoal(
+        frame = 0,
+        relative = False,
+        pose= Pose(
+          position = Point(1.833, 0.713, 0.782),
+          orientation = Quaternion(-0.539, -0.332, 0.370, 0.681)
+        )
+      ),
+      TEST_NAME, 'test_04_arm_move_cartesian'
+    ) 
+
+  def test_05_task_deliver_sample(self):
+    task_deliver_sample_result = test_arm_action(self,
+      'TaskDeliverSample', owl_msgs.msg.TaskDeliverSampleAction,
+      owl_msgs.msg.TaskDeliverSampleGoal(),
+      TEST_NAME, "test_05_task_deliver_sample",
+    )
+
+if __name__ == '__main__':
+  import rostest
+  rostest.rosrun(PKG, TEST_NAME, TestTaskDeliverSample)

--- a/ow_sim_tests/scripts/test_task_discard_sample.py
+++ b/ow_sim_tests/scripts/test_task_discard_sample.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import rospy
+import roslib
+import unittest
+import owl_msgs.msg
+
+from action_testing import *
+from ow_lander import constants
+
+PKG = 'ow_sim_tests'
+TEST_NAME = 'task_discard_sample'
+roslib.load_manifest(PKG)
+
+class TestTaskDiscardSample(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    rospy.init_node("test_task_discard_sample")
+
+    set_ignore_action_checks(True)
+    # proceed with test only when ros clock has been initialized
+    while rospy.get_time() == 0:
+      rospy.sleep(0.1)
+
+  def test_01_task_discard_sample(self):
+    task_discard_sample_result = test_arm_action(self,
+      'TaskDiscardSample', owl_msgs.msg.TaskDiscardSampleAction,
+      owl_msgs.msg.TaskDiscardSampleGoal(
+        frame = 0,
+        relative = False,
+        point = Point(2.1, 0.2, constants.DEFAULT_GROUND_HEIGHT),
+        height = 0.7
+      ),
+      TEST_NAME, "test_01_task_discard_sample",
+      server_timeout = 50.0 # (seconds) first action call needs longer timeout
+    )
+
+  def test_02_task_discard_sample(self):
+    task_discard_sample_result = test_arm_action(self,
+      'TaskDiscardSample', owl_msgs.msg.TaskDiscardSampleAction,
+      owl_msgs.msg.TaskDiscardSampleGoal(
+        frame = 0,
+        relative = False,
+        point = Point(2.1, -0.1, constants.DEFAULT_GROUND_HEIGHT),
+        height = 0.5
+      ),
+      TEST_NAME, "test_02_task_discard_sample"
+    )
+
+  def test_03_task_discard_sample(self):
+    task_discard_sample_result = test_arm_action(self,
+      'TaskDiscardSample', owl_msgs.msg.TaskDiscardSampleAction,
+      owl_msgs.msg.TaskDiscardSampleGoal(
+        frame = 0,
+        relative = False,
+        point = Point(2.0, -0.3, constants.DEFAULT_GROUND_HEIGHT),
+        height = 0.7
+      ),
+      TEST_NAME, "test_03_task_discard_sample"
+    )
+
+  def test_04_task_discard_sample(self):
+    task_discard_sample_result = test_arm_action(self,
+      'TaskDiscardSample', owl_msgs.msg.TaskDiscardSampleAction,
+      owl_msgs.msg.TaskDiscardSampleGoal(
+        frame = 0,
+        relative = True,
+        point = Point(-0.1, -0.2, 0),
+        height = 0.0
+      ),
+      TEST_NAME, "test_04_task_discard_sample"
+    )
+
+  def test_05_task_discard_sample(self):
+    task_discard_sample_result = test_arm_action(self,
+      'TaskDiscardSample', owl_msgs.msg.TaskDiscardSampleAction,
+      owl_msgs.msg.TaskDiscardSampleGoal(
+        frame = 0,
+        relative = True,
+        point = Point(-0.3, -0.15, 0.1),
+        height = 0.1
+      ),
+      TEST_NAME, "test_05_task_discard_sample"
+    )
+
+  def test_06_task_discard_sample(self):
+    task_discard_sample_result = test_arm_action(self,
+      'TaskDiscardSample', owl_msgs.msg.TaskDiscardSampleAction,
+      owl_msgs.msg.TaskDiscardSampleGoal(
+        frame = 1,
+        relative = False,
+        point = Point(0, -0.4, 0.1),
+        height = 0.0
+      ),
+      TEST_NAME, "test_06_task_discard_sample"
+    )
+
+  def test_07_task_discard_sample(self):
+    task_discard_sample_result = test_arm_action(self,
+      'TaskDiscardSample', owl_msgs.msg.TaskDiscardSampleAction,
+      owl_msgs.msg.TaskDiscardSampleGoal(
+        frame = 1,
+        relative = False,
+        point = Point(0.1, -0.1, 0.1),
+        height = 0.2
+      ),
+      TEST_NAME, "test_07_task_discard_sample"
+    )
+
+if __name__ == '__main__':
+  import rostest
+  rostest.rosrun(PKG, TEST_NAME, TestTaskDiscardSample)

--- a/ow_sim_tests/scripts/test_task_discard_sample.py
+++ b/ow_sim_tests/scripts/test_task_discard_sample.py
@@ -112,6 +112,18 @@ class TestTaskDiscardSample(unittest.TestCase):
       TEST_NAME, "test_07_task_discard_sample"
     )
 
+  def test_08_task_discard_sample(self):
+    task_discard_sample_result = test_arm_action(self,
+      'TaskDiscardSample', owl_msgs.msg.TaskDiscardSampleAction,
+      owl_msgs.msg.TaskDiscardSampleGoal(
+        frame = 0,
+        relative = False,
+        point = Point(1.5, 0.8, constants.DEFAULT_GROUND_HEIGHT),
+        height = 0.7
+      ),
+      TEST_NAME, "test_08_task_discard_sample"
+    )
+
 if __name__ == '__main__':
   import rostest
   rostest.rosrun(PKG, TEST_NAME, TestTaskDiscardSample)

--- a/ow_sim_tests/scripts/test_task_grind.py
+++ b/ow_sim_tests/scripts/test_task_grind.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import rospy
+import roslib
+import unittest
+import owl_msgs.msg
+
+from action_testing import *
+from ow_lander import constants
+
+PKG = 'ow_sim_tests'
+TEST_NAME = 'task_grind'
+roslib.load_manifest(PKG)
+
+class TestTaskGrind(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    rospy.init_node("test_task_grind")
+
+    set_ignore_action_checks(True)
+    # proceed with test only when ros clock has been initialized
+    while rospy.get_time() == 0:
+      rospy.sleep(0.1)
+
+  def test_01_task_grind(self):
+    task_grind_result = test_arm_action(self,
+      'TaskGrind', owl_msgs.msg.TaskGrindAction,
+      owl_msgs.msg.TaskGrindGoal(
+        x_start = 1.65,
+        y_start = 0.0,
+        depth = 0.05,
+        length = 0.6,
+        parallel = True,
+        ground_position = constants.DEFAULT_GROUND_HEIGHT
+      ),
+      TEST_NAME, "test_01_task_grind",
+      server_timeout = 50.0 # (seconds) first action call needs longer timeout
+    )
+
+  def test_02_task_grind(self):
+    task_grind_result = test_arm_action(self,
+      'TaskGrind', owl_msgs.msg.TaskGrindAction,
+      owl_msgs.msg.TaskGrindGoal(
+        x_start = 1.65,
+        y_start = 0.0,
+        depth = 0.05,
+        length = 0.6,
+        parallel = False,
+        ground_position = constants.DEFAULT_GROUND_HEIGHT
+      ),
+      TEST_NAME, "test_02_task_grind"
+    )
+
+  def test_03_task_grind(self):
+    task_grind_result = test_arm_action(self,
+      'TaskGrind', owl_msgs.msg.TaskGrindAction,
+      owl_msgs.msg.TaskGrindGoal(
+        x_start = 2.0,
+        y_start = 0.6,
+        depth = 0.1,
+        length = 0.4,
+        parallel = False,
+        ground_position = constants.DEFAULT_GROUND_HEIGHT
+      ),
+      TEST_NAME, "test_03_task_grind"
+    )
+
+  def test_04_task_grind(self):
+    task_grind_result = test_arm_action(self,
+      'TaskGrind', owl_msgs.msg.TaskGrindAction,
+      owl_msgs.msg.TaskGrindGoal(
+        x_start = 1.8,
+        y_start = -0.2,
+        depth = 0.05,
+        length = 0.4,
+        parallel = True,
+        ground_position = constants.DEFAULT_GROUND_HEIGHT
+      ),
+      TEST_NAME, "test_04_task_grind"
+    )
+
+  def test_05_task_grind(self):
+    task_grind_result = test_arm_action(self,
+      'TaskGrind', owl_msgs.msg.TaskGrindAction,
+      owl_msgs.msg.TaskGrindGoal(
+        x_start = 1.5,
+        y_start = -0.4,
+        depth = 0.05,
+        length = 0.6,
+        parallel = True,
+        ground_position = constants.DEFAULT_GROUND_HEIGHT
+      ),
+      TEST_NAME, "test_05_task_grind"
+    )
+
+  def test_06_task_grind(self):
+    task_grind_result = test_arm_action(self,
+      'TaskGrind', owl_msgs.msg.TaskGrindAction,
+      owl_msgs.msg.TaskGrindGoal(
+        x_start = 1.5,
+        y_start = -0.4,
+        depth = 0.05,
+        length = 0.6,
+        parallel = False,
+        ground_position = constants.DEFAULT_GROUND_HEIGHT
+      ),
+      TEST_NAME, "test_06_task_grind"
+    )
+
+if __name__ == '__main__':
+  import rostest
+  rostest.rosrun(PKG, TEST_NAME, TestTaskGrind)

--- a/ow_sim_tests/scripts/test_task_scoop_circular.py
+++ b/ow_sim_tests/scripts/test_task_scoop_circular.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import rospy
+import roslib
+import unittest
+import owl_msgs.msg
+
+from action_testing import *
+from ow_lander import constants
+
+PKG = 'ow_sim_tests'
+TEST_NAME = 'task_scoop_circular'
+roslib.load_manifest(PKG)
+
+class TestTaskScoopCircular(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    rospy.init_node("test_task_scoop_circular")
+
+    set_ignore_action_checks(True)
+    # proceed with test only when ros clock has been initialized
+    while rospy.get_time() == 0:
+      rospy.sleep(0.1)
+
+  def test_01_task_scoop_circular(self):
+    task_scoop_circular_result = test_arm_action(self,
+      'TaskScoopCircular', owl_msgs.msg.TaskScoopCircularAction,
+      owl_msgs.msg.TaskScoopCircularGoal(
+        frame = 0,
+        relative = False,
+        point = Point(1.65, 0.0, constants.DEFAULT_GROUND_HEIGHT + 0.5),
+        depth = 0.01,
+        parallel = True
+      ),
+      TEST_NAME, "test_01_task_scoop_circular",
+      server_timeout = 50.0 # (seconds) first action call needs longer timeout
+    )
+
+  def test_02_task_grind(self):
+    task_grind_result = test_arm_action(self,
+      'TaskGrind', owl_msgs.msg.TaskGrindAction,
+      owl_msgs.msg.TaskGrindGoal(
+        x_start = 1.65,
+        y_start = 0.0,
+        depth = 0.05,
+        length = 0.6,
+        parallel = True,
+        ground_position = constants.DEFAULT_GROUND_HEIGHT
+      ),
+      TEST_NAME, "test_02_task_grind",
+    )
+  
+  def test_03_task_scoop_circular(self):
+    task_scoop_circular_result = test_arm_action(self,
+      'TaskScoopCircular', owl_msgs.msg.TaskScoopCircularAction,
+      owl_msgs.msg.TaskScoopCircularGoal(
+        frame = 0,
+        relative = False,
+        point = Point(1.65, 0.0, constants.DEFAULT_GROUND_HEIGHT),
+        depth = 0.01,
+        parallel = True
+      ),
+      TEST_NAME, "test_03_task_scoop_circular"
+    )
+
+  def test_04_task_scoop_circular(self):
+    task_scoop_circular_result = test_arm_action(self,
+      'TaskScoopCircular', owl_msgs.msg.TaskScoopCircularAction,
+      owl_msgs.msg.TaskScoopCircularGoal(
+        frame = 0,
+        relative = True,
+        point = Point(-0.65, -0.02, -0.44),
+        depth = 0.01,
+        parallel = True
+      ),
+      TEST_NAME, "test_04_task_scoop_circular"
+    )
+
+  def test_05_task_scoop_circular(self):
+    task_scoop_circular_result = test_arm_action(self,
+      'TaskScoopCircular', owl_msgs.msg.TaskScoopCircularAction,
+      owl_msgs.msg.TaskScoopCircularGoal(
+        frame = 1,
+        relative = True,
+        point = Point(-0.8, -0.08, -0.4),
+        depth = 0.03,
+        parallel = True
+      ),
+      TEST_NAME, "test_05_task_scoop_circular"
+    )
+
+  def test_06_task_grind(self):
+    task_grind_result = test_arm_action(self,
+      'TaskGrind', owl_msgs.msg.TaskGrindAction,
+      owl_msgs.msg.TaskGrindGoal(
+        x_start = 1.65,
+        y_start = 0.0,
+        depth = 0.05,
+        length = 0.6,
+        parallel = False,
+        ground_position = constants.DEFAULT_GROUND_HEIGHT
+      ),
+      TEST_NAME, "test_06_task_grind"
+    )
+
+  def test_07_task_scoop_circular(self):
+    task_scoop_circular_result = test_arm_action(self,
+      'TaskScoopCircular', owl_msgs.msg.TaskScoopCircularAction,
+      owl_msgs.msg.TaskScoopCircularGoal(
+        frame = 0,
+        relative = False,
+        point = Point(1.65, 0.0, constants.DEFAULT_GROUND_HEIGHT),
+        depth = 0.02,
+        parallel = False
+      ),
+      TEST_NAME, "test_07_task_scoop_circular"
+    )
+
+  def test_08_task_grind(self):
+    task_grind_result = test_arm_action(self,
+      'TaskGrind', owl_msgs.msg.TaskGrindAction,
+      owl_msgs.msg.TaskGrindGoal(
+        x_start = 2.0,
+        y_start = 0.6,
+        depth = 0.1,
+        length = 0.4,
+        parallel = False,
+        ground_position = constants.DEFAULT_GROUND_HEIGHT
+      ),
+      TEST_NAME, "test_08_task_grind"
+    )
+
+  def test_09_task_scoop_circular(self):
+    task_scoop_circular_result = test_arm_action(self,
+      'TaskScoopCircular', owl_msgs.msg.TaskScoopCircularAction,
+      owl_msgs.msg.TaskScoopCircularGoal(
+        frame = 0,
+        relative = False,
+        point = Point(2.0, 0.6, constants.DEFAULT_GROUND_HEIGHT),
+        depth = 0.02,
+        parallel = False
+      ),
+      TEST_NAME, "test_09_task_scoop_circular"
+    )
+
+if __name__ == '__main__':
+  import rostest
+  rostest.rosrun(PKG, TEST_NAME, TestTaskScoopCircular)

--- a/ow_sim_tests/scripts/test_task_scoop_linear.py
+++ b/ow_sim_tests/scripts/test_task_scoop_linear.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import rospy
+import roslib
+import unittest
+import owl_msgs.msg
+
+from action_testing import *
+from ow_lander import constants
+
+PKG = 'ow_sim_tests'
+TEST_NAME = 'task_scoop_linear'
+roslib.load_manifest(PKG)
+
+class TestTaskScoopLinear(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    rospy.init_node("test_task_scoop_linear")
+
+    set_ignore_action_checks(True)
+    # proceed with test only when ros clock has been initialized
+    while rospy.get_time() == 0:
+      rospy.sleep(0.1)
+
+  def test_01_task_grind(self):
+    task_grind_result = test_arm_action(self,
+      'TaskGrind', owl_msgs.msg.TaskGrindAction,
+      owl_msgs.msg.TaskGrindGoal(
+        x_start = 1.65,
+        y_start = 0.0,
+        depth = 0.15,
+        length = 0.7,
+        parallel = True,
+        ground_position = constants.DEFAULT_GROUND_HEIGHT
+      ),
+      TEST_NAME, "test_01_task_grind",
+      server_timeout = 50.0 # (seconds) first action call needs longer timeout
+    )
+  
+  def test_02_task_scoop_linear(self):
+    task_scoop_linear_result = test_arm_action(self,
+      'TaskScoopLinear', owl_msgs.msg.TaskScoopLinearAction,
+      owl_msgs.msg.TaskScoopLinearGoal(
+        frame = 0,
+        relative = False,
+        point = Point(1.45, 0.0, constants.DEFAULT_GROUND_HEIGHT),
+        depth = 0.01,
+        length = 0.15
+      ),
+      TEST_NAME, "test_02_task_scoop_linear"
+    )
+
+  def test_03_task_scoop_linear(self):
+    task_scoop_linear_result = test_arm_action(self,
+      'TaskScoopLinear', owl_msgs.msg.TaskScoopLinearAction,
+      owl_msgs.msg.TaskScoopLinearGoal(
+        frame = 0,
+        relative = True,
+        point = Point(-0.856, 0.095, -0.337),
+        depth = 0.02,
+        length = 0.05
+      ),
+      TEST_NAME, "test_03_task_scoop_linear"
+    )
+
+  def test_04_task_scoop_linear(self):
+    task_scoop_linear_result = test_arm_action(self,
+      'TaskScoopLinear', owl_msgs.msg.TaskScoopLinearAction,
+      owl_msgs.msg.TaskScoopLinearGoal(
+        frame = 1,
+        relative = True,
+        point = Point(-0.8, 0.0, -0.4),
+        depth = 0.01,
+        length = 0.05
+      ),
+      TEST_NAME, "test_04_task_scoop_linear"
+    )
+
+  def test_05_task_grind(self):
+    task_grind_result = test_arm_action(self,
+      'TaskGrind', owl_msgs.msg.TaskGrindAction,
+      owl_msgs.msg.TaskGrindGoal(
+        x_start = 1.6,
+        y_start = 0.4,
+        depth = 0.05,
+        length = 0.8,
+        parallel = True,
+        ground_position = constants.DEFAULT_GROUND_HEIGHT
+      ),
+      TEST_NAME, "test_05_task_grind"
+    )
+
+  def test_06_task_scoop_linear(self):
+    task_scoop_linear_result = test_arm_action(self,
+      'TaskScoopLinear', owl_msgs.msg.TaskScoopLinearAction,
+      owl_msgs.msg.TaskScoopLinearGoal(
+        frame = 0,
+        relative = False,
+        point = Point(1.60, 0.4, constants.DEFAULT_GROUND_HEIGHT),
+        depth = 0.01,
+        length = 0.1
+      ),
+      TEST_NAME, "test_06_task_scoop_linear"
+    )
+
+  def test_07_task_grind(self):
+    task_grind_result = test_arm_action(self,
+      'TaskGrind', owl_msgs.msg.TaskGrindAction,
+      owl_msgs.msg.TaskGrindGoal(
+        x_start = 1.6,
+        y_start = -0.2,
+        depth = 0.05,
+        length = 0.7,
+        parallel = True,
+        ground_position = constants.DEFAULT_GROUND_HEIGHT
+      ),
+      TEST_NAME, "test_07_task_grind"
+    )
+
+  def test_08_task_scoop_linear(self):
+    task_scoop_linear_result = test_arm_action(self,
+      'TaskScoopLinear', owl_msgs.msg.TaskScoopLinearAction,
+      owl_msgs.msg.TaskScoopLinearGoal(
+        frame = 0,
+        relative = False,
+        point = Point(1.60, -0.2, constants.DEFAULT_GROUND_HEIGHT),
+        depth = 0.01,
+        length = 0.03
+      ),
+      TEST_NAME, "test_08_task_scoop_linear"
+    )
+
+if __name__ == '__main__':
+  import rostest
+  rostest.rosrun(PKG, TEST_NAME, TestTaskScoopLinear)

--- a/ow_sim_tests/scripts/test_task_scoop_linear.py
+++ b/ow_sim_tests/scripts/test_task_scoop_linear.py
@@ -27,43 +27,43 @@ class TestTaskScoopLinear(unittest.TestCase):
     while rospy.get_time() == 0:
       rospy.sleep(0.1)
 
-  def test_01_task_grind(self):
-    task_grind_result = test_arm_action(self,
-      'TaskGrind', owl_msgs.msg.TaskGrindAction,
-      owl_msgs.msg.TaskGrindGoal(
-        x_start = 1.65,
-        y_start = 0.0,
-        depth = 0.15,
-        length = 0.7,
-        parallel = True,
-        ground_position = constants.DEFAULT_GROUND_HEIGHT
-      ),
-      TEST_NAME, "test_01_task_grind",
-      server_timeout = 50.0 # (seconds) first action call needs longer timeout
-    )
-  
-  def test_02_task_scoop_linear(self):
+  def test_01_task_scoop_linear(self):
     task_scoop_linear_result = test_arm_action(self,
       'TaskScoopLinear', owl_msgs.msg.TaskScoopLinearAction,
       owl_msgs.msg.TaskScoopLinearGoal(
         frame = 0,
         relative = False,
-        point = Point(1.45, 0.0, constants.DEFAULT_GROUND_HEIGHT),
+        point = Point(1.1, 0.0, 0.1),
         depth = 0.01,
-        length = 0.15
+        length = 0.5
       ),
-      TEST_NAME, "test_02_task_scoop_linear"
+      TEST_NAME, "test_01_task_scoop_linear",
+      server_timeout = 50.0 # (seconds) first action call needs longer timeout
     )
 
+  def test_02_task_grind(self):
+    task_grind_result = test_arm_action(self,
+      'TaskGrind', owl_msgs.msg.TaskGrindAction,
+      owl_msgs.msg.TaskGrindGoal(
+        x_start = 1.6,
+        y_start = 0.0,
+        depth = 0.15,
+        length = 0.8,
+        parallel = True,
+        ground_position = constants.DEFAULT_GROUND_HEIGHT
+      ),
+      TEST_NAME, "test_02_task_grind",
+    )
+  
   def test_03_task_scoop_linear(self):
     task_scoop_linear_result = test_arm_action(self,
       'TaskScoopLinear', owl_msgs.msg.TaskScoopLinearAction,
       owl_msgs.msg.TaskScoopLinearGoal(
         frame = 0,
-        relative = True,
-        point = Point(-0.856, 0.095, -0.337),
-        depth = 0.02,
-        length = 0.05
+        relative = False,
+        point = Point(1.4, 0.0, constants.DEFAULT_GROUND_HEIGHT),
+        depth = 0.01,
+        length = 0.3
       ),
       TEST_NAME, "test_03_task_scoop_linear"
     )
@@ -72,16 +72,29 @@ class TestTaskScoopLinear(unittest.TestCase):
     task_scoop_linear_result = test_arm_action(self,
       'TaskScoopLinear', owl_msgs.msg.TaskScoopLinearAction,
       owl_msgs.msg.TaskScoopLinearGoal(
-        frame = 1,
+        frame = 0,
         relative = True,
-        point = Point(-0.8, 0.0, -0.4),
-        depth = 0.01,
-        length = 0.05
+        point = Point(-1.081, -0.01, -0.52),
+        depth = 0.02,
+        length = 0.2
       ),
       TEST_NAME, "test_04_task_scoop_linear"
     )
 
-  def test_05_task_grind(self):
+  def test_05_task_scoop_linear(self):
+    task_scoop_linear_result = test_arm_action(self,
+      'TaskScoopLinear', owl_msgs.msg.TaskScoopLinearAction,
+      owl_msgs.msg.TaskScoopLinearGoal(
+        frame = 1,
+        relative = True,
+        point = Point(-0.9, -0.05, -0.5),
+        depth = 0.01,
+        length = 0.05
+      ),
+      TEST_NAME, "test_05_task_scoop_linear"
+    )
+
+  def test_06_task_grind(self):
     task_grind_result = test_arm_action(self,
       'TaskGrind', owl_msgs.msg.TaskGrindAction,
       owl_msgs.msg.TaskGrindGoal(
@@ -92,10 +105,10 @@ class TestTaskScoopLinear(unittest.TestCase):
         parallel = True,
         ground_position = constants.DEFAULT_GROUND_HEIGHT
       ),
-      TEST_NAME, "test_05_task_grind"
+      TEST_NAME, "test_06_task_grind"
     )
 
-  def test_06_task_scoop_linear(self):
+  def test_07_task_scoop_linear(self):
     task_scoop_linear_result = test_arm_action(self,
       'TaskScoopLinear', owl_msgs.msg.TaskScoopLinearAction,
       owl_msgs.msg.TaskScoopLinearGoal(
@@ -105,10 +118,10 @@ class TestTaskScoopLinear(unittest.TestCase):
         depth = 0.01,
         length = 0.1
       ),
-      TEST_NAME, "test_06_task_scoop_linear"
+      TEST_NAME, "test_07_task_scoop_linear"
     )
 
-  def test_07_task_grind(self):
+  def test_08_task_grind(self):
     task_grind_result = test_arm_action(self,
       'TaskGrind', owl_msgs.msg.TaskGrindAction,
       owl_msgs.msg.TaskGrindGoal(
@@ -119,10 +132,10 @@ class TestTaskScoopLinear(unittest.TestCase):
         parallel = True,
         ground_position = constants.DEFAULT_GROUND_HEIGHT
       ),
-      TEST_NAME, "test_07_task_grind"
+      TEST_NAME, "test_08_task_grind"
     )
 
-  def test_08_task_scoop_linear(self):
+  def test_09_task_scoop_linear(self):
     task_scoop_linear_result = test_arm_action(self,
       'TaskScoopLinear', owl_msgs.msg.TaskScoopLinearAction,
       owl_msgs.msg.TaskScoopLinearGoal(
@@ -132,7 +145,7 @@ class TestTaskScoopLinear(unittest.TestCase):
         depth = 0.01,
         length = 0.03
       ),
-      TEST_NAME, "test_08_task_scoop_linear"
+      TEST_NAME, "test_09_task_scoop_linear"
     )
 
 if __name__ == '__main__':

--- a/ow_sim_tests/test/test_camera_capture.test
+++ b/ow_sim_tests/test/test_camera_capture.test
@@ -2,13 +2,14 @@
 <launch>
 
     <arg name="gzclient" default="true" />
-
+    <arg name="rqt_gui" default="true" />
+    
     <include file="$(find ow)/launch/europa_terminator_workspace.launch">
-        <arg name="rqt_gui" value="true" />
+        <arg name="rqt_gui" value="$(arg rqt_gui)" />
         <arg name="use_rviz" value="false"/>
         <arg name="gzclient" value="$(arg gzclient)"/>
     </include>
-
+    
     <test test-name="test_camera_capture" pkg="ow_sim_tests"
         type="test_camera_capture.py" time-limit="700.0"/>
     

--- a/ow_sim_tests/test/test_camera_set_exposure.test
+++ b/ow_sim_tests/test/test_camera_set_exposure.test
@@ -2,9 +2,10 @@
 <launch>
 
     <arg name="gzclient" default="true" />
-
+    <arg name="rqt_gui" default="true" />
+    
     <include file="$(find ow)/launch/europa_terminator_workspace.launch">
-        <arg name="rqt_gui" value="true" />
+        <arg name="rqt_gui" value="$(arg rqt_gui)" />
         <arg name="use_rviz" value="false"/>
         <arg name="gzclient" value="$(arg gzclient)"/>
     </include>

--- a/ow_sim_tests/test/test_camera_set_exposure.test
+++ b/ow_sim_tests/test/test_camera_set_exposure.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+
+    <arg name="gzclient" default="true" />
+
+    <include file="$(find ow)/launch/europa_terminator_workspace.launch">
+        <arg name="rqt_gui" value="true" />
+        <arg name="use_rviz" value="false"/>
+        <arg name="gzclient" value="$(arg gzclient)"/>
+    </include>
+
+    <test test-name="test_camera_set_exposure" pkg="ow_sim_tests"
+        type="test_camera_set_exposure.py" time-limit="700.0"/>
+    
+</launch>

--- a/ow_sim_tests/test/test_light_set_intensity.test
+++ b/ow_sim_tests/test/test_light_set_intensity.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+
+    <arg name="gzclient" default="true" />
+
+    <include file="$(find ow)/launch/europa_terminator_workspace.launch">
+        <arg name="rqt_gui" value="false" />
+        <arg name="use_rviz" value="false"/>
+        <arg name="gzclient" value="$(arg gzclient)"/>
+    </include>
+
+    <test test-name="test_light_set_intensity" pkg="ow_sim_tests"
+        type="test_light_set_intensity.py" time-limit="700.0"/>
+    
+</launch>

--- a/ow_sim_tests/test/test_task_deliver_sample.test
+++ b/ow_sim_tests/test/test_task_deliver_sample.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+
+    <arg name="gzclient" default="true" />
+
+    <include file="$(find ow)/launch/europa_terminator_workspace.launch">
+        <arg name="rqt_gui" value="false" />
+        <arg name="use_rviz" value="false"/>
+        <arg name="gzclient" value="$(arg gzclient)"/>
+    </include>
+
+    <test test-name="test_task_deliver_sample" pkg="ow_sim_tests"
+        type="test_task_deliver_sample.py" time-limit="700.0"/>
+    
+</launch>

--- a/ow_sim_tests/test/test_task_discard_sample.test
+++ b/ow_sim_tests/test/test_task_discard_sample.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+
+    <arg name="gzclient" default="true" />
+
+    <include file="$(find ow)/launch/europa_terminator_workspace.launch">
+        <arg name="rqt_gui" value="false" />
+        <arg name="use_rviz" value="false"/>
+        <arg name="gzclient" value="$(arg gzclient)"/>
+    </include>
+
+    <test test-name="test_task_discard_sample" pkg="ow_sim_tests"
+        type="test_task_discard_sample.py" time-limit="700.0"/>
+    
+</launch>

--- a/ow_sim_tests/test/test_task_grind.test
+++ b/ow_sim_tests/test/test_task_grind.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+
+    <arg name="gzclient" default="true" />
+
+    <include file="$(find ow)/launch/europa_terminator_workspace.launch">
+        <arg name="rqt_gui" value="false" />
+        <arg name="use_rviz" value="false"/>
+        <arg name="gzclient" value="$(arg gzclient)"/>
+    </include>
+
+    <test test-name="test_task_grind" pkg="ow_sim_tests"
+        type="test_task_grind.py" time-limit="700.0"/>
+    
+</launch>

--- a/ow_sim_tests/test/test_task_scoop_circular.test
+++ b/ow_sim_tests/test/test_task_scoop_circular.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+
+    <arg name="gzclient" default="true" />
+
+    <include file="$(find ow)/launch/europa_terminator_workspace.launch">
+        <arg name="rqt_gui" value="false" />
+        <arg name="use_rviz" value="false"/>
+        <arg name="gzclient" value="$(arg gzclient)"/>
+    </include>
+
+    <test test-name="test_task_scoop_circular" pkg="ow_sim_tests"
+        type="test_task_scoop_circular.py" time-limit="700.0"/>
+    
+</launch>

--- a/ow_sim_tests/test/test_task_scoop_linear.test
+++ b/ow_sim_tests/test/test_task_scoop_linear.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+
+    <arg name="gzclient" default="true" />
+
+    <include file="$(find ow)/launch/europa_terminator_workspace.launch">
+        <arg name="rqt_gui" value="false" />
+        <arg name="use_rviz" value="false"/>
+        <arg name="gzclient" value="$(arg gzclient)"/>
+    </include>
+
+    <test test-name="test_task_scoop_linear" pkg="ow_sim_tests"
+        type="test_task_scoop_linear.py" time-limit="700.0"/>
+    
+</launch>


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-983](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-983) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1175](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1175) |


## Summary of Changes

* Additional tests for actions. 
* Some errors observed during testing: 
   - Warning in ros topic [ WARN] [1689639620.134610941, 1916525242.934999943]: The input topic '/StereoCamera/left/camera_info' is not yet advertised
   - CameraCapture aborted error (see OW-1186)
* Please let me know if any additional tests are still required to develop. I assumed for this branch all the actions have it own rostest now, except the pan_tile_move actions.


## Test
* rostest ow_sim_tests test_task_deliver_sample.test
* rostest ow_sim_tests test_task_discard_sample.test
* rostest ow_sim_tests test_task_grind.test
* rostest ow_sim_tests test_task_scoop_circular.test
* rostest ow_sim_tests test_task_scoop_linear.test
* rostest ow_sim_tests test_camera_set_exposure.test
* rostest ow_sim_tests test_light_set_intensity.test
