### PR TITLE
Made terrain texture mask

### DIFF
--- a/ow_dynamic_terrain/include/TerrainModifier.h
+++ b/ow_dynamic_terrain/include/TerrainModifier.h
@@ -18,19 +18,19 @@ namespace ow_dynamic_terrain
 class TerrainModifier
 {
 public:
-  static bool modifyCircle(gazebo::rendering::Heightmap* heightmap,
+  static bool modifyCircle(gazebo::rendering::Heightmap* heightmap, Ogre::TexturePtr maskmap,
                            const ow_dynamic_terrain::modify_terrain_circle::ConstPtr& msg,
                            const std::function<float(int, int)>& get_height_value,
                            const std::function<void(int, int, float)>& set_height_value,
                            ow_dynamic_terrain::modified_terrain_diff& out_diff_msg);
 
-  static bool modifyEllipse(gazebo::rendering::Heightmap* heightmap,
+  static bool modifyEllipse(gazebo::rendering::Heightmap* heightmap, Ogre::TexturePtr maskmap,
                             const ow_dynamic_terrain::modify_terrain_ellipse::ConstPtr& msg,
                             const std::function<float(int, int)>& get_height_value,
                             const std::function<void(int, int, float)>& set_height_value,
                             ow_dynamic_terrain::modified_terrain_diff& out_diff_msg);
 
-  static bool modifyPatch(gazebo::rendering::Heightmap* heightmap,
+  static bool modifyPatch(gazebo::rendering::Heightmap* heightmap, Ogre::TexturePtr maskmap,
                           const ow_dynamic_terrain::modify_terrain_patch::ConstPtr& msg,
                           const std::function<float(int, int)>& get_height_value,
                           const std::function<void(int, int, float)>& set_height_value,
@@ -46,7 +46,8 @@ private:
   // Imports an OpenCV Matrix object from a sensor_msgs::Image object through cv_bridge
   static cv_bridge::CvImageConstPtr importImageToOpenCV(const ow_dynamic_terrain::modify_terrain_patch::ConstPtr& msg);
 
-  // Applies the an OpenCV image to a heightmap at a given position
+  // Applies the an OpenCV image to a heightmap at a given position, and updates
+  // the maskmap to show heightmap points that have been modified.
   // param heightmap: heightmap to merge the image with
   // param center: absolute position within the heightmap where the image will be applied
   // param z_bias: a value that will be applied as an offset to height values retrieved from the image.
@@ -57,13 +58,13 @@ private:
   // param merge_method: Choices are keep, replace, add, sub, min, max and avg.
   // param out_diff_image: an image that stores the change in heightmap around the tool
   // return: true if there was a change made to the heightmap, false otherwise
-  static bool applyImageToHeightmap(gazebo::rendering::Heightmap* heightmap,
-                                    const cv::Point2i& center, float z_bias,
-                                    const cv::Mat& image, bool skip_zeros,
-                                    const std::function<float(int, int)>& get_height_value,
-                                    const std::function<void(int, int, float)>& set_height_value,
-                                    const std::function<float(float, float)>& merge_method,
-                                    cv_bridge::CvImage& out_diff_image);
+  static bool applyImage(gazebo::rendering::Heightmap* heightmap,
+                         Ogre::TexturePtr maskmap, const cv::Point2i& center,
+                         float z_bias, const cv::Mat& image, bool skip_zeros,
+                         const std::function<float(int, int)>& get_height_value,
+                         const std::function<void(int, int, float)>& set_height_value,
+                         const std::function<float(float, float)>& merge_method,
+                         cv_bridge::CvImage& out_diff_image);
 };
 }  // namespace ow_dynamic_terrain
 

--- a/ow_dynamic_terrain/src/DynamicTerrainModel.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainModel.cpp
@@ -115,7 +115,9 @@ private:
 
     modified_terrain_diff diff_msg;
 
-    auto changed = modify_method(heightmap, msg, 
+    Ogre::TexturePtr dummy_mask_map;  // Null texture will not be updated
+
+    auto changed = modify_method(heightmap, dummy_mask_map, msg,
         [&heightmap_shape](int x, int y) { return getHeightInWorldCoords(heightmap_shape, x, y); },
         [&heightmap_shape](int x, int y, float value) { setHeightFromWorldCoords(heightmap_shape, x, y, value); },
         diff_msg);

--- a/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
@@ -2,7 +2,7 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-#include "DynamicTerrainBase.h"
+#include "DynamicTerrainVisual.h"
 #include "TerrainModifier.h"
 #include <gazebo/rendering/RenderingIface.hh>
 
@@ -13,129 +13,133 @@ using namespace Ogre;
 
 namespace ow_dynamic_terrain
 {
-class DynamicTerrainVisual : public VisualPlugin, public DynamicTerrainBase
+
+GZ_REGISTER_VISUAL_PLUGIN(DynamicTerrainVisual)
+
+DynamicTerrainVisual::DynamicTerrainVisual() :
+  DynamicTerrainBase{ "ow_dynamic_terrain", "DynamicTerrainVisual" }
 {
-public:
-  DynamicTerrainVisual() : DynamicTerrainBase{ "ow_dynamic_terrain", "DynamicTerrainVisual" }
+}
+
+void DynamicTerrainVisual::Load(VisualPtr /*visual*/, sdf::ElementPtr /*sdf*/)
+{
+  Initialize("visual");
+
+  m_on_prerender_connection = gazebo::event::Events::ConnectPreRender([this]() {
+    initTextureUnits();
+  });
+}
+
+float DynamicTerrainVisual::getHeightInWorldCoords(const Ogre::Terrain* terrain, int x, int y)
+{
+  auto value = terrain->getHeightAtPoint(x, y);
+  value += terrain->getPosition().z;
+  return value;
+}
+
+void DynamicTerrainVisual::setHeightFromWorldCoords(Ogre::Terrain* terrain, int x, int y, float value)
+{
+  value -= terrain->getPosition().z;
+  terrain->setHeightAtPoint(x, y, value);
+}
+
+void DynamicTerrainVisual::onModifyTerrainCircleMsg(const modify_terrain_circle::ConstPtr& msg)
+{
+  onModifyTerrainMsg(msg, TerrainModifier::modifyCircle);
+}
+
+void DynamicTerrainVisual::onModifyTerrainEllipseMsg(const modify_terrain_ellipse::ConstPtr& msg)
+{
+  onModifyTerrainMsg(msg, TerrainModifier::modifyEllipse);
+}
+
+void DynamicTerrainVisual::onModifyTerrainPatchMsg(const modify_terrain_patch::ConstPtr& msg)
+{
+  onModifyTerrainMsg(msg, TerrainModifier::modifyPatch);
+}
+
+/**
+ * Create texture to draw into
+ * @returns true if texture already exists or has successfully been created
+ */
+void DynamicTerrainVisual::initMaskTexture(unsigned int texSize)
+{
+  // Create a single link track texture for all terrain materials.
+  mMaterialMaskTexture = TextureManager::getSingleton().createManual("modifyMaskTexture",
+    ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, TEX_TYPE_2D,
+    texSize, texSize, 0, PF_L8, TU_DYNAMIC_WRITE_ONLY_DISCARDABLE);
+
+  // Lock the pixel buffer
+  HardwarePixelBufferSharedPtr pixelBuffer = mMaterialMaskTexture->getBuffer();
+  pixelBuffer->lock(HardwareBuffer::HBL_DISCARD);
+
+  const PixelBox& pixelBox = pixelBuffer->getCurrentLock();
+  uint8* pixels = static_cast<uint8*>(pixelBox.data);
+
+  // Paint it white
+  memset(pixels, 255, texSize * texSize);
+
+  // Unlock the pixel buffer
+  pixelBuffer->unlock();
+
+  gzlog << "DynamicTerrainVisual::initMaskTexture - mask texture was created." << endl;
+}
+
+void DynamicTerrainVisual::initTextureUnits()
+{
+  auto heightmap = getHeightmap(get_scene());
+  if (heightmap == nullptr)
   {
+    gzerr << m_plugin_name << ": DynamicTerrainVisual::initTextureUnits()"
+      " could not acquire heightmap." << endl;
+    return;
   }
+  auto terrain = heightmap->OgreTerrain()->getTerrain(0, 0);
 
-  void Load(VisualPtr /*visual*/, sdf::ElementPtr /*sdf*/) override
+  initMaskTexture(heightmap->OgreTerrain()->getTerrainSize() - 1);
+
+  // Override custom material normal map labeled "ow_dynamic_terrain_normal_map"
+  // with Ogre::Terrain's internal normal map, and assign a custom mask texture.
+  // Ogre::Terrain generates an internal normal map and it is updated by
+  // Terrain::updateDerivedData(). But if you use a custom material script
+  // with a custom normal map, the internal normal map will never be seen.
+  // Note: If you are not using a custom material this code will have no
+  // effect, but Ogre should be using the correct normal map and a generated
+  // material and shader in that case.
+  // Caveat: The internal normal map is always sized to the terrain's DEM
+  // resolution, so using a larger texture for more detail is not possible
+  // with this plugin.
+  ResourceManager::ResourceMapIterator res_it = MaterialManager::getSingleton().getResourceIterator();
+  while (res_it.hasMoreElements())
   {
-    Initialize("visual");
-
-    m_on_prerender_connection = gazebo::event::Events::ConnectPreRender([this]() {
-      // Initialize terrain with Ogre-generated normal map.
-      applyNormalMap();
-      // Disconnect so this method will not be called again.
-      m_on_prerender_connection.reset();
-    });
-  }
-
-private:
-  static inline float getHeightInWorldCoords(const Ogre::Terrain* terrain, int x, int y)
-  {
-    auto value = terrain->getHeightAtPoint(x, y);
-    value += terrain->getPosition().z;
-    return value;
-  }
-
-  static inline void setHeightFromWorldCoords(Ogre::Terrain* terrain, int x, int y, float value)
-  {
-    value -= terrain->getPosition().z;
-    terrain->setHeightAtPoint(x, y, value);
-  }
-
-  template <typename T, typename M>
-  void onModifyTerrainMsg(T msg, M modify_method)
-  {
-    auto heightmap = getHeightmap(get_scene());
-    if (heightmap == nullptr)
+    ResourcePtr resource = res_it.getNext();
+    MaterialPtr material = resource.staticCast<Material>();
+    Material::TechniqueIterator tech_it = material->getTechniqueIterator();
+    while (tech_it.hasMoreElements())
     {
-      gzerr << m_plugin_name << ": DynamicTerrainVisual::onModifyTerrainMsg()"
-        " could not acquire heightmap." << endl;
-      return;
-    }
-
-    modified_terrain_diff diff_msg;
-
-    auto terrain = heightmap->OgreTerrain()->getTerrain(0, 0);
-    auto changed = modify_method(heightmap, msg, 
-        [&terrain](int x, int y) { return getHeightInWorldCoords(terrain, x, y); },
-        [&terrain](int x, int y, float value) { setHeightFromWorldCoords(terrain, x, y, value); }, 
-        diff_msg);
-
-    if (changed)
-    {
-      terrain->updateGeometry();
-      terrain->updateDerivedData(false, Ogre::Terrain::DERIVED_DATA_NORMALS | Ogre::Terrain::DERIVED_DATA_LIGHTMAP);
-
-      m_differential_pub.publish(diff_msg);
-    }
-  }
-
-  void onModifyTerrainCircleMsg(const modify_terrain_circle::ConstPtr& msg) override
-  {
-    onModifyTerrainMsg(msg, TerrainModifier::modifyCircle);
-  }
-
-  void onModifyTerrainEllipseMsg(const modify_terrain_ellipse::ConstPtr& msg) override
-  {
-    onModifyTerrainMsg(msg, TerrainModifier::modifyEllipse);
-  }
-
-  void onModifyTerrainPatchMsg(const modify_terrain_patch::ConstPtr& msg) override
-  {
-    onModifyTerrainMsg(msg, TerrainModifier::modifyPatch);
-  }
-
-  void applyNormalMap()
-  {
-    auto heightmap = getHeightmap(get_scene());
-    if (heightmap == nullptr)
-    {
-      gzerr << m_plugin_name << ": DynamicTerrainVisual::applyNormalMap()"
-        " could not acquire heightmap." << endl;
-      return;
-    }
-    auto terrain = heightmap->OgreTerrain()->getTerrain(0, 0);
-
-    // Override custom material normal map labeled "ow_dynamic_terrain_normal_map"
-    // with Ogre::Terrain's internal normal map.
-    // Ogre::Terrain generates an internal normal map and it is updated by
-    // Terrain::updateDerivedData(). But if you use a custom material script
-    // with a custom normal map, the internal normal map will never be seen.
-    // Note: If you are not using a custom material this code will have no
-    // effect, but Ogre should be using the correct normal map and a generated
-    // material and shader in that case.
-    // Caveat: The internal normal map is always sized to the terrain's DEM
-    // resolution, so using a larger texture for more detail is not possible
-    // with this plugin.
-    ResourceManager::ResourceMapIterator res_it = MaterialManager::getSingleton().getResourceIterator();
-    while (res_it.hasMoreElements())
-    {
-      ResourcePtr resource = res_it.getNext();
-      MaterialPtr material = resource.staticCast<Material>();
-      Material::TechniqueIterator tech_it = material->getTechniqueIterator();
-      while (tech_it.hasMoreElements())
+      Technique* technique = tech_it.getNext();
+      Technique::PassIterator pass_it = technique->getPassIterator();
+      while (pass_it.hasMoreElements())
       {
-        Technique* technique = tech_it.getNext();
-        Technique::PassIterator pass_it = technique->getPassIterator();
-        while (pass_it.hasMoreElements())
+        Pass* pass = pass_it.getNext();
+        // Assign Ogre-generated normal map to the named texture unit if it exists
+        TextureUnitState* tus = pass->getTextureUnitState("ow_dynamic_terrain_normal_map");
+        if (tus != 0)
         {
-          Pass* pass = pass_it.getNext();
-          TextureUnitState* tus = pass->getTextureUnitState("ow_dynamic_terrain_normal_map");
-          if (tus != 0)
-          {
-            tus->setTexture(terrain->getTerrainNormalMap());
-          }
+          tus->setTexture(terrain->getTerrainNormalMap());
+        }
+        // Assign mask map to the named texture unit if it exists
+        tus = pass->getTextureUnitState("ow_dynamic_terrain_mask_map");
+        if (tus != 0)
+        {
+          tus->setTexture(mMaterialMaskTexture);
         }
       }
     }
   }
 
-  gazebo::event::ConnectionPtr m_on_prerender_connection;
-};
+  // Disconnect so this method will not be called again.
+  m_on_prerender_connection.reset();
+}
 
-GZ_REGISTER_VISUAL_PLUGIN(DynamicTerrainVisual)
 }  // namespace ow_dynamic_terrain

--- a/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
+++ b/ow_dynamic_terrain/src/DynamicTerrainVisual.cpp
@@ -74,7 +74,7 @@ void DynamicTerrainVisual::initMaskTexture(unsigned int texSize)
   pixelBuffer->lock(HardwareBuffer::HBL_DISCARD);
 
   const PixelBox& pixelBox = pixelBuffer->getCurrentLock();
-  uint8* pixels = static_cast<uint8*>(pixelBox.data);
+  uint8_t* pixels = static_cast<uint8_t*>(pixelBox.data);
 
   // Paint it white
   memset(pixels, 255, texSize * texSize);

--- a/ow_dynamic_terrain/src/DynamicTerrainVisual.h
+++ b/ow_dynamic_terrain/src/DynamicTerrainVisual.h
@@ -1,0 +1,66 @@
+// The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+// Research and Simulation can be found in README.md in the root directory of
+// this repository.
+
+#include "DynamicTerrainBase.h"
+#include "TerrainModifier.h"
+#include <gazebo/rendering/RenderingIface.hh>
+
+namespace ow_dynamic_terrain
+{
+class DynamicTerrainVisual : public gazebo::VisualPlugin, public DynamicTerrainBase
+{
+public:
+  DynamicTerrainVisual();
+
+  void Load(gazebo::rendering::VisualPtr /*visual*/, sdf::ElementPtr /*sdf*/) override;
+
+private:
+  static inline float getHeightInWorldCoords(const Ogre::Terrain* terrain, int x, int y);
+
+  static inline void setHeightFromWorldCoords(Ogre::Terrain* terrain, int x, int y, float value);
+
+  template <typename T, typename M>
+  void onModifyTerrainMsg(T msg, M modify_method)
+  {
+    auto heightmap = getHeightmap(gazebo::rendering::get_scene());
+    if (heightmap == nullptr)
+    {
+      gzerr << m_plugin_name << ": DynamicTerrainVisual::onModifyTerrainMsg()"
+        " could not acquire heightmap." << std::endl;
+      return;
+    }
+
+    modified_terrain_diff diff_msg;
+
+    auto terrain = heightmap->OgreTerrain()->getTerrain(0, 0);
+    auto changed = modify_method(heightmap, mMaterialMaskTexture, msg,
+        [&terrain](int x, int y) { return getHeightInWorldCoords(terrain, x, y); },
+        [&terrain](int x, int y, float value) { setHeightFromWorldCoords(terrain, x, y, value); }, 
+        diff_msg);
+
+    if (changed)
+    {
+      terrain->updateGeometry();
+      terrain->updateDerivedData(false, Ogre::Terrain::DERIVED_DATA_NORMALS | Ogre::Terrain::DERIVED_DATA_LIGHTMAP);
+
+      m_differential_pub.publish(diff_msg);
+    }
+  }
+
+  void onModifyTerrainCircleMsg(const modify_terrain_circle::ConstPtr& msg) override;
+
+  void onModifyTerrainEllipseMsg(const modify_terrain_ellipse::ConstPtr& msg) override;
+
+  void onModifyTerrainPatchMsg(const modify_terrain_patch::ConstPtr& msg) override;
+
+  void initMaskTexture(unsigned int texSize);
+
+  void initTextureUnits();
+
+  gazebo::event::ConnectionPtr m_on_prerender_connection;
+
+  Ogre::TexturePtr mMaterialMaskTexture;
+};
+
+}  // namespace ow_dynamic_terrain

--- a/ow_dynamic_terrain/src/TerrainModifier.cpp
+++ b/ow_dynamic_terrain/src/TerrainModifier.cpp
@@ -252,9 +252,9 @@ bool TerrainModifier::applyImage(Heightmap* heightmap, TexturePtr maskmap,
 
   auto diff = OpenCV_Util::createZerosMatLike(image);
 
-  uint32 mask_size = 0;
+  uint32_t mask_size = 0;
   HardwarePixelBufferSharedPtr pixel_buffer;
-  uint8* mask_pixels = nullptr;
+  uint8_t* mask_pixels = nullptr;
   if (!maskmap.isNull())
   {
     mask_size = maskmap->getWidth();
@@ -263,7 +263,7 @@ bool TerrainModifier::applyImage(Heightmap* heightmap, TexturePtr maskmap,
     pixel_buffer->lock(HardwareBuffer::HBL_DISCARD);
     // Get pixel pointer
     const PixelBox& pixel_box = pixel_buffer->getCurrentLock();
-    mask_pixels = static_cast<uint8*>(pixel_box.data);
+    mask_pixels = static_cast<uint8_t*>(pixel_box.data);
   }
 
   bool change_occurred = false;


### PR DESCRIPTION
| Jira Ticket 🎟️ | [OCEANWATER-1142](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1142) |


## Summary of Changes
* Made terrain texture mask, which is updated when heightmap pixels are modified.

## Test
* This can't be tested without modifying a material file and shader. Instead, I offer this image as proof that it works. Terrain is drawn in yellow where the mask has been set to 0. 
![Screenshot_20230808_141448](https://github.com/nasa/ow_simulator/assets/30808090/72b7971c-8b07-4669-afa1-80672163e2dd)

