### PR TITLE
Oceanwater 1174 mechanical power moving average modification

### DIFF
--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -44,3 +44,8 @@ power_average_size: 100
 # workaround to prevent this, we cap its power input.
 max_gsap_power_input: 20    # watts
 
+# Number of threads to use for the asynchronous ROS spinning in the main
+# power system loop (to allow the joint states callback function to run
+# at the same 50Hz publication rate, rather than the loop's 0.5Hz rate).
+spinner_threads: 4
+

--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -35,10 +35,10 @@ gsap_rate: 0.5              # hz
 profile_increment: 2
 
 # Similarly, since the inputs used to compute power consumption come
-# from the /joint_states topic published at 50Hz, we multiply this by
+# from the /joint_states topic published at 50Hz, we divide this by
 # GSAP's rate to determine the number of entries used in a moving
 # average:
-power_average_size: 25
+power_average_size: 100
 
 # The current GSAP model breaks if power input is to high.  As a
 # workaround to prevent this, we cap its power input.

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -61,7 +61,7 @@ private:
   ros::Publisher m_battery_temperature_pub;           // Battery Temperature Publisher
   ros::Subscriber m_joint_states_sub;                 // Mechanical Power Subscriber
 
-  int m_moving_average_window = 25;
+  int m_moving_average_window = 100;
   std::vector<double> m_power_values;
   size_t m_power_values_index = 0;
 

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -61,7 +61,7 @@ private:
   ros::Publisher m_battery_temperature_pub;           // Battery Temperature Publisher
   ros::Subscriber m_joint_states_sub;                 // Mechanical Power Subscriber
 
-  int m_moving_average_window = 100;
+  int m_moving_average_window = 25;
   std::vector<double> m_power_values;
   size_t m_power_values_index = 0;
 

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -103,6 +103,11 @@ private:
   // Release 9.  This initial value is overriden by the system config.
   int m_profile_increment = 2;
 
+  // Number of threads to use for the asynchronous ROS spinning in the main
+  // loop (to allow jointStatesCb to run at 50Hz separate from the 0.5Hz main
+  // loop).
+  int m_spinner_threads = 4;
+
   // End main system configuration.
 
   // Utilize a Mersenne Twister pseudo-random generation.

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -74,6 +74,7 @@ bool PowerSystemNode::loadSystemConfig()
   m_gsap_rate_hz = system_config.getDouble("gsap_rate");
   m_profile_increment = system_config.getInt32("profile_increment");
   m_moving_average_window = system_config.getInt32("power_average_size");
+  m_spinner_threads = system_config.getInt32("spinner_threads");
   return true;
 }
 
@@ -529,7 +530,7 @@ void PowerSystemNode::Run()
 
   // Start the asynchronous spinner, which will call jointStatesCb as the
   // joint_states topic is published (50Hz).
-  ros::AsyncSpinner spinner(4);
+  ros::AsyncSpinner spinner(m_spinner_threads);
   spinner.start();
 
   // For simplicity, we run the power node at the same rate as GSAP.
@@ -548,6 +549,8 @@ void PowerSystemNode::Run()
 
     rate.sleep();
   }
+  
+  spinner.stop();
 }
 
 int main(int argc, char* argv[])

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -198,7 +198,7 @@ bool PowerSystemNode::initTopics()
   m_battery_remaining_useful_life_pub = m_nh.advertise<owl_msgs::BatteryRemainingUsefulLife>("/battery_remaining_useful_life", 1);
   m_battery_temperature_pub = m_nh.advertise<owl_msgs::BatteryTemperature>("/battery_temperature", 1);
   // Finally subscribe to the joint_states to estimate the mechanical power
-  m_joint_states_sub = m_nh.subscribe("/joint_states", 1, &PowerSystemNode::jointStatesCb, this);
+  m_joint_states_sub = m_nh.subscribe("/joint_states", 100, &PowerSystemNode::jointStatesCb, this);
   return true;
 }
 
@@ -211,12 +211,6 @@ void PowerSystemNode::jointStatesCb(const sensor_msgs::JointStateConstPtr& msg)
   m_power_values[++m_power_values_index % m_power_values.size()] = power_watts;   // [W]
   auto mean_mechanical_power =
       accumulate(begin(m_power_values), end(m_power_values), 0.0) / m_power_values.size();
-
-  Float64 mechanical_power_raw_msg, mechanical_power_avg_msg;
-  mechanical_power_raw_msg.data = power_watts;
-  mechanical_power_avg_msg.data = mean_mechanical_power;
-  m_mechanical_power_raw_pub.publish(mechanical_power_raw_msg);
-  m_mechanical_power_avg_pub.publish(mechanical_power_avg_msg);
 
   m_unprocessed_mechanical_power = mean_mechanical_power;
 
