### PR TITLE
OW-1196: battery pack partial disabling

### DIFF
--- a/ow_faults_injection/cfg/Faults.cfg
+++ b/ow_faults_injection/cfg/Faults.cfg
@@ -101,9 +101,17 @@ ft_sensor_faults.add("signal_noise_failure", double_t, 0,
 power_faults = gen.add_group("power_faults")
 power_faults.add("high_power_draw",   double_t, 0,
     "High power draw increment", 1.0, 1.0, 360.0)
-power_faults.add("activate_high_power_draw",    bool_t, 0,  "Activate high power draw at the selected wattage", False)
+power_faults.add("activate_high_power_draw",    bool_t, 0,
+    "Activate high power draw at the selected wattage", False)
 
-power_faults.add("custom_fault_profile",   str_t, 0, "Enter the name of a CSV file that has been placed in ow_power_system/profiles", "example_fault.csv")
-power_faults.add("activate_custom_fault",   bool_t, 0, "Select and activate custom fault CSV", False)
+power_faults.add("custom_fault_profile",   str_t, 0, 
+    "Enter the name of a CSV file that has been placed in ow_power_system/profiles", "example_fault.csv")
+power_faults.add("activate_custom_fault",   bool_t, 0,
+    "Select and activate custom fault CSV", False)
+
+power_faults.add("battery_nodes_to_disconnect",   int_t, 0,
+    "Total number of parallel nodes in the battery to disconnect, to simulate an intra-battery fault", 0, 0, 3)
+power_faults.add("disconnect_battery_nodes",    bool_t, 0,
+    "Disconnect the selected number of battery nodes. Cannot be reversed without restarting the simulation", False)
 
 exit(gen.generate(PACKAGE, "faults", "Faults"))

--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -27,16 +27,21 @@ battery_lifetime: 27380.0		    # s
 
 # Power system related configurations
 
-# IMPORTANT: This flag heavily modifies the power system by
-# reducing the number of simulated models from the default 4
-# to 1. This will dramatically improve performance, but at 
-# the cost of simulating the individual battery nodes.
-# Any faults that apply differing behavior to each model
-# (e.g. one model experiencing a deterioration in performance)
-# will not be possible with this flag set to true.
-# Additionally, predictions may be less accurate with less models
-# to compare, though overall power behavior should not change.
-performance_mode: false
+# IMPORTANT: This flag governs whether the power system
+# runs only one instance of GSAP to get predictions from
+# one model, or four instances to simulate 4 separate models
+# as expected for the full battery. While any intra-battery
+# fault that would apply differing behavior to specific models
+# (e.g. one model deteriorating in performance) is not
+# possible to simulate with only one instance of GSAP running,
+# the additional CPU load imposed by each additional prognoser
+# is too large to run by default.
+#
+# When false, the one prognoser is treated as a random sample
+# of the status of the full battery. Predictions may be less
+# accurate with less models to compare, though overall
+# power behavior should not change.
+full_battery_simulation: false
 
 # The frequency of the main loop in the power system.
 # Dictates the time interval between publications

--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -27,21 +27,19 @@ battery_lifetime: 27380.0		    # s
 
 # Power system related configurations
 
-# IMPORTANT: This flag governs whether the power system
-# runs only one instance of GSAP to get predictions from
-# one model, or four instances to simulate 4 separate models
-# as expected for the full battery. While any intra-battery
-# fault that would apply differing behavior to specific models
-# (e.g. one model deteriorating in performance) is not
-# possible to simulate with only one instance of GSAP running,
-# the additional CPU load imposed by each additional prognoser
-# is too large to run by default.
-#
-# When false, the one prognoser is treated as a random sample
-# of the status of the full battery. Predictions may be less
-# accurate with less models to compare, though overall
-# power behavior should not change.
-full_battery_simulation: false
+# IMPORTANT: This value governs the number of GSAP prognosers
+# initialized by the power system to get predictions. 4
+# is the maximum amount and provides a full battery
+# simulation, but the additional load imposed by each
+# additional prognoser is too large to run by default.
+# As such, the default is 1 prognoser (which represents
+# a sample of the full battery), but most intra-battery
+# faults are not possible to simulate with only 1 active model.
+# At least 2 are required to run at once to allow for intra-
+# battery fault modeling on 1 model.
+# Predictions may also be less accurate with less models to
+# compare, though overall power behavior should not change.
+active_models: 1
 
 # The frequency of the main loop in the power system.
 # Dictates the time interval between publications

--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -27,6 +27,17 @@ battery_lifetime: 27380.0		    # s
 
 # Power system related configurations
 
+# IMPORTANT: This flag heavily modifies the power system by
+# reducing the number of simulated models from the default 4
+# to 1. This will dramatically improve performance, but at 
+# the cost of simulating the individual battery nodes.
+# Any faults that apply differing behavior to each model
+# (e.g. one model experiencing a deterioration in performance)
+# will not be possible with this flag set to true.
+# Additionally, predictions may be less accurate with less models
+# to compare, though overall power behavior should not change.
+performance_mode: false
+
 # The frequency of the main loop in the power system.
 # Dictates the time interval between publications
 # & the size of the mechanical power moving average window.

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -90,11 +90,10 @@ private:
 
   // system.cfg variables:
 
-  // Whether or not to run the power system with the full battery simulation.
-  // If false, only 1 prognoser will be created during initialization.
-  // This prevents the possibility of simulating various intra-battery faults,
-  // but enabling the full battery simulation is CPU-intensive.
-  bool m_full_battery_simulation;
+  // The number of currently simulated models. Default 1, but can be modified
+  // mid-simulation by intra-battery faults (or set to a different starting
+  // value in system.cfg).
+  int m_active_models;
 
   // HACK ALERT.  The prognoser produces erratic/erroneous output when
   // given too high a power input.  The value assigned to this in system.cfg
@@ -129,11 +128,6 @@ private:
   double m_initial_soc;
   
   // End system.cfg variables.
-
-  // The number of currently simulated models. Typically equal to NUM_MODELS,
-  // it can change mid-simulation by intra-battery faults (or by enabling
-  // full battery simulation in system.cfg).
-  int m_active_models;
 
   // The number of models deactivated via faults. Used separately from
   // m_active_models to allow the system to distribute power draw as if

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -90,11 +90,11 @@ private:
 
   // system.cfg variables:
 
-  // Whether or not to run the power system in performance mode, which
-  // sets the number of simulated prognosers to 1. This prevents the possibility
-  // of simulating various intra-battery faults, but dramatically improves
-  // performance.
-  bool m_performance_mode;
+  // Whether or not to run the power system with the full battery simulation.
+  // If false, only 1 prognoser will be created during initialization.
+  // This prevents the possibility of simulating various intra-battery faults,
+  // but enabling the full battery simulation is CPU-intensive.
+  bool m_full_battery_simulation;
 
   // HACK ALERT.  The prognoser produces erratic/erroneous output when
   // given too high a power input.  The value assigned to this in system.cfg
@@ -132,12 +132,13 @@ private:
 
   // The number of currently simulated models. Typically equal to NUM_MODELS,
   // it can change mid-simulation by intra-battery faults (or by enabling
-  // performance mode in system.cfg).
+  // full battery simulation in system.cfg).
   int m_active_models;
 
   // The number of models deactivated via faults. Used separately from
-  // m_active_models to allow performance mode to distribute power draw as if
-  // there were more models running at once.
+  // m_active_models to allow the system to distribute power draw as if
+  // there were more models running at once (i.e. when full battery simulation
+  // is disabled).
   int m_deactivated_models;
 
   // The rate at which /joint_states is expected to publish. If this is changed,

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -164,6 +164,7 @@ private:
 
   bool m_high_power_draw_activated = false;
   bool m_custom_power_fault_activated = false;
+  bool m_disconnect_battery_nodes_fault_activated = false;
   PrognoserVector m_custom_power_fault_sequence;
   size_t m_custom_power_fault_sequence_index = 0;
 

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -90,6 +90,12 @@ private:
 
   // system.cfg variables:
 
+  // Whether or not to run the power system in performance mode, which
+  // sets the number of simulated prognosers to 1. This prevents the possibility
+  // of simulating various intra-battery faults, but dramatically improves
+  // performance.
+  bool m_performance_mode;
+
   // HACK ALERT.  The prognoser produces erratic/erroneous output when
   // given too high a power input.  The value assigned to this in system.cfg
   // protects against this by capping the power input, but it is a temporary
@@ -123,6 +129,16 @@ private:
   double m_initial_soc;
   
   // End system.cfg variables.
+
+  // The number of currently simulated models. Typically equal to NUM_MODELS,
+  // it can change mid-simulation by intra-battery faults (or by enabling
+  // performance mode in system.cfg).
+  int m_active_models;
+
+  // The number of models deactivated via faults. Used separately from
+  // m_active_models to allow performance mode to distribute power draw as if
+  // there were more models running at once.
+  int m_deactivated_models;
 
   // The rate at which /joint_states is expected to publish. If this is changed,
   // this variable will need to change as well.

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -74,7 +74,7 @@ void PowerSystemNode::initAndRun()
     }
     // If print_debug was false, then all flags remain false as initialized.
 
