### PR TITLE
Oceanwater 1095 failures messages communication

### DIFF
--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -50,7 +50,7 @@ private:
   void jointStatesFlagCb(const ow_faults_detection::JointStatesFlagConstPtr& msg);
   bool isFlagSet(uint joint, const std::vector<uint8_t>& flags);
 
-  void ArmFaultsInternalCb(const owl_msgs::ArmFaultsStatus::ConstPtr& msg);
+  void armFaultsInternalCb(const owl_msgs::ArmFaultsStatus::ConstPtr& msg);
   
   // Find an item in an std::vector or other find-able data structure, and
   // return its index. Return -1 if not found.
@@ -93,7 +93,7 @@ private:
   ros::Subscriber m_camera_raw_sub;
   ros::Subscriber m_power_soc_sub;
   ros::Subscriber m_power_temperature_sub;
-  ros::Subscriber arm_faults_internal_sub;
+  ros::Subscriber m_arm_faults_internal_sub;
 
   // faults bitflags
   uint64_t m_arm_faults_flags     = owl_msgs::ArmFaultsStatus::NONE;
@@ -106,7 +106,8 @@ private:
   std::vector<unsigned int> m_joint_state_indices;
   bool m_camera_data_pending = false;
   float m_last_soc = std::numeric_limits<float>::quiet_NaN();
-  int trajectory_error_flag = 0; // for arm planning error, msg published by ow_lander
+  // for arm planning error, msg published by ow_lander
+  uint64_t m_arm_faults_internal_flag = owl_msgs::ArmFaultsStatus::NONE;
 };
 
 #endif

--- a/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
+++ b/ow_faults_detection/include/ow_faults_detection/FaultDetector.h
@@ -49,6 +49,8 @@ private:
   // Arm
   void jointStatesFlagCb(const ow_faults_detection::JointStatesFlagConstPtr& msg);
   bool isFlagSet(uint joint, const std::vector<uint8_t>& flags);
+
+  void ArmFaultsInternalCb(const owl_msgs::ArmFaultsStatus::ConstPtr& msg);
   
   // Find an item in an std::vector or other find-able data structure, and
   // return its index. Return -1 if not found.
@@ -91,6 +93,7 @@ private:
   ros::Subscriber m_camera_raw_sub;
   ros::Subscriber m_power_soc_sub;
   ros::Subscriber m_power_temperature_sub;
+  ros::Subscriber arm_faults_internal_sub;
 
   // faults bitflags
   uint64_t m_arm_faults_flags     = owl_msgs::ArmFaultsStatus::NONE;
@@ -103,6 +106,7 @@ private:
   std::vector<unsigned int> m_joint_state_indices;
   bool m_camera_data_pending = false;
   float m_last_soc = std::numeric_limits<float>::quiet_NaN();
+  int trajectory_error_flag = 0; // for arm planning error, msg published by ow_lander
 };
 
 #endif

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -203,8 +203,8 @@ void FaultDetector::jointStatesFlagCb(const ow_faults_detection::JointStatesFlag
   }
 
   // update faults from ow_lander
-  uint64_t hardward_fault_bit = m_arm_faults_flags & ArmFaultsStatus::HARDWARE;
-  m_arm_faults_flags = (m_arm_faults_internal_flag & ~ArmFaultsStatus::HARDWARE) | hardward_fault_bit;
+  uint64_t hardware_fault_bit = m_arm_faults_flags & ArmFaultsStatus::HARDWARE;
+  m_arm_faults_flags = (m_arm_faults_internal_flag & ~ArmFaultsStatus::HARDWARE) | hardware_fault_bit;
 
   // publish updated faults messages
   publishFaultsMessage(m_arm_faults_msg_pub, ArmFaultsStatus(), m_arm_faults_flags);

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -148,7 +148,6 @@ bool FaultDetector::isFlagSet(uint joint, const std::vector<uint8_t>& flags)
 void FaultDetector::ArmFaultsInternalCb(const owl_msgs::ArmFaultsStatus::ConstPtr& msg)
 {
   //The actual publish on arm faults status intergrate in jointStatesFlagCb
-  ROS_INFO("arm faults internal error messages receieved");
   trajectory_error_flag = msg->value;
 }
 
@@ -196,11 +195,15 @@ void FaultDetector::jointStatesFlagCb(const ow_faults_detection::JointStatesFlag
   }
 
   // update system faults
