### PR TITLE
OCEANWATER-1175_Additional_rostests_2

### DIFF
--- a/ow_sim_tests/scripts/test_arm_move_joints_guarded.py
+++ b/ow_sim_tests/scripts/test_arm_move_joints_guarded.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import rospy
+import roslib
+import unittest
+import owl_msgs.msg
+
+from action_testing import *
+
+PKG = 'ow_sim_tests'
+TEST_NAME = 'arm_move_joints_guarded'
+roslib.load_manifest(PKG)
+
+class TestArmMoveJointsGuarded(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    rospy.init_node("test_arm_move_joints_guarded")
+
+    set_ignore_action_checks(True)
+    # proceed with test only when ros clock has been initialized
+    while rospy.get_time() == 0:
+      rospy.sleep(0.1)
+
+  def test_01_arm_move_joints_guarded(self):
+    arm_move_joints_guarded_result = test_arm_action(self,
+      'ArmMoveJointsGuarded', owl_msgs.msg.ArmMoveJointsGuardedAction,
+      owl_msgs.msg.ArmMoveJointsGuardedGoal(
+        relative = False,
+        angles = [0.0349066, 0.890118, -1.78024, 0.907571, 0.994838, -0.0174533],
+        force_threshold = 200,
+        torque_threshold = 100
+      ),
+      TEST_NAME, 'test_01_arm_move_joints_guarded',
+      server_timeout = 50.0 # (seconds) first action call needs longer timeout
+    )
+
+  def test_02_arm_move_joints_guarded(self):
+    arm_move_joints_guarded_result = test_arm_action(self,
+      'ArmMoveJointsGuarded', owl_msgs.msg.ArmMoveJointsGuardedAction,
+      owl_msgs.msg.ArmMoveJointsGuardedGoal(
+        relative = True,
+        angles = [0, 0, 0, 0, -0.6, 0],
+        force_threshold = 50,
+        torque_threshold = 30
+      ),
+      TEST_NAME, 'test_02_arm_move_joints_guarded'
+    )
+    
+  def test_03_arm_move_joints_guarded(self):
+    arm_move_joints_guarded_result = test_arm_action(self,
+      'ArmMoveJointsGuarded', owl_msgs.msg.ArmMoveJointsGuardedAction,
+      owl_msgs.msg.ArmMoveJointsGuardedGoal(
+        relative = True,
+        angles = [-0.2, 0, 0, 0, 0, 0],
+        force_threshold = 200,
+        torque_threshold = 100
+      ),
+      TEST_NAME, 'test_03_arm_move_joints_guarded'
+    )
+
+  def test_04_arm_move_joints_guarded(self):
+    arm_move_joints_guarded_result = test_arm_action(self,
+      'ArmMoveJointsGuarded', owl_msgs.msg.ArmMoveJointsGuardedAction,
+      owl_msgs.msg.ArmMoveJointsGuardedGoal(
+        relative = True,
+        angles = [-0.2, 0, 0, 0, 0, 0],
+        force_threshold = 50,
+        torque_threshold = 100
+      ),
+      TEST_NAME, 'test_04_arm_move_joints_guarded'
+    )
+    
+if __name__ == '__main__':
+  import rostest
+  rostest.rosrun(PKG, TEST_NAME, TestArmMoveJointsGuarded)

--- a/ow_sim_tests/scripts/test_arm_stop.py
+++ b/ow_sim_tests/scripts/test_arm_stop.py
@@ -8,6 +8,7 @@ import rospy
 import roslib
 import unittest
 import owl_msgs.msg
+import actionlib
 
 from action_testing import *
 
@@ -25,19 +26,16 @@ class TestArmStop(unittest.TestCase):
     # proceed with test only when ros clock has been initialized
     while rospy.get_time() == 0:
       rospy.sleep(0.1)
-    
+
+  # GoalStatus as ABORTED because arm_stop is not stop any action
   def test_01_arm_stop(self):
-
-    client_stop = actionlib.SimpleActionClient('ArmStop', owl_msgs.msg.ArmStopAction)
-
-    connected_stop = client_stop.wait_for_server(timeout = rospy.Duration(50))
-
-    client_stop.send_goal(owl_msgs.msg.ArmStopGoal())
-    client_stop.wait_for_result()
-
-    result = client_stop.get_result()
-
-    self.assertTrue(result, "No arm trajectory to stop")
+    arm_stop_result = test_arm_action(self,
+      'ArmStop', owl_msgs.msg.ArmStopAction,
+      owl_msgs.msg.ArmStopGoal(),
+      TEST_NAME, "test_01_arm_stop",
+      server_timeout = 50.0, # (seconds) first action call needs longer timeout,
+      expected_end_state = actionlib.GoalStatus.ABORTED
+    )
 
   def test_02_arm_unstow_and_stop(self):
 
@@ -55,7 +53,7 @@ class TestArmStop(unittest.TestCase):
 
     result = client_stop.get_result()
 
-    self.assertTrue(result, "Arm trajectory stopped")
+    self.assertEqual(client_stop.get_goal_status_text(), "Arm trajectory stopped")
 
   def test_03_task_deliver_sample_and_stop(self):
 
@@ -73,7 +71,7 @@ class TestArmStop(unittest.TestCase):
 
     result = client_stop.get_result()
 
-    self.assertTrue(result, "Arm trajectory stopped")
+    self.assertEqual(client_stop.get_goal_status_text(), "Arm trajectory stopped")
 
   def test_04_arm_stow_and_stop(self):
 
@@ -91,7 +89,7 @@ class TestArmStop(unittest.TestCase):
 
     result = client_stop.get_result()
 
-    self.assertTrue(result, "Arm trajectory stopped")
+    self.assertEqual(client_stop.get_goal_status_text(), "Arm trajectory stopped")
 
 if __name__ == '__main__':
   import rostest

--- a/ow_sim_tests/scripts/test_arm_stop.py
+++ b/ow_sim_tests/scripts/test_arm_stop.py
@@ -16,6 +16,10 @@ PKG = 'ow_sim_tests'
 TEST_NAME = 'arm_stop'
 roslib.load_manifest(PKG)
 
+# NOTE: Running this test at 3x real-time factor results in a slightly different
+# log outcome, but otherwise the test still succeeds. This should be fixed by
+# OW-1193
+
 class TestArmStop(unittest.TestCase):
 
   @classmethod

--- a/ow_sim_tests/scripts/test_arm_stop.py
+++ b/ow_sim_tests/scripts/test_arm_stop.py
@@ -51,8 +51,6 @@ class TestArmStop(unittest.TestCase):
     client_stop.send_goal(owl_msgs.msg.ArmStopGoal())
     client_stop.wait_for_result()
 
-    result = client_stop.get_result()
-
     self.assertEqual(client_stop.get_goal_status_text(), "Arm trajectory stopped")
 
   def test_03_task_deliver_sample_and_stop(self):
@@ -69,8 +67,6 @@ class TestArmStop(unittest.TestCase):
     client_stop.send_goal(owl_msgs.msg.ArmStopGoal())
     client_stop.wait_for_result()
 
-    result = client_stop.get_result()
-
     self.assertEqual(client_stop.get_goal_status_text(), "Arm trajectory stopped")
 
   def test_04_arm_stow_and_stop(self):
@@ -86,8 +82,6 @@ class TestArmStop(unittest.TestCase):
 
     client_stop.send_goal(owl_msgs.msg.ArmStopGoal())
     client_stop.wait_for_result()
-
-    result = client_stop.get_result()
 
     self.assertEqual(client_stop.get_goal_status_text(), "Arm trajectory stopped")
 

--- a/ow_sim_tests/scripts/test_arm_stop.py
+++ b/ow_sim_tests/scripts/test_arm_stop.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import rospy
+import roslib
+import unittest
+import owl_msgs.msg
+
+from action_testing import *
+
+PKG = 'ow_sim_tests'
+TEST_NAME = 'arm_stop'
+roslib.load_manifest(PKG)
+
+class TestArmStop(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    rospy.init_node("arm_stop_test")
+
+    set_ignore_action_checks(True)
+    # proceed with test only when ros clock has been initialized
+    while rospy.get_time() == 0:
+      rospy.sleep(0.1)
+    
+  def test_01_arm_stop(self):
+
+    client_stop = actionlib.SimpleActionClient('ArmStop', owl_msgs.msg.ArmStopAction)
+
+    connected_stop = client_stop.wait_for_server(timeout = rospy.Duration(50))
+
+    client_stop.send_goal(owl_msgs.msg.ArmStopGoal())
+    client_stop.wait_for_result()
+
+    result = client_stop.get_result()
+
+    self.assertTrue(result, "No arm trajectory to stop")
+
+  def test_02_arm_unstow_and_stop(self):
+
+    client_unstow = actionlib.SimpleActionClient('ArmUnstow', owl_msgs.msg.ArmUnstowAction)
+    client_stop = actionlib.SimpleActionClient('ArmStop', owl_msgs.msg.ArmStopAction)
+
+    connected_unstow = client_unstow.wait_for_server(timeout = rospy.Duration(10))
+    connected_stop = client_stop.wait_for_server(timeout = rospy.Duration(10))
+    
+    client_unstow.send_goal(owl_msgs.msg.ArmUnstowGoal())
+    client_unstow.wait_for_result(timeout=rospy.Duration.from_sec(5))
+
+    client_stop.send_goal(owl_msgs.msg.ArmStopGoal())
+    client_stop.wait_for_result()
+
+    result = client_stop.get_result()
+
+    self.assertTrue(result, "Arm trajectory stopped")
+
+  def test_03_task_deliver_sample_and_stop(self):
+
+    client_deliver = actionlib.SimpleActionClient('TaskDeliverSample', owl_msgs.msg.TaskDeliverSampleAction)
+    client_stop = actionlib.SimpleActionClient('ArmStop', owl_msgs.msg.ArmStopAction)
+
+    connected_unstow = client_deliver.wait_for_server(timeout = rospy.Duration(10))
+    connected_stop = client_stop.wait_for_server(timeout = rospy.Duration(10))
+    
+    client_deliver.send_goal(owl_msgs.msg.TaskDeliverSampleGoal())
+    client_deliver.wait_for_result(timeout=rospy.Duration.from_sec(30))
+
+    client_stop.send_goal(owl_msgs.msg.ArmStopGoal())
+    client_stop.wait_for_result()
+
+    result = client_stop.get_result()
+
+    self.assertTrue(result, "Arm trajectory stopped")
+
+  def test_04_arm_stow_and_stop(self):
+
+    client_stow = actionlib.SimpleActionClient('ArmStow', owl_msgs.msg.ArmUnstowAction)
+    client_stop = actionlib.SimpleActionClient('ArmStop', owl_msgs.msg.ArmStopAction)
+
+    connected_unstow = client_stow.wait_for_server(timeout = rospy.Duration(10))
+    connected_stop = client_stop.wait_for_server(timeout = rospy.Duration(10))
+    
+    client_stow.send_goal(owl_msgs.msg.ArmStowGoal())
+    client_stow.wait_for_result(timeout=rospy.Duration.from_sec(5))
+
+    client_stop.send_goal(owl_msgs.msg.ArmStopGoal())
+    client_stop.wait_for_result()
+
+    result = client_stop.get_result()
+
+    self.assertTrue(result, "Arm trajectory stopped")
+
+if __name__ == '__main__':
+  import rostest
+  rostest.rosrun(PKG, TEST_NAME, TestArmStop)

--- a/ow_sim_tests/scripts/test_pan_tilt_move_cartesian.py
+++ b/ow_sim_tests/scripts/test_pan_tilt_move_cartesian.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import rospy
+import roslib
+import unittest
+import owl_msgs.msg
+
+from action_testing import *
+
+PKG = 'ow_sim_tests'
+TEST_NAME = 'pan_tilt_move_cartesian'
+roslib.load_manifest(PKG)
+
+class TestPanTiltMoveCartesian(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    rospy.init_node("pan_tilt_move_cartesian_test")
+
+    set_ignore_action_checks(True)
+    # proceed with test only when ros clock has been initialized
+    while rospy.get_time() == 0:
+      rospy.sleep(30.0)
+
+  def test_01_pan_tilt_move_cartesian(self):
+    pan_tilt_move_cartesian_result = test_action(self,
+      'PanTiltMoveCartesian', owl_msgs.msg.PanTiltMoveCartesianAction,
+      owl_msgs.msg.PanTiltMoveCartesianGoal(
+        frame = 0,
+        point = Point(0, 0, 0)
+      ),
+      TEST_NAME, "test_01_pan_tilt_move_cartesian",
+      server_timeout = 400.0 # (seconds) first action call needs longer timeout
+    ) 
+
+  def test_02_pan_tilt_move_cartesian(self):
+    pan_tilt_move_cartesian_result = test_action(self,
+      'PanTiltMoveCartesian', owl_msgs.msg.PanTiltMoveCartesianAction,
+      owl_msgs.msg.PanTiltMoveCartesianGoal(
+        frame = 0,
+        point = Point(10, 15, 10)
+      ),
+      TEST_NAME, "test_02_pan_tilt_move_cartesian",
+    ) 
+
+  def test_03_pan_tilt_move_cartesian(self):
+    pan_tilt_move_cartesian_result = test_action(self,
+      'PanTiltMoveCartesian', owl_msgs.msg.PanTiltMoveCartesianAction,
+      owl_msgs.msg.PanTiltMoveCartesianGoal(
+        frame = 0,
+        point = Point(7, 7, 7)
+      ),
+      TEST_NAME, "test_03_pan_tilt_move_cartesian",
+    ) 
+
+  def test_04_pan_tilt_move_cartesian(self):
+    pan_tilt_move_cartesian_result = test_action(self,
+      'PanTiltMoveCartesian', owl_msgs.msg.PanTiltMoveCartesianAction,
+      owl_msgs.msg.PanTiltMoveCartesianGoal(
+        frame = 1,
+        point = Point(0, 0, 0)
+      ),
+      TEST_NAME, "test_04_pan_tilt_move_cartesian",
+    ) 
+
+  def test_05_pan_tilt_move_cartesian(self):
+    pan_tilt_move_cartesian_result = test_action(self,
+      'PanTiltMoveCartesian', owl_msgs.msg.PanTiltMoveCartesianAction,
+      owl_msgs.msg.PanTiltMoveCartesianGoal(
+        frame = 1,
+        point = Point(1, 0, 0)
+      ),
+      TEST_NAME, "test_05_pan_tilt_move_cartesian",
+    ) 
+
+  def test_06_pan_tilt_move_cartesian(self):
+    pan_tilt_move_cartesian_result = test_action(self,
+      'PanTiltMoveCartesian', owl_msgs.msg.PanTiltMoveCartesianAction,
+      owl_msgs.msg.PanTiltMoveCartesianGoal(
+        frame = 1,
+        point = Point(7, 7, 7)
+      ),
+      TEST_NAME, "test_06_pan_tilt_move_cartesian",
+    ) 
+
+if __name__ == '__main__':
+  import rostest
+  rostest.rosrun(PKG, TEST_NAME, TestPanTiltMoveCartesian)

--- a/ow_sim_tests/scripts/test_pan_tilt_move_cartesian.py
+++ b/ow_sim_tests/scripts/test_pan_tilt_move_cartesian.py
@@ -24,7 +24,9 @@ class TestPanTiltMoveCartesian(unittest.TestCase):
     set_ignore_action_checks(True)
     # proceed with test only when ros clock has been initialized
     while rospy.get_time() == 0:
-      rospy.sleep(30.0)
+      rospy.sleep(0.1)
+    # NOTE: work around for pan/tilt actions failing when called too early (see OW-1181)
+    rospy.sleep(30.0)
 
   def test_01_pan_tilt_move_cartesian(self):
     pan_tilt_move_cartesian_result = test_action(self,
@@ -34,7 +36,7 @@ class TestPanTiltMoveCartesian(unittest.TestCase):
         point = Point(0, 0, 0)
       ),
       TEST_NAME, "test_01_pan_tilt_move_cartesian",
-      server_timeout = 400.0 # (seconds) first action call needs longer timeout
+      server_timeout = 50.0 # (seconds) first action call needs longer timeout
     ) 
 
   def test_02_pan_tilt_move_cartesian(self):

--- a/ow_sim_tests/scripts/test_pan_tilt_move_joints.py
+++ b/ow_sim_tests/scripts/test_pan_tilt_move_joints.py
@@ -24,7 +24,9 @@ class TestPanTiltMoveJoints(unittest.TestCase):
     set_ignore_action_checks(True)
     # proceed with test only when ros clock has been initialized
     while rospy.get_time() == 0:
-      rospy.sleep(30.0)
+      rospy.sleep(0.1)
+    # NOTE: work around for pan/tilt actions failing when called too early (see OW-1181)
+    rospy.sleep(30.0)
 
   def test_01_pan_tilt_move_joints(self):
     pan_tilt_move_joints_result = test_action(self,
@@ -34,7 +36,7 @@ class TestPanTiltMoveJoints(unittest.TestCase):
         tilt = 1
       ),
       TEST_NAME, "test_01_pan_tilt_move_joints",
-      server_timeout = 400.0 # (seconds) first action call needs longer timeout
+      server_timeout = 50.0 # (seconds) first action call needs longer timeout
     ) 
 
   def test_02_pan_tilt_move_joints(self):

--- a/ow_sim_tests/scripts/test_pan_tilt_move_joints.py
+++ b/ow_sim_tests/scripts/test_pan_tilt_move_joints.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import rospy
+import roslib
+import unittest
+import owl_msgs.msg
+import ow_lander.msg
+from action_testing import *
+
+PKG = 'ow_sim_tests'
+TEST_NAME = 'pan_tilt_move_joints'
+roslib.load_manifest(PKG)
+
+class TestPanTiltMoveJoints(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    rospy.init_node("pan_tilt_move_joints_test")
+
+    set_ignore_action_checks(True)
+    # proceed with test only when ros clock has been initialized
+    while rospy.get_time() == 0:
+      rospy.sleep(30.0)
+
+  def test_01_pan_tilt_move_joints(self):
+    pan_tilt_move_joints_result = test_action(self,
+      'PanTiltMoveJoints', owl_msgs.msg.PanTiltMoveJointsAction,
+      owl_msgs.msg.PanTiltMoveJointsGoal(
+        pan = 0.785,
+        tilt = 1
+      ),
+      TEST_NAME, "test_01_pan_tilt_move_joints",
+      server_timeout = 400.0 # (seconds) first action call needs longer timeout
+    ) 
+
+  def test_02_pan_tilt_move_joints(self):
+    pan_tilt_move_joints_result = test_action(self,
+      'PanTiltMoveJoints', owl_msgs.msg.PanTiltMoveJointsAction,
+      owl_msgs.msg.PanTiltMoveJointsGoal(
+        pan = 0.785,
+        tilt = 1
+      ),
+      TEST_NAME, "test_02_pan_tilt_move_joints"
+    ) 
+
+  def test_03_pan_tilt_move_joints(self):
+    pan_tilt_move_joints_result = test_action(self,
+      'PanTiltMoveJoints', owl_msgs.msg.PanTiltMoveJointsAction,
+      owl_msgs.msg.PanTiltMoveJointsGoal(
+        pan = 0.785,
+        tilt = 0.785
+      ),
+      TEST_NAME, "test_03_pan_tilt_move_joints"
+    ) 
+
+  def test_04_pan_tilt_move_joints(self):
+    pan_tilt_move_joints_result = test_action(self,
+      'PanTiltMoveJoints', owl_msgs.msg.PanTiltMoveJointsAction,
+      owl_msgs.msg.PanTiltMoveJointsGoal(
+        pan = -0.785,
+        tilt = -0.785
+      ),
+      TEST_NAME, "test_04_pan_tilt_move_joints"
+    ) 
+
+  def test_05_pan_tilt_move_joints(self):
+    pan_tilt_move_joints_result = test_action(self,
+      'PanTiltMoveJoints', owl_msgs.msg.PanTiltMoveJointsAction,
+      owl_msgs.msg.PanTiltMoveJointsGoal(
+        pan = 0,
+        tilt = -0.785
+      ),
+      TEST_NAME, "test_05_pan_tilt_move_joints"
+    ) 
+
+  def test_06_pan_tilt_move_joints(self):
+    pan_tilt_move_joints_result = test_action(self,
+      'PanTiltMoveJoints', owl_msgs.msg.PanTiltMoveJointsAction,
+      owl_msgs.msg.PanTiltMoveJointsGoal(
+        pan = -0.785,
+        tilt = 0
+      ),
+      TEST_NAME, "test_06_pan_tilt_move_joints"
+    ) 
+
+  def test_07_pan_tilt_move_joints(self):
+    pan_tilt_move_joints_result = test_action(self,
+      'PanTiltMoveJoints', owl_msgs.msg.PanTiltMoveJointsAction,
+      owl_msgs.msg.PanTiltMoveJointsGoal(
+        pan = 3.1,
+        tilt = 1.55
+      ),
+      TEST_NAME, "test_07_pan_tilt_move_joints"
+    )
+
+  def test_08_pan_tilt_move_joints(self):
+    pan_tilt_move_joints_result = test_action(self,
+      'PanTiltMoveJoints', owl_msgs.msg.PanTiltMoveJointsAction,
+      owl_msgs.msg.PanTiltMoveJointsGoal(
+        pan = -3.1,
+        tilt = -1.55
+      ),
+      TEST_NAME, "test_08_pan_tilt_move_joints"
+    )
+
+  def test_09_pan_tilt_move_joints(self):
+    pan_tilt_move_joints_result = test_action(self,
+      'PanTiltMoveJoints', owl_msgs.msg.PanTiltMoveJointsAction,
+      owl_msgs.msg.PanTiltMoveJointsGoal(
+        pan = 0,
+        tilt = 0
+      ),
+      TEST_NAME, "test_09_pan_tilt_move_joints"
+    )
+
+  # Test 10 and 11 are employed to test pan.py and tilt.py
+  def test_10_pan(self):
+    pan_result = test_action(self,
+      'Pan', ow_lander.msg.PanAction,
+      ow_lander.msg.PanGoal(
+        pan = 1
+      ),
+      TEST_NAME, "test_10_pan"
+    )
+
+  def test_11_tilt(self):
+    tilt_result = test_action(self,
+      'Tilt', ow_lander.msg.TiltAction,
+      ow_lander.msg.TiltGoal(
+        tilt = 1
+      ),
+      TEST_NAME, "test_11_tilt"
+    )
+
+if __name__ == '__main__':
+  import rostest
+  rostest.rosrun(PKG, TEST_NAME, TestPanTiltMoveJoints)

--- a/ow_sim_tests/test/test_arm_move_joints_guarded.test
+++ b/ow_sim_tests/test/test_arm_move_joints_guarded.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+
+    <arg name="gzclient" default="true" />
+
+    <include file="$(find ow)/launch/europa_terminator_workspace.launch">
+        <arg name="rqt_gui" value="false" />
+        <arg name="use_rviz" value="false"/>
+        <arg name="gzclient" value="$(arg gzclient)"/>
+    </include>
+
+    <test test-name="test_arm_move_joints_guarded" pkg="ow_sim_tests"
+        type="test_arm_move_joints_guarded.py" time-limit="700.0"/>
+    
+</launch>

--- a/ow_sim_tests/test/test_arm_stop.test
+++ b/ow_sim_tests/test/test_arm_stop.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+
+    <arg name="gzclient" default="true" />
+
+    <include file="$(find ow)/launch/europa_terminator_workspace.launch">
+        <arg name="rqt_gui" value="false" />
+        <arg name="use_rviz" value="false"/>
+        <arg name="gzclient" value="$(arg gzclient)"/>
+    </include>
+
+    <test test-name="arm_stop" pkg="ow_sim_tests"
+        type="test_arm_stop.py" time-limit="700.0"/>
+    
+</launch>

--- a/ow_sim_tests/test/test_pan_tilt_move_cartesian.test
+++ b/ow_sim_tests/test/test_pan_tilt_move_cartesian.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+
+    <arg name="gzclient" default="true" />
+
+    <include file="$(find ow)/launch/europa_terminator_workspace.launch">
+        <arg name="rqt_gui" value="false" />
+        <arg name="use_rviz" value="false"/>
+        <arg name="gzclient" value="$(arg gzclient)"/>
+    </include>
+
+    <test test-name="pan_tilt_move_cartesian" pkg="ow_sim_tests"
+        type="test_pan_tilt_move_cartesian.py" time-limit="700.0"/>
+    
+</launch>

--- a/ow_sim_tests/test/test_pan_tilt_move_joints.test
+++ b/ow_sim_tests/test/test_pan_tilt_move_joints.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+
+    <arg name="gzclient" default="true" />
+
+    <include file="$(find ow)/launch/europa_terminator_workspace.launch">
+        <arg name="rqt_gui" value="false" />
+        <arg name="use_rviz" value="false"/>
+        <arg name="gzclient" value="$(arg gzclient)"/>
+    </include>
+
+    <test test-name="pan_tilt_move_joints" pkg="ow_sim_tests"
+        type="test_pan_tilt_move_joints.py" time-limit="700.0"/>
+    
+</launch>


### PR DESCRIPTION


## Linked Issues:
| EPIC ⚡ | [OCEANWATER-983](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-983) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1175](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1175) |


## Summary of Changes
Additional testing for `arm_stop`, `arm_move_joints_guarded`, `pan_tilt_move_cartesian` and `pan_tilt_move_joints`.
* `test_pan_tilt_move_cartesian`: Antenna facing the given valid vector in space.
* `test_pan_tilt_move_joints`: Change antenna position by assigning the angle of pan and tilt, The first 9 tests using `PanTiltMoveJointsAction,` in which the pan and tilt move simultaneously, the `test_10` with `PanAction`only move `Pan` and `test_11`with `TiltAction` only move `Tilt`.
* `test_arm_move_joints_guarded`: Scoop tries to dig the ground but with different parameters, `test 01` pre-position the scoop at the specified location and then proceeds with the digging with `test 02`. `Test 02` rotates the hand_yaw and tries to dig, expect to see the action stop since the force_threshold is low. `Test 03` and `Test 04` will rotate the shoulder_yaw, and we expect to see `Test 03` drag the scoop at a small distance and `Test 04` stop the arm very quickly because of the low force and torque threshold.
* `test_arm_stop`: Except for the first test that calls the `arm_stop` directly, the test can split into two parts, at first the function call one of the arm move action, and the second part use `arm_stop` to stop that action. `client.wait_for_result(timeout=rospy.Duration.from_sec(5))` is used between the arms move and `arm_stop` in which allow `arm_stop` call before arm move finish, the number in `Duration.from_sec( )`specify the time in second wait between two actions.
## Test
* `rostest ow_sim_tests test_pan_tilt_move_cartesian.test`
* `rostest ow_sim_tests test_pan_tilt_move_joints.test`
* `rostest ow_sim_tests test_arm_move_joints_guarded.test`
* `rostest ow_sim_tests test_arm_stop.test`