-    m_performance_mode = (system_config.getString("performance_mode") == TRUE);
+    m_full_battery_simulation = (system_config.getString("full_battery_simulation") == TRUE);
     m_max_horizon_secs = system_config.getInt32("max_horizon");
     m_num_samples = system_config.getInt32("num_samples");
     m_initial_power = system_config.getDouble("initial_power");
@@ -94,14 +94,14 @@ void PowerSystemNode::initAndRun()
     return;
   }
 
-  // Set m_active_nodes.
-  if (m_performance_mode)
+  // Set m_active_nodes depending on the full_battery_simulation flag.
+  if (m_full_battery_simulation)
   {
-    m_active_models = 1;
+    m_active_models = NUM_MODELS;
   }
   else
   {
-    m_active_models = NUM_MODELS;
+    m_active_models = 1;
   }
   m_deactivated_models = 0;
   
@@ -182,12 +182,21 @@ void PowerSystemNode::initAndRun()
 
   ROS_INFO_STREAM("Power system node running.");
 
-  // Notify the user if performance mode is enabled.
-  if (m_performance_mode)
+  // Notify the user of the state of the battery simulation.
+  if (m_full_battery_simulation)
   {
-    ROS_INFO_STREAM("OW_POWER_SYSTEM NOTE: Performance mode activated. This"
-                    << " means only one GSAP model will run predictions."
-                    << " Intra-battery faults may not work properly.");
+    ROS_INFO_STREAM("OW_POWER_SYSTEM NOTE: Full battery simulation active. "
+                    << "This means " << std::to_string(NUM_MODELS)
+                    << " prognosers are running battery predictions at once. "
+                    << "Intra-battery faults are possible to model with this, "
+                    << "but CPU load will be much higher.");
+  }
+  else
+  {
+    ROS_INFO_STREAM("OW_POWER_SYSTEM NOTE: Not simulating full battery. "
+                    << "This means only one GSAP model will run predictions to "
+                    << "keep performance optimal, but intra-battery faults "
+                    << "may not work properly.");
   }
 
   // This rate object is used to sync the cycles up to the provided Hz.

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -595,14 +595,13 @@ void PowerSystemNode::injectFault (const std::string& fault_name)
     {
       ros::param::getCached("/faults/" + FAULT_NAME_DBN, dbn_nodes);
 
-      ROS_INFO_STREAM(fault_name << " activated! Disconnecting "
-                      << std::to_string(dbn_nodes) << " nodes...");
+
 
       m_disconnect_battery_nodes_fault_activated = true;
 
       // Warn the user if they tried to reduce the number of deactivated nodes
       // from a previous fault activation.
-      if (m_deactivated_models > dbn_nodes)
+      if (m_deactivated_models >= dbn_nodes)
       {
         ROS_WARN_STREAM("Attempted to disconnect " << std::to_string(dbn_nodes)
                         << " out of " << std::to_string(NUM_MODELS)
@@ -610,6 +609,13 @@ void PowerSystemNode::injectFault (const std::string& fault_name)
                         << std::to_string(m_deactivated_models)
                         << " out of " << std::to_string(NUM_MODELS)
                         << " disconnected. Behavior has not changed.");
+      }
+      else
+      {
+        ROS_INFO_STREAM(fault_name << " activated! "
+                      << std::to_string(dbn_nodes)
+                      << " out of " << std::to_string(NUM_MODELS) << " models "
+                      << "are now disconnected.");
       }
 
       // Update the number of active and deactivated nodes.
@@ -619,9 +625,9 @@ void PowerSystemNode::injectFault (const std::string& fault_name)
     }
     else if (m_disconnect_battery_nodes_fault_activated && !fault_enabled)
     {
-      ROS_INFO_STREAM(fault_name << " deactivated!");
-      ROS_WARN_STREAM_ONCE("Note that disconnected battery nodes cannot "
-                    << "be reconnected, even if the fault is deactivated.");
+      ROS_INFO_STREAM(fault_name << " deactivated. Note that disconnected "
+                    << "battery nodes cannot be reconnected, even if the fault "
+                    << "is deactivated.");
       m_disconnect_battery_nodes_fault_activated = false;
     }
   }

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -98,7 +98,7 @@ void PowerSystemNode::initAndRun()
   if (m_active_models < 1 || m_active_models > NUM_MODELS)
   {
     ROS_WARN_STREAM("OW_POWER_SYSTEM WARNING: "
-                    << "Invalid number of active nodes specified in "
+                    << "Invalid number of active models specified in "
                     << "system.cfg! Check the value of 'active_models' "
                     << "and ensure it is between 1 & "
                     << std::to_string(NUM_MODELS) << ". Defaulting to 1...");

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -353,7 +353,13 @@ void PowerSystemNode::initAndRun()
     }
 
     // DEBUG PRINT FORMATTING