-  if (ArmFaultsStatus::NONE == m_arm_faults_flags) {
-    m_system_faults_flags &= ~SystemFaultsStatus::ARM_EXECUTION_ERROR;
-  } else {
-    m_system_faults_flags |= SystemFaultsStatus::ARM_EXECUTION_ERROR;
-  }
+
+  // TODO: The comment out codes were not sure if necessary, but keep these  for now for
+  // reference
+
+  // if (ArmFaultsStatus::NONE == m_arm_faults_flags) {
+  //   m_system_faults_flags &= ~SystemFaultsStatus::ARM_EXECUTION_ERROR;
+  // } else {
+  //   m_system_faults_flags |= SystemFaultsStatus::ARM_EXECUTION_ERROR;
+  // }
   if (PanTiltFaultsStatus::NONE == m_antenna_faults_flags) {
     m_system_faults_flags &= ~SystemFaultsStatus::PAN_TILT_EXECUTION_ERROR;
   } else {
@@ -211,8 +214,10 @@ void FaultDetector::jointStatesFlagCb(const ow_faults_detection::JointStatesFlag
   // TODO: Currently only trajectory_generation faults under consideration
   if (trajectory_error_flag == ArmFaultsStatus::TRAJECTORY_GENERATION){
     m_arm_faults_flags |= ArmFaultsStatus::TRAJECTORY_GENERATION;
+    m_system_faults_flags |= SystemFaultsStatus::ARM_GOAL_ERROR;
   } else {
     m_arm_faults_flags &= ~ArmFaultsStatus::TRAJECTORY_GENERATION;
+    m_system_faults_flags &= ~SystemFaultsStatus::ARM_GOAL_ERROR;
   }
   // publish updated faults messages
   publishFaultsMessage(m_arm_faults_msg_pub, ArmFaultsStatus(), m_arm_faults_flags);

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -147,7 +147,8 @@ bool FaultDetector::isFlagSet(uint joint, const std::vector<uint8_t>& flags)
 
 void FaultDetector::armFaultsInternalCb(const owl_msgs::ArmFaultsStatus::ConstPtr& msg)
 {
-  //The actual publish on arm faults status intergrate in jointStatesFlagCb
+  //arm_faults_internal was published from ow_lander/action.py
+  //m_arm_faults_internal_flag go to jointStatesFlagCb and publishes an updated message to '/arm_faults_status'.
   m_arm_faults_internal_flag = msg->value;
 }
 
@@ -195,7 +196,6 @@ void FaultDetector::jointStatesFlagCb(const ow_faults_detection::JointStatesFlag
   }
 
   // update system faults
-
   if (PanTiltFaultsStatus::NONE == m_antenna_faults_flags) {
     m_system_faults_flags &= ~SystemFaultsStatus::PAN_TILT_EXECUTION_ERROR;
   } else {

--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -18,9 +18,9 @@ FaultDetector::FaultDetector(ros::NodeHandle& nh)
 {
   srand (static_cast <unsigned> (time(0)));
   // arm and antenna
-  arm_faults_internal_sub = nh.subscribe("/arm_faults_internal", 
+  m_arm_faults_internal_sub = nh.subscribe("/arm_faults_internal", 
                                           10, 
-                                          &FaultDetector::ArmFaultsInternalCb,
+                                          &FaultDetector::armFaultsInternalCb,
                                           this);
   m_joint_states_sub = nh.subscribe( "/flags/joint_states",
                                       10,
@@ -145,10 +145,10 @@ bool FaultDetector::isFlagSet(uint joint, const std::vector<uint8_t>& flags)
   return false;
 }
 
-void FaultDetector::ArmFaultsInternalCb(const owl_msgs::ArmFaultsStatus::ConstPtr& msg)
+void FaultDetector::armFaultsInternalCb(const owl_msgs::ArmFaultsStatus::ConstPtr& msg)
 {
   //The actual publish on arm faults status intergrate in jointStatesFlagCb
-  trajectory_error_flag = msg->value;
+  m_arm_faults_internal_flag = msg->value;
 }
 
 void FaultDetector::jointStatesFlagCb(const ow_faults_detection::JointStatesFlagConstPtr& msg)
@@ -196,14 +196,6 @@ void FaultDetector::jointStatesFlagCb(const ow_faults_detection::JointStatesFlag
 
   // update system faults
 
-  // TODO: The comment out codes were not sure if necessary, but keep these  for now for
-  // reference
-
-  // if (ArmFaultsStatus::NONE == m_arm_faults_flags) {
-  //   m_system_faults_flags &= ~SystemFaultsStatus::ARM_EXECUTION_ERROR;
-  // } else {
-  //   m_system_faults_flags |= SystemFaultsStatus::ARM_EXECUTION_ERROR;
-  // }
   if (PanTiltFaultsStatus::NONE == m_antenna_faults_flags) {
     m_system_faults_flags &= ~SystemFaultsStatus::PAN_TILT_EXECUTION_ERROR;
   } else {
@@ -211,14 +203,9 @@ void FaultDetector::jointStatesFlagCb(const ow_faults_detection::JointStatesFlag
   }
 
   // update faults from ow_lander
-  // TODO: Currently only trajectory_generation faults under consideration
-  if (trajectory_error_flag == ArmFaultsStatus::TRAJECTORY_GENERATION){
-    m_arm_faults_flags |= ArmFaultsStatus::TRAJECTORY_GENERATION;
-    m_system_faults_flags |= SystemFaultsStatus::ARM_GOAL_ERROR;
-  } else {
-    m_arm_faults_flags &= ~ArmFaultsStatus::TRAJECTORY_GENERATION;
-    m_system_faults_flags &= ~SystemFaultsStatus::ARM_GOAL_ERROR;
-  }
+  uint64_t hardward_fault_bit = m_arm_faults_flags & ArmFaultsStatus::HARDWARE;
+  m_arm_faults_flags = (m_arm_faults_internal_flag & ~ArmFaultsStatus::HARDWARE) | hardward_fault_bit;
+
   // publish updated faults messages
   publishFaultsMessage(m_arm_faults_msg_pub, ArmFaultsStatus(), m_arm_faults_flags);
   publishFaultsMessage(m_antenna_faults_msg_pub, PanTiltFaultsStatus(), m_antenna_faults_flags);

--- a/ow_lander/src/ow_lander/faults_interface.py
+++ b/ow_lander/src/ow_lander/faults_interface.py
@@ -1,0 +1,33 @@
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+"""Defines a fault messages interface to the OceanWATERS simulator. Integrates
+communication mechanism between ow_faults_detection package and the ow_lander package.
+"""
+
+import rospy
+from ow_lander.common import Singleton
+from owl_msgs.msg import ArmFaultsStatus
+
+class FaultsInterFace(metaclass = Singleton):
+  """Communication not directly publish the arm_faults_status, instead, publish the arm_faults_internal
+  and let faultdetector handle the messages.
+  """
+  def __init__(self):
+    self.arm_faults_status = ArmFaultsStatus.NONE
+    self._arm_faults_internal_pub = rospy.Publisher('arm_faults_internal', 
+                                                   ArmFaultsStatus, 
+                                                   queue_size = 10, 
+                                                   latch = True)
+
+  def set_arm_faults_flag(self, flags):
+    self.arm_faults_status |= flags
+    self.publish()
+
+  def reset_arm_faults_flags(self):
+    self.arm_faults_status = ArmFaultsStatus.NONE
+    self.publish()
+
+  def publish(self):
+    self._arm_faults_internal_pub.publish(value = self.arm_faults_status)

--- a/ow_lander/src/ow_lander/faults_interface.py
+++ b/ow_lander/src/ow_lander/faults_interface.py
@@ -10,24 +10,24 @@ import rospy
 from ow_lander.common import Singleton
 from owl_msgs.msg import ArmFaultsStatus
 
-class FaultsInterFace(metaclass = Singleton):
+class FaultsInterface(metaclass = Singleton):
   """Communication not directly publish the arm_faults_status, instead, publish the arm_faults_internal
-  and let faultdetector handle the messages.
+  and let ow_fault_detector handle the messages.
   """
   def __init__(self):
-    self.arm_faults_status = ArmFaultsStatus.NONE
+    self._arm_faults_status = ArmFaultsStatus.NONE
     self._arm_faults_internal_pub = rospy.Publisher('arm_faults_internal', 
                                                    ArmFaultsStatus, 
                                                    queue_size = 10, 
                                                    latch = True)
 
   def set_arm_faults_flag(self, flags):
-    self.arm_faults_status |= flags
-    self.publish()
+    self._arm_faults_status |= flags
+    self._publish()
 
   def reset_arm_faults_flags(self):
-    self.arm_faults_status = ArmFaultsStatus.NONE
-    self.publish()
+    self._arm_faults_status = ArmFaultsStatus.NONE
+    self._publish()
 
-  def publish(self):
-    self._arm_faults_internal_pub.publish(value = self.arm_faults_status)
+  def _publish(self):
+    self._arm_faults_internal_pub.publish(value = self._arm_faults_status)

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -16,6 +16,7 @@ from std_msgs.msg import Float64
 from sensor_msgs.msg import JointState
 from geometry_msgs.msg import Pose, PoseStamped, PointStamped
 from tf2_geometry_msgs import do_transform_pose
+from owl_msgs.msg import ArmFaultsStatus
 
 from ow_lander import constants
 from ow_lander import math3d
@@ -24,7 +25,7 @@ from ow_lander.exception import (ArmPlanningError, ArmExecutionError,
                                  AntennaPlanningError, AntennaExecutionError)
 from ow_lander.subscribers import LinkStateSubscriber, JointAnglesSubscriber
 from ow_lander.arm_interface import OWArmInterface
-from ow_lander.faults_interface import FaultsInterFace
+from ow_lander.faults_interface import FaultsInterface
 from ow_lander.frame_transformer import FrameTransformer
 from ow_lander.trajectory_sequence import TrajectorySequence
 
@@ -41,7 +42,7 @@ class ArmActionMixin:
     moveit_commander.roscpp_initialize(sys.argv)
     # initialize/reference
     self._arm = OWArmInterface()
-    self._arm_faults = FaultsInterFace()
+    self._arm_faults = FaultsInterface()
     # initialize interface for querying scoop tip position
     self._arm_tip_monitor = LinkStateSubscriber('lander::l_scoop_tip')
     self._start_server()
@@ -51,16 +52,21 @@ class ArmTrajectoryMixin(ArmActionMixin, ABC):
 
   def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)
-
   def execute_action(self, goal):
+    # Reset faults messages before the arm start moving
+    self._arm_faults.reset_arm_faults_flags()
     try:
       self._arm.checkout_arm(self.name)
       self._arm.execute_arm_trajectory(
         self.plan_trajectory(goal),
         action_feedback_cb = self.publish_feedback_cb
       )
-    except (ArmExecutionError, ArmPlanningError) as err:
+    except ArmExecutionError as err:
       self._arm.checkin_arm(self.name)
+      self._set_aborted(str(err))
+    except ArmPlanningError as err:
+      self._arm.checkin_arm(self.name)
+      self._arm_faults.set_arm_faults_flag(ArmFaultsStatus.TRAJECTORY_GENERATION)
       self._set_aborted(str(err))
     else:
       self._arm.checkin_arm(self.name)
@@ -91,14 +97,21 @@ class GrinderTrajectoryMixin(ArmTrajectoryMixin):
     self._arm.checkin_arm(self.name)
 
   def execute_action(self, goal):
+    # Reset faults messages before the arm start moving
+    self._arm_faults.reset_arm_faults_flags()
     try:
       self._arm.checkout_arm(self.name)
       self._arm.switch_to_grinder_controller()
       plan = self.plan_trajectory(goal)
       self._arm.execute_arm_trajectory(plan)
-    except (ArmExecutionError, ArmPlanningError) as err:
+    except ArmExecutionError as err:
       self._cleanup()
       self._set_aborted(str(err))
+    except ArmPlanningError as err:
+      self._cleanup()
+      self._arm_faults.set_arm_faults_flag(ArmFaultsStatus.TRAJECTORY_GENERATION)
+      self._set_aborted(str(err))
+      
     else:
       self._cleanup()
       self._set_succeeded(f"{self.name} trajectory succeeded")
@@ -124,6 +137,8 @@ class ModifyJointValuesMixin(ArmActionMixin, ABC):
       angles=self._arm_joints_monitor.get_joint_positions())
 
   def execute_action(self, goal):
+    # Reset faults messages before the arm start moving
+    self._arm_faults.reset_arm_faults_flags()
     try:
       self._arm.checkout_arm(self.name)
       new_positions = self.modify_joint_positions(goal)
@@ -131,8 +146,13 @@ class ModifyJointValuesMixin(ArmActionMixin, ABC):
       sequence.plan_to_joint_positions(new_positions)
       self._arm.execute_arm_trajectory(sequence.merge(),
         action_feedback_cb=self.publish_feedback_cb)
-    except (ArmPlanningError, ArmExecutionError) as err:
+    except ArmExecutionError as err:
       self._arm.checkin_arm(self.name)
+      self._set_aborted(str(err),
+        final_angles=self._arm_joints_monitor.get_joint_positions())
+    except ArmPlanningError  as err:
+      self._arm.checkin_arm(self.name)
+      self._arm_faults.set_arm_faults_flag(ArmFaultsStatus.TRAJECTORY_GENERATION)
       self._set_aborted(str(err),
         final_angles=self._arm_joints_monitor.get_joint_positions())
     else:

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -24,6 +24,7 @@ from ow_lander.exception import (ArmPlanningError, ArmExecutionError,
                                  AntennaPlanningError, AntennaExecutionError)
 from ow_lander.subscribers import LinkStateSubscriber, JointAnglesSubscriber
 from ow_lander.arm_interface import OWArmInterface
+from ow_lander.faults_interface import FaultsInterFace
 from ow_lander.frame_transformer import FrameTransformer
 from ow_lander.trajectory_sequence import TrajectorySequence
 
@@ -40,6 +41,7 @@ class ArmActionMixin:
     moveit_commander.roscpp_initialize(sys.argv)
     # initialize/reference
     self._arm = OWArmInterface()
+    self._arm_faults = FaultsInterFace()
     # initialize interface for querying scoop tip position
     self._arm_tip_monitor = LinkStateSubscriber('lander::l_scoop_tip')
     self._start_server()


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️ | [OCEANWATER-1195](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1195) |


## Summary of Changes
The current failure messages relayed from `ow_lander` to `PLEXIL` are still incomplete. This branch primarily aims to establish a robust communication mechanism between the `ow_faults_detection `package and the `ow_lander` package.

Previously, the Arm action servers treated both `ArmExecutionError` and `ArmPlanningError` in the same manner. Furthermore, there was no linkage with the `ow_faults_detection` package. 

This PR introduces a communication method. Here's an overview of the design (Note: Changes currently apply to only `ArmMoveCartesianGurard` and `ArmMoveCartesian`):

* The Arm action can produce outcomes like `ArmExecutionError`, `ArmPlanningError`, or successful action. When ROS encounters an `ArmPlanningError`, `action.py` will publish an error flag to the ROS topic `arm_faults_interal`.
* `FaultsDetector` continuously publishes `ArmFaultsStatus` and `SystemFaultsStatus` since the simulator's initiation. When it detects an error flag on the topic `arm_faults_internal`, it updates the flags on both `arm_faults_status` and `system_faults_status`.
* In the event of an `arm_execution_error`, the arm will freeze, preventing subsequent action calls. However, if only `arm_goal_error` is detected and the next action is valid, the arm process and updates the error flag on both `arm_faults_status` and `system_faults_status`.


## Test
We need four terminals for testing:

1. `roslaunch ow europa_terminator_workspace.launch`
2. After the simulator fully starts, this can tell once the ros info shows `Ready to take commands for planning group arm.`. In the second terminal run the following command `rostopic echo /arm_faults_status`
3. To check the system faults messages, input the following command in the third terminal `rostopic echo /system_faults_status`
4. The fourth terminal, we want to call the arm actions. `rosrun ow_lander arm_move_cartesian_guarded.py`

* The defaults parameter of `rosrun ow_lander arm_move_cartesian_guarded.py` is invalid so we expected to see the following logs: ![Screenshot from 2023-08-18 15-35-53](https://github.com/nasa/ow_simulator/assets/124640235/d461cb99-5f57-4e8a-b0d5-81d8080e2e89)
The action returns an error because the input provides an invalid location, hence we see both `rostopic echo /arm_faults_status` and `rostopic echo /system_faults_status` have a value equal to 2, which represent `TRAJECTORY_GENERATION` error in `/arm_faults_status` and `ARM_GOAL_ERROR` in `/system_faults_status`.
* For the next action run the following command with a valid location `rosrun ow_lander arm_move_cartesian_guarded.py -x 1.86 -y -0.63 -z 0.045 -q 1 0.005 0.053 0.029`
We should expect to see the arm start moving in the gazebo desktop, and the expectation logs as below:
![Screenshot from 2023-08-18 15-50-11](https://github.com/nasa/ow_simulator/assets/124640235/2b94d3e5-ad78-4501-9f9c-af71402f6ad9)
And both ros topics should change the value back to 0, meaning no error occurred.



