### PR TITLE
Oceanwater 1191 fix hole orientation and position

### DIFF
--- a/ow_dynamic_terrain/src/TerrainModifier.cpp
+++ b/ow_dynamic_terrain/src/TerrainModifier.cpp
@@ -243,7 +243,6 @@ bool TerrainModifier::applyImageToHeightmap(Heightmap* heightmap, const cv::Poin
     return false;
   }
 
-  int heightmap_size = static_cast<int>(terrain->getSize());
   int left = center.x - image.cols / 2;
   int top = center.y - image.rows / 2;
   int right = left + image.cols - 1;

--- a/ow_dynamic_terrain/src/TerrainModifier.cpp
+++ b/ow_dynamic_terrain/src/TerrainModifier.cpp
@@ -257,7 +257,9 @@ bool TerrainModifier::applyImageToHeightmap(Heightmap* heightmap, const cv::Poin
     {
       // Using bottom - y instead of y - top because cv::Mat has a different
       // layout than Ogre Heightmaps.
-      auto pixel_value = image.at<float>(bottom - y, x - left);
+      auto cv_index_y = bottom - y;
+      auto cv_index_x = x - left;
+      auto pixel_value = image.at<float>(cv_index_y, cv_index_x);
       if (skip_zeros && ignition::math::equal<float>(pixel_value, 0.0f))
         continue;
 
@@ -268,7 +270,7 @@ bool TerrainModifier::applyImageToHeightmap(Heightmap* heightmap, const cv::Poin
         continue; // no change is necessary
 
       set_height_value(x, y, new_height);
-      diff.at<float>(y - top, x - left) = new_height - old_height;
+      diff.at<float>(cv_index_y, cv_index_x) = new_height - old_height;
       
       // if we make it here, flag that a change has occurred
       change_occurred = true;

--- a/ow_dynamic_terrain/src/TerrainModifier.cpp
+++ b/ow_dynamic_terrain/src/TerrainModifier.cpp
@@ -243,29 +243,31 @@ bool TerrainModifier::applyImageToHeightmap(Heightmap* heightmap, const cv::Poin
     return false;
   }
 
-  auto heightmap_size = static_cast<int>(terrain->getSize());
-  auto left = max(center.x - image.cols / 2, 0);
-  auto top = max(center.y - image.rows / 2, 0);
-  auto right = min(center.x - image.cols / 2 + image.cols - 1, heightmap_size);
-  auto bottom = min(center.y - image.rows / 2 + image.rows - 1, heightmap_size);
+  int heightmap_size = static_cast<int>(terrain->getSize());
+  int left = center.x - image.cols / 2;
+  int top = center.y - image.rows / 2;
+  int right = left + image.cols - 1;
+  int bottom = top + image.rows - 1;
 
   auto diff = OpenCV_Util::createZerosMatLike(image);
 
   bool change_occurred = false;
 
-  for (auto y = top; y <= bottom; ++y)
-    for (auto x = left; x <= right; ++x)
+  for (int y = top; y <= bottom; ++y)
+    for (int x = left; x <= right; ++x)
     {
-      auto pixel_value = image.at<float>(y - top, x - left);
+      // Using bottom - y instead of y - top because cv::Mat has a different
+      // layout than Ogre Heightmaps.
+      auto pixel_value = image.at<float>(bottom - y, x - left);
       if (skip_zeros && ignition::math::equal<float>(pixel_value, 0.0f))
         continue;
-      
+
       auto old_height = get_height_value(x, y);
       auto new_height = merge_method(old_height, pixel_value + z_bias);
 
       if (old_height == new_height) 
         continue; // no change is necessary
-      
+
       set_height_value(x, y, new_height);
       diff.at<float>(y - top, x - left) = new_height - old_height;
       


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️ | [OCEANWATER-1191](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1191) |


## Summary of Changes
* Fixed orientation and position problems with dynamic terrain holes.

## Test
* There's not a good way to test this without extra changes to other files. Instead, here are some before and after screenshots:

Before/after positioning changes. Positions of holes should be points on a regular grid.
![Screenshot_20230725_111311](https://github.com/nasa/ow_simulator/assets/30808090/fc52b0f5-b9e9-46ff-914b-134c186e7d04)
![Screenshot_20230725_133531](https://github.com/nasa/ow_simulator/assets/30808090/5b03d645-8491-4203-b3da-e663b963c60a)

Before/after flip across x-axis. I patched the terrain with europa_test_dem since you can see its proper orientation using `roslaunch ow europa_test_dem.launch`
![Screenshot_20230725_111057](https://github.com/nasa/ow_simulator/assets/30808090/75ddeb4c-773a-47a1-afc7-88d32a410e9f)
![Screenshot_20230725_113738](https://github.com/nasa/ow_simulator/assets/30808090/968a15cf-a644-4a3c-b42e-cfd98a364b76)