-    if (m_print_debug && m_power_models[0].input_info.timestamp > 0)
+    // Skip a line for formatting purposes as long as a printout is being used.
+    if (m_print_debug && m_power_models[0].input_info.timestamp > 0
+        && (m_timestamp_print_debug
+         || m_inputs_print_debug
+         || m_outputs_print_debug
+         || m_topics_print_debug
+         || m_mech_power_print_debug))
     {
       std::cout << std::endl;
     }

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -627,7 +627,7 @@ void PowerSystemNode::injectFault (const std::string& fault_name)
                         << " out of " << std::to_string(NUM_MODELS)
                         << " disconnected. Behavior has not changed.");
         ROS_WARN_STREAM_THROTTLE(30, "This warning will repeat periodically "
-                        << "until the fault value is reset to "
+                        << "until the value of \"battery_nodes_to_disconnect\" is reset "
                         << std::to_string(m_deactivated_models)
                         << ", updated to disconnect more nodes, "
                         << "or the fault is deactivated.");


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | n/a |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1196](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1196) |
| Github :octocat:  | # |

**Note**: If you are a new reviewer (i.e. anyone except Mike & Thomas), the only test you need to complete is the performance test at the bottom of this PR description.

This PR will be merged into [OW-1163](https://github.com/nasa/ow_simulator/pull/352), ideally before its merge into noetic-devel. It should provide an option for users to reduce the CPU usage of the new multi-cell battery system without fully sacrificing the new changes, while also adding a new fault type only possible with the new implementation.

## Summary of Changes
* A new variable has been added to ``system.cfg``: ``active_models``. This can be set from 1-4, causing the power system to instantiate that number of prognosers. 4 are needed to simulate a full battery, but the CPU load is quite high as a result (excessively so if the user is not planning on focusing on the power model), so the default here is 1.
  * Power distribution will remain as-is, meaning that even in the case of 1 prognoser, it will still only be fed 1/4th of the power draw (as if the other models were still running and being fed the other 3/4ths). In this sense, reducing the number of active models will let the user get predictions as if they were sampling one part of the battery instead.
* A new power fault has been added: battery disconnection. The user can specify in the RQT window a number of battery nodes to disconnect, between 0-3 (since there are 4 nodes total). This will have the effect of halting input data being sent into their respective GSAP prognosers, effectively removing them from the system (this will tangentially increase performance since the prognosers will not start new predictions, but it is not the purpose of the fault). The remaining node(s) will receive a larger fraction of any applied power draw from external sources. This simulates losing one or more parallel nodes in a battery pack, which would force any additional load onto the remaining cells.
  * For example, at the start of the simulation, any running prognoser receives 1/4th of any applied power draw. If 1 model is disconnected, the remaining models will now receive 1/3rd the power each. If 3 models disconnect, the remaining 1 model will receive 100% of the power draw. This will not have an instantaneous effect on predictions unless there is already a significant amount of power draw being applied (i.e. if the battery loses 3 nodes at 95% SoC, it will still read 95% SoC), but the battery will deteriorate faster as a result of higher power draw. Discussion with Chetan may be necessary to confirm this is the expected behavior with this kind of fault.
    * This behavior does not change if less than 4 prognosers are instantiated at start to save on performance. If only 1 is running & 3 prognosers are designed to be disconnected, the simulation will run as if power was being distributed across 4 prognosers anyways.

## Tests Overview
* For both tests, check ``ow_power_system/config/system.cfg`` and ensure ``print_debug`` is ``true`` to allow important battery stats to be printed to the terminal during runtime. For the purposes of these tests, all debug printout flags in ``system.cfg`` should be set to true for simplicity.

## Test 1 (Battery Disconnection Fault)
* In ``system.cfg``, set ``active_models`` to 4 for this test.
* Open up a terminal and build & run the simulator in the OceanWATERS directory. The world shouldn't matter, though I used the ``atacama`` world (``roslaunch ow atacama_y1a.launch``).
* Monitor the terminal and confirm the 4 separate models running predictions.
* Once the simulation has started, navigate to the ``Dynamic Reconfigure`` tab on the bottom of the RQT window, and from there, to the ``faults`` section. Scroll down until you see the section governing the new fault, ``disconnect_battery_nodes``.
  * Adjust the value of ``battery_nodes_to_disconnect`` to some nonzero value (note it only allows whole numbers) and activate it by checking ``disconnect_battery_nodes``.
  * **Monitor the debug statement outputs and confirm that the correct amount of models were deactivated** (e.g. if 1 node was disconnected, 3 should remain). **Confirm that adjusting the value of ``battery_nodes_to_disconnect`` after the fault has already been activated updates the number of disconnected nodes, only if the number was increased. Decreasing the number should not result in any changes to the system**.
  * Using the ``high_power_draw`` fault, apply an additional amount of power draw on the system.
  * **Confirm that the additional power draw is correctly distributed amongst the remaining models** (e.g. with 120W of additional power draw amongst 3 remaining models, each should see a 40W increase).
  * Deactivate ``disconnect_battery_nodes`` and observe the warning statement (though it may be easier to miss with the debug printouts). **Confirm that the disconnection remains**.
  * Adjust the value of ``battery_nodes_to_disconnect`` and reapply the fault. **Confirm, if the number of disconnected nodes was higher than before, that the new number is reflected in the debug printouts. If the number of disconnected nodes is lower than before, confirm that no change in behavior occurs**.

## Test 2 (Modifying Active Models)
* Ensure ``active_models`` is set to 1 in ``system.cfg``.
* Open up a terminal and build & run the simulator in the OceanWATERS directory.
* Monitor the terminal and confirm only 1 model is running predictions. **Monitor the CPU usage of the simulation. ``ow_power_system`` should be using much less of the CPU**.
* Like the previous test, go to the ``Dynamic Reconfigure`` tab in the RQT window and navigate to the ``faults`` section. Use ``high_power_draw`` to apply an additional power load on the system.
  * **Confirm the single model only receives 1/4th the additional power draw from the fault such that its individual behavior is identical to if performance mode was off**.
  * Using the new battery disconnection fault, remove one or more models from the simulation and check the power draw. **Confirm the power draw is still affected by the disconnection fault with identical distribution behavior to that seen in Test 1**. The only difference should be that only 1 model is actually running at any given time, regardless of the number of disconnected nodes.

## Performance Test (for new reviewers)
This test is just to informally measure the CPU usage of these changes to the power system, and should require little input other than idling your computer:
* Navigate to ``ow_power_system/config/system.cfg`` and set ``active_models`` to 4.
* Build & run the simulator in the OceanWATERS directory under this OW-1196 branch. The world might affect performance one way or another, though I used the ``atacama`` world across all my tests (``roslaunch ow atacama_y1a.launch``).
* Let the simulation run idly for at least 15 minutes. Afterwards, record the average CPU load, the % of the CPU the ``ow_power_system`` process used, the number of cores in your setup, and your RAM size.
  * The average CPU load can be determined by opening up a 2nd terminal and running the ``uptime`` command, which will display the CPU load average for the past 1, 5, & 15 minutes. We're looking for the 15 minute average.
  * ``ow_power_system``'s CPU usage can be seen by running the ``top`` command in a 2nd terminal while the simulation is running. It can also be checked via System Monitor. Note that ``top`` will show CPU usage relative to a single core while System Monitor will show CPU usage relative to all cores (to my understanding), so the percentages will be very different.
  * The amount of RAM your setup has can be determined by going to Settings -> About.
  * The number of CPU cores you have can be seen by calling `nproc` in the terminal.
* Feel free to record any qualitative observations you might notice while the simulation is idling (e.g. computer heating up, fans getting faster, etc.).
* Repeat this one time with ``active_models`` set to ``2`` in ``system.cfg`` instead, letting it idle for 15 minutes again to get the new load average from ``uptime``.
* Report your observations as a comment to this PR.