### PR TITLE
Option to disable power system for performance

### DIFF
--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -1,3 +1,10 @@
+# IMPORTANT: If disabled, the power system will not run predictions
+# 	     or use GSAP. All power publications will remain static.
+#	     This maximizes performance for those not looking for
+#	     power predictions, but the power system will not react
+#	     to anything as a result.
+enable_power_system: true
+
 # configuration
 efficiency: 0.9			            # a value 0 - 1
 

--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -3,7 +3,7 @@
 #	     This maximizes performance for those not looking for
 #	     power predictions, but the power system will not react
 #	     to anything as a result.
-enable_power_system: true
+enable_power_system: false
 
 # configuration
 efficiency: 0.9			            # a value 0 - 1

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -57,6 +57,7 @@ public:
   PowerSystemNode& operator=(const PowerSystemNode&) = delete;
   void initAndRun();
 private:
+  void runDisabledLoop();
   bool initModels();
   void initTopics();
   void injectCustomFault();
@@ -89,6 +90,10 @@ private:
 
 
   // system.cfg variables:
+
+  // Whether or not the power system is active to begin with. Can be disabled
+  // to maximize performance for those who do not need battery predictions.
+  bool m_enable_power_system;
 
   // The number of currently simulated models. Default 1, but can be modified
   // mid-simulation by intra-battery faults (or set to a different starting

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -42,6 +42,7 @@ static void printPrognoserOutputs(double rul,
                                   int index);
 static void printMechanicalPower(double raw, double mean, int window);
 static void printTopics(double rul, double soc, double tmp);
+static void printFaultDisabledWarning();
 
 /*
  * The primary function with the loop that controls each cycle.
@@ -74,6 +75,7 @@ void PowerSystemNode::initAndRun()
     }
     // If print_debug was false, then all flags remain false as initialized.
 
+    m_enable_power_system = (system_config.getString("enable_power_system") == TRUE);
     m_active_models = system_config.getInt32("active_models");
     m_max_horizon_secs = system_config.getInt32("max_horizon");
     m_num_samples = system_config.getInt32("num_samples");
@@ -120,6 +122,15 @@ void PowerSystemNode::initAndRun()
                             );
 
   initTopics();
+
+  // If the power system is fully disabled, swap to a basic loop instead.
+  if (!m_enable_power_system)
+  {
+    ROS_INFO_STREAM("Power system disabled via system.cfg! Node will publish "
+                    << "static values and ignore faults.");
+    runDisabledLoop();
+    return;
+  }
 
   // Initialize EoD_events and previous_times.
   for (int i = 0; i < NUM_MODELS; i++)
@@ -382,6 +393,80 @@ void PowerSystemNode::initAndRun()
   spinner.stop();
 }
 
+/*
+ * Used if the power system is disabled. Simply publishes static values
+ * without using GSAP prognosers or reacting to faults. Mechanical power is
+ * still calculated using jointStatesCb for publication.
+ */
+void PowerSystemNode::runDisabledLoop()
+{
+  // This rate object is used to sync the cycles up to the provided Hz.
+  // NOTE: If the cycle takes longer than the provided Hz, nothing bad will
+  //       necessarily occur, but the simulation will be out of sync with real
+  //       time. Should essentially never happen with the disabled version of
+  //       the loop.
+  ros::Rate rate(m_loop_rate_hz);
+
+  // Start the asynchronous spinner, which will call jointStatesCb as the
+  // joint_states topic is published (50Hz).
+  ros::AsyncSpinner spinner(m_spinner_threads);
+
+  try
+  {
+    spinner.start();
+  }
+  catch(const std::runtime_error& e)
+  {
+    ROS_ERROR_STREAM("OW_POWER_SYSTEM ERROR: Encountered a std::runtime_error"
+                    << " while starting up asynchronous ROS spinner threads!");
+    return;
+  }
+
+  bool skip_first_loop = true;
+
+  while (ros::ok())
+  {
+    // Create the published messages and set them to their ideal states.
+    owl_msgs::BatteryRemainingUsefulLife rul_msg;
+    owl_msgs::BatteryStateOfCharge soc_msg;
+    owl_msgs::BatteryTemperature tmp_msg;
+
+    rul_msg.value = m_max_horizon_secs;   // Will always be the max possible RUL
+    soc_msg.value = 1.0;                  // Hardcoded 100% battery charge
+    tmp_msg.value = 20;                   // Hardcoded 20C battery temperature
+
+    // Apply the most recent timestamp to each message header.
+    auto timestamp = ros::Time::now();
+    rul_msg.header.stamp = timestamp;
+    soc_msg.header.stamp = timestamp;
+    tmp_msg.header.stamp = timestamp;
+
+    // Publish the data.
+    m_state_of_charge_pub.publish(soc_msg);
+    m_remaining_useful_life_pub.publish(rul_msg);
+    m_battery_temperature_pub.publish(tmp_msg);
+
+    // While faults cannot be injected, this call is simply to allow the system
+    // to warn the user if they attempt fault activation in this disabled state.
+    // Skip on the first loop to prevent messages from being printed during
+    // startup.
+    if (skip_first_loop)
+    {
+      skip_first_loop = false;
+    }
+    else
+    {
+      injectFaults();
+    }
+
+    // Sleep for any remaining time in the loop that would cause it to
+    // complete before the set rate.
+    rate.sleep();
+  }
+
+  spinner.stop();
+}
+
 /* 
  * Initializes every PrognoserInputHandler by calling their respective Initialize()
  * functions.
@@ -450,6 +535,13 @@ void PowerSystemNode::injectCustomFault()
 
   if (!m_custom_power_fault_activated && fault_enabled)
   {
+    // Block the fault if the power system is disabled.
+    if (!m_enable_power_system)
+    {
+      printFaultDisabledWarning();
+      return;
+    }
+
     // Multiple potential points of failure, so alert user the process has started.
     ROS_INFO_STREAM("Attempting custom fault activation...");
 
@@ -569,6 +661,13 @@ void PowerSystemNode::injectFault (const std::string& fault_name)
     // Check if the fault has switched.
     if (!m_high_power_draw_activated && fault_enabled)
     {
+      // Block the fault if the power system is disabled.
+      if (!m_enable_power_system)
+      {
+        printFaultDisabledWarning();
+        return;
+      }
+
       ROS_INFO_STREAM(fault_name << " activated!");
       m_high_power_draw_activated = true;
     }
@@ -598,6 +697,13 @@ void PowerSystemNode::injectFault (const std::string& fault_name)
     // Check if the fault has switched.
     if (!m_disconnect_battery_nodes_fault_activated && fault_enabled)
     {
+      // Block the fault if the power system is disabled.
+      if (!m_enable_power_system)
+      {
+        printFaultDisabledWarning();
+        return;
+      }
+
       ROS_INFO_STREAM(fault_name << " activated!");
       m_disconnect_battery_nodes_fault_activated = true;
     }
@@ -945,4 +1051,15 @@ static void printTopics(double rul, double soc, double tmp)
   ROS_INFO_STREAM("min_rul: " << std::to_string(rul) <<
                   ", min_soc: " << std::to_string(soc) <<
                   ", max_tmp: " << std::to_string(tmp));
+}
+
+/*
+ * Prints a warning to the user should they attempt to inject a fault while
+ * the power system is disabled. Only prints once.
+ */
+static void printFaultDisabledWarning()
+{
+  ROS_WARN_STREAM_ONCE("Faults cannot be injected while the power system "
+                    << "is disabled. Modify ow_power_system/config/system.cfg "
+                    << "and restart the simulator to re-enable.");
 }

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -126,7 +126,7 @@ void PowerSystemNode::initAndRun()
   // If the power system is fully disabled, swap to a basic loop instead.
   if (!m_enable_power_system)
   {
-    ROS_INFO_STREAM("Power system disabled via system.cfg! Node will publish "
+    ROS_WARN_STREAM("Power system disabled via system.cfg! Node will publish "
                     << "static values and ignore faults.");
     runDisabledLoop();
     return;
@@ -431,9 +431,9 @@ void PowerSystemNode::runDisabledLoop()
     owl_msgs::BatteryStateOfCharge soc_msg;
     owl_msgs::BatteryTemperature tmp_msg;
 
-    rul_msg.value = m_max_horizon_secs;   // Will always be the max possible RUL
-    soc_msg.value = 1.0;                  // Hardcoded 100% battery charge
-    tmp_msg.value = 20;                   // Hardcoded 20C battery temperature
+    rul_msg.value = m_max_horizon_secs;   // Will always publish the initial
+    soc_msg.value = m_initial_soc;        // values
+    tmp_msg.value = m_initial_temperature;
 
     // Apply the most recent timestamp to each message header.
     auto timestamp = ros::Time::now();
@@ -1059,7 +1059,7 @@ static void printTopics(double rul, double soc, double tmp)
  */
 static void printFaultDisabledWarning()
 {
-  ROS_WARN_STREAM_ONCE("Faults cannot be injected while the power system "
+  ROS_WARN_STREAM_THROTTLE(60, "Faults cannot be injected while the power system "
                     << "is disabled. Modify ow_power_system/config/system.cfg "
                     << "and restart the simulator to re-enable.");
 }


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | n/a |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1203](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1203) |
| Github :octocat:  | # |

While it's possible to completely disable all functions within the power system, the vast majority of performance issues arise from using GSAP's prognosers for battery predictions. This PR allows for the removal of all prediction work, while still maintaining publications to external components so as to prevent future issues if said external components rely on these publications. Of course, these publications will not be accurate of a real battery, but the published status should be ideal for preventing any errors if the user is not actively utilizing the power system's new modeling capabilities.

## Summary of Changes
* A new flag has been added to ``ow_power_system/config/system.cfg``: ``enable_power_system``, set to ``true`` by default. If ``false``, the power system skips initialization of the vast majority of its objects and instead runs a minimal loop that does not manage or trigger any predictions. Under this case, the typical battery predictions of RUL/SoC/temperature remain at static values, ignoring any attempted modifications from faults or lander actions. Mechanical power is calculated as normal but not applied to the system.
  * If the user tries to inject a fault while the power system is running in this disabled state, a warning will be printed once to the terminal.
  * Debug printouts will *not* work, since the power system is not running the relevant functions when it is in the minimal disabled state.

## Test
* In ``system.cfg``, set ``enable_power_system`` to ``false``.
* Open up 2 terminals.
  * In terminal 1, build & run the simulator in the OceanWATERS directory. The world shouldn't matter, though I used the ``atacama`` world (``roslaunch ow atacama_y1a.launch``).
  * In terminal 2, check the various rostopics relating to the power system:
    * ``rostopic echo /battery_remaining_useful_life``
    * ``rostopic echo /battery_state_of_charge``
    * ``rostopic echo /battery_temperature``
    * ``rostopic echo mechanical_power/raw``
    * ``rostopic echo mechanical_power/average``
  * **Confirm the expected behavior for these 5 published topics**:
    * RUL, SoC, and temperature should all remain constant. RUL should be the maximum horizon value, SoC should stay at 100% (``1.0``), and temperature should sit at 20C. These should publish at the same rate set in ``loop_rate`` in ``system.cfg``.
    * Mechanical power should be calculated as per usual and published at the same rate as the ``/joint_states`` topic (typically 50Hz).
  * Navigate to the ``Dynamic Reconfigure`` tab on the bottom of the simulation's RQT window, and from there, to the ``faults`` section.
  * **Attempt to inject various power faults. The first time you do so, the terminal should print a warning that the faults will not work.**