@@ -519,7 +513,26 @@ void PowerSystemNode::Run()
 
   while (ros::ok())
   {
+    // Run all callbacks in queue (in particular, 100 jointStatesCb msgs)
     ros::spinOnce();
+    // Publish mechanical raw & average power from jointStatesCb calculations.
+    Float64 mechanical_power_raw_msg, mechanical_power_avg_msg;
+    // Take the last entry in the moving average window.
+    // NOTE: This is not ideal behavior, and instead lines up with previous
+    //       behavior where only one /joint_states message out of every 100 was
+    //       processed. Unless publishing 100 raw values at once is preferred,
+    //       this is the better option until asynchronous GSAP prognosers are
+    //       implemented (see OW-994 for the pack model).
+    auto power_watts = m_power_values[m_power_values.size() - 1];
+    mechanical_power_raw_msg.data = power_watts;
+    // Get the average of all mechanical power values since last loop.
+    auto mean_mechanical_power =
+      accumulate(begin(m_power_values), end(m_power_values), 0.0)
+                 / m_power_values.size();
+    mechanical_power_avg_msg.data = mean_mechanical_power;
+    m_mechanical_power_raw_pub.publish(mechanical_power_raw_msg);
+    m_mechanical_power_avg_pub.publish(mechanical_power_avg_msg);
+
 
     if (m_trigger_processing_new_power_batch)
     {

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -211,7 +211,7 @@ void PowerSystemNode::jointStatesCb(const sensor_msgs::JointStateConstPtr& msg)
 
   // Add the current power_watts value to the moving average window, overwriting
   // the oldest entry. Calculate the average mechanical power within the window.
-  m_power_values[m_power_values_index++ % m_power_values.size()] = power_watts;   // [W]
+  m_power_values[m_power_values_index++ % m_power_values.size()] = power_watts;
   auto mean_mechanical_power =
       accumulate(begin(m_power_values), end(m_power_values), 0.0) / m_power_values.size();
 
@@ -549,7 +549,7 @@ void PowerSystemNode::Run()
 
     rate.sleep();
   }
-  
+
   spinner.stop();
 }
 


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | n/a |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1174](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1174) |
| Github :octocat:  | # |

OW-1174 was originally created to discuss and modify the size of the moving average window within ``jointStatesCb`` (which calculates mechanical power from the ``/joint_states`` topic before passing it into GSAP's simple prognoser to affect predictions) because it was discovered to be too large during the PR for OW-994. However, further investigation revealed ``jointStatesCb`` itself may not be working as intended to begin with. Its current implementation runs once every loop in ``ow_power_system``, which is 0.5Hz, but the ``/joint_states`` topic publishes at a rate of 50Hz. Because the subscriber in the power system only has a queue size of 1, this means roughly 99 messages are discarded between callbacks. This may help explain the original size-25 moving average window size, which would average out the mechanical power from the last 0.5s if ``jointStatesCb`` were running at 50Hz like the topic. Instead, it is averaging out the mechanical power from the last 50s and discarding 99 of the 100 messages per cycle. More ideally, it should average out the mechanical power from the last 2s (to fit the 0.5Hz rate of the main loop). This was achieved using ``ros::AsyncSpinner``.

## Summary of Changes
* The main power system ``while`` loop now uses ``ros::AsyncSpinner`` instead of ``ros::spinOnce`` to run callbacks asynchronously. The current number of threads used is set to the default ``4`` but can be changed in ``system.cfg`` via ``spinner_threads`` if performance requires it. This means ``jointStatesCb`` now runs at the same 50Hz as the ``/joint_states`` topic rather than 0.5Hz.
  * This also means that ``mechanical_power/raw`` & ``mechanical_power/average`` now publish at a rate of 50Hz rather than 0.5Hz. I suspect this was the original intended behavior, because previously it only published 1 out of every 100 mechanical power calculations, discarding the rest.
  * The GSAP prognoser now receives as input the average of the last 100 mechanical power values, which comes out to the average power used in the last 2s. Before, it was receiving the average of 25 out of 2500 power values in the last 50s, which is unrealistic.
* Updated the moving average from size ``25`` to ``100`` in both ``system.cfg`` & ``PowerSystemNode.h``. While the original size was too large, that was because ``jointStatesCb`` was running at 0.5Hz with the main loop instead of at 50Hz with ``/joint_states``. The original calculation for the window size said to multiply the rate of ``/joint_states``' publication rate (50Hz) by the main loop's rate (0.5Hz) to account for all messages, but this is actually achieved by dividing instead. 100 messages will publish in the time it takes for the main loop to cycle, not 25.

## Test
* Open up 4 terminals.
* In the 1st terminal, build & run the simulation in the OceanWATERS directory. The world shouldn't matter, though I used the ``atacama`` world (``roslaunch ow atacama_y1a.launch``).
* In the other 3 terminals, run one of the following commands in each once the simulation is running:
  * ``rostopic echo /joint_states``
  * ``rostopic echo mechanical_power/raw``
  * ``rostopic echo mechanical_power/average``
* **The 3 terminals should each be outputting messages at the same time, at a rate of 50Hz**. It may be hard to keep up with the messages, but as long as ``mechanical_power/raw`` & ``mechanical_power/average`` are outputting as fast as ``/joint_states`` they should be good to go.
