### PR TITLE
OW-1187: jointStatesCb handling in the pack model

### DIFF
--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -47,6 +47,11 @@ power_average_size: 25
 # workaround to prevent this, we cap its power input.
 max_gsap_power_input: 20    # watts
 
+# Number of threads to use for the asynchronous ROS spinning in the main
+# power system loop (to allow the joint states callback function to run
+# at the same 50Hz publication rate, rather than the loop's 0.5Hz rate).
+spinner_threads: 4
+
 # DEBUG CUSTOMIZATION
 # This flag disables all power-related debug output from printing if false.
 # The other flags allow filtering of specific messages.
@@ -68,6 +73,6 @@ outputs_print_debug: false
 # Output: 1 line per cycle.
 topics_print_debug: false
 
-# Prints the mechanical power calculated during jointStatesCb each cycle.
-# Output: 3 lines per cycle.
+# Prints the mechanical power calculated during jointStatesCb each time it calls.
+# Output: 50Hz, just like the publishing rate of /joint_states. Will eclipse all other outputs in the terminal.
 mech_power_print_debug: false

--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -38,10 +38,10 @@ gsap_rate: 0.5              # hz
 time_interval: 2
 
 # Similarly, since the inputs used to compute power consumption come
-# from the /joint_states topic published at 50Hz, we multiply this by
+# from the /joint_states topic published at 50Hz, we divide this by
 # GSAP's rate to determine the number of entries used in a moving
 # average:
-power_average_size: 25
+power_average_size: 100
 
 # The current GSAP model breaks if power input is too high.  As a
 # workaround to prevent this, we cap its power input.
@@ -74,5 +74,6 @@ outputs_print_debug: false
 topics_print_debug: false
 
 # Prints the mechanical power calculated during jointStatesCb each time it calls.
-# Output: 50Hz, just like the publishing rate of /joint_states. Will eclipse all other outputs in the terminal.
+# Output: 2 lines at 50Hz, just like the publishing rate of /joint_states.
+# NOTE: Will eclipse all other outputs in the terminal.
 mech_power_print_debug: false

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -166,7 +166,7 @@ private:
 
   // Vector w/ supporting variables that stores the moving average of the
   // past mechanical power values.
-  const int m_moving_average_window = 25;
+  int m_moving_average_window = 100;
   std::vector<double> m_power_values;
   size_t m_power_values_index = 0;
 

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -127,6 +127,15 @@ private:
   // testing for confirmation).
   int m_num_samples;
 
+  // Number of threads to use for the asynchronous ROS spinning in the main
+  // loop (to allow jointStatesCb to run at 50Hz separate from the 0.5Hz main
+  // loop).
+  int m_spinner_threads = 4;
+
+  // Signifies if the main power loop is in the process of sending data
+  // to GSAP prognosers.
+  bool m_processing_power_batch = false;
+
   // GSAP's cycle time.
   double m_gsap_rate_hz;
 

--- a/ow_power_system/include/PrognoserInputHandler.h
+++ b/ow_power_system/include/PrognoserInputHandler.h
@@ -40,7 +40,7 @@ public:
   bool initialize();
   bool runOnce();
   void getPowerStats(InputInfo &inputs);
-  void applyMechanicalPower(double mechanical_power);
+  void applyMechanicalPower(double mechanical_power, bool process_lock);
   void setHighPowerDraw(double draw);
   void setCustomPowerDraw(double draw);
   void setCustomVoltageFault(double volts);
@@ -51,7 +51,7 @@ private:
   double generateVoltageEstimate();
   void applyValueMods(double& power, double& voltage, double& temperature);
 
-  bool runPrognoser(double electrical_power);
+  bool cyclePrognoserInputs(double electrical_power);
 
   std::chrono::time_point<std::chrono::system_clock> m_init_time;
 


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-994](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-994) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1187](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1187) |
| Github :octocat:  | # |

Similar to the [PR for OW-1174](https://github.com/nasa/ow_simulator/pull/348), this PR addresses the existing invalid behavior of the ``jointStatesCb`` function within the power system. However, it requires a separate fix due to the differences in the current ``noetic-devel`` version of the power system and the most recent pack model version in [OW-1163](https://github.com/nasa/ow_simulator/tree/OCEANWATER-1163_Improve_Pack_Model_Performance).

Note that this PR is merging into the in-development branch OW-1163, *not* noetic-devel. As such, someone who previously reviewed the pack model is best to review this (short) PR.

## Summary of Changes
* The main power system ``while`` loop now uses ``ros::AsyncSpinner`` instead of ``ros::spinOnce`` to run callbacks asynchronously. The current number of threads used is set to the default ``4`` but can be changed in ``system.cfg`` via ``spinner_threads`` if needed. This means ``jointStatesCb`` now runs at the same 50Hz frequency as the ``/joint_states`` topic itself, rather than at the 0.5Hz of the power system loop.
  * This also means that the ``mechanical_power/raw`` and ``mechanical_power/average`` topics publish at 50Hz instead of 0.5Hz.
  * The GSAP prognosers now receive as input the average of the last 100 mechanical power values, which comes out to the average power used in the last 2 seconds. Previous behavior was the last 25 out of 2500 power values in the last 50s, which is unrealistic.
* Updated the size of the mechanical power moving average window from ``25`` to ``100``. While the original size was so large as to be unresponsive to power changes, this was because ``jointStatesCb`` was running at 0.5Hz instead of 50Hz. Now that it is running at the proper frequency, size 100 is adequate to hold all values in the last 2 seconds.
* **Critically, these changes open up the possibility of modifying the rate of the power system's main loop, whereas before it was locked to 0.5Hz due to GSAP's simple prognoser**. This PR does not change the loop's rate, but it is now a viable option if needed (i.e. if GSAP needs input data at a faster rate than 0.5Hz to stabilize).

## Test
* Open up 5 terminals.
* In the 1st terminal, build & run the simulation in the OceanWATERS directory. The world shouldn't matter, though I used the ``atacama`` world (``roslaunch ow atacama_y1a.launch``).
* In the 2nd, 3rd, & 4th terminals, run one of the following commands in each:
  * ``rostopic echo /joint_states``
  * ``rostopic echo mechanical_power/raw``
  * ``rostopic echo mechanical_power/average``
* **The 3 terminals should each be outputting messages at the same time, at a rate of 50Hz**. It may be hard to keep up with the messages, but as long as ``mechanical_power/raw`` & ``mechanical_power/average`` are outputting as fast as ``/joint_states`` they should be good to go.
* In the 5th terminal, run PLEXIL (``roslaunch ow_plexil ow_exec.launch``).
  * Run one or more PLEXIL plans in the 2nd terminal. Some examples are ``ReferenceMission1.plx``, ``ReferenceMission2.plx``, and ``TestActions.plx``.
  * As the lander initiates and completes actions, the values within ``mechanical_power/raw`` & ``mechanical_power/average`` should increase to reflect the power draw from said actions. **Confirm these topics respond properly to lander actions**.
    * Note that the power draw shown in ``mechanical_power/average`` (which is the value applied to the battery) may be higher than previously observed in past PRs. If so, this is because the previous average took only 1 value out of every 100 published by ``/joint_states``, and then averaged out the last 25 values stored. Any power draw applied in the past, especially if it were due to short actions, would not have its power use reflected properly in this average.