### PR TITLE
Oceanwater 1099 plan optimizaion for consistency

### DIFF
--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -520,6 +520,7 @@ class ArmMoveCartesianServer(mixins.FrameMixin, mixins.ArmActionMixin,
     self._publish_feedback(pose=self._arm_tip_monitor.get_link_pose())
 
   def execute_action(self, goal):
+    self._arm.move_group_scoop.set_planner_id('RRTConnect')
     try:
       intended_pose_stamped = self.get_intended_pose(goal.frame, goal.relative,
                                                      goal.pose)

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -520,7 +520,6 @@ class ArmMoveCartesianServer(mixins.FrameMixin, mixins.ArmActionMixin,
     self._publish_feedback(pose=self._arm_tip_monitor.get_link_pose())
 
   def execute_action(self, goal):
-    self._arm.move_group_scoop.set_planner_id('RRTConnect')
     try:
       intended_pose_stamped = self.get_intended_pose(goal.frame, goal.relative,
                                                      goal.pose)

--- a/ow_sim_tests/scripts/test_arm_consistency.py
+++ b/ow_sim_tests/scripts/test_arm_consistency.py
@@ -57,6 +57,7 @@ def _plot_helper(trajectories):
   ax.set_zlabel('Z')
   plt.title('3D Trajectories')
   plt.legend()
+  # TODO change the saving location in your local directory
   fig.savefig('/home/honghao/Documents/3D_trajectories_RRTConnect_testing.png')
   
 class TestArmConsistency(unittest.TestCase):
@@ -129,6 +130,7 @@ class TestArmConsistency(unittest.TestCase):
     outlier_indices, threshold = _dtw_helper(trajectories, num_runs)
     total_outliers = len(outlier_indices)
     try:
+      # TODO change the saving location in your local directory
       with open('/home/honghao/Documents/test_results_RRTConnect_testing.txt', 'w') as f:
         f.write("Total number of runs: {}\n".format(num_runs))
         f.write("Outliers found at runs: {}\n".format(outlier_indices))
@@ -144,6 +146,7 @@ class TestArmConsistency(unittest.TestCase):
     result = pd.concat(dfs, axis = 1)
 
     try:
+      # TODO change the saving location in your local directory
       result.to_csv('/home/honghao/Documents/all_trajectories_RRTConnect_testing.csv')
       print("File saved successfully")
     except Exception as e:

--- a/ow_sim_tests/scripts/test_arm_consistency.py
+++ b/ow_sim_tests/scripts/test_arm_consistency.py
@@ -26,7 +26,7 @@ TEST_NAME = 'arm_consistency'
 common_dir = os.path.expanduser('~/Documents')
 fig_3d_path = os.path.join(common_dir, '3D_trajectories_RRTConnect_testing.png')
 result_path = os.path.join(common_dir, 'test_results_RRTConnect_testing.txt')
-data_path = os.path.join(common_dir, 'all_trajectories_RRTConnect_testing.csv.txt')
+data_path = os.path.join(common_dir, 'all_trajectories_RRTConnect_testing.csv')
 roslib.load_manifest(PKG)
 
 def _dtw_helper(trajectories, runs):

--- a/ow_sim_tests/scripts/test_arm_consistency.py
+++ b/ow_sim_tests/scripts/test_arm_consistency.py
@@ -62,7 +62,6 @@ def _plot_helper(trajectories):
   ax.set_zlabel('Z')
   plt.title('3D Trajectories')
   plt.legend()
-  # TODO change the saving location in your local directory
   fig.savefig(fig_3d_path)
   
 class TestArmConsistency(unittest.TestCase):
@@ -135,7 +134,6 @@ class TestArmConsistency(unittest.TestCase):
     outlier_indices, threshold = _dtw_helper(trajectories, num_runs)
     total_outliers = len(outlier_indices)
     try:
-      # TODO change the saving location in your local directory
       with open(result_path, 'w') as f:
         f.write("Total number of runs: {}\n".format(num_runs))
         f.write("Outliers found at runs: {}\n".format(outlier_indices))
@@ -151,7 +149,6 @@ class TestArmConsistency(unittest.TestCase):
     result = pd.concat(dfs, axis = 1)
 
     try:
-      # TODO change the saving location in your local directory
       result.to_csv(data_path)
       print("File saved successfully")
     except Exception as e:

--- a/ow_sim_tests/scripts/test_arm_consistency.py
+++ b/ow_sim_tests/scripts/test_arm_consistency.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+
+# The Notices and Disclaimers for Ocean Worlds Autonomy Testbed for Exploration
+# Research and Simulation can be found in README.md in the root directory of
+# this repository.
+
+import rospy
+import actionlib
+import pandas as pd
+import tf2_ros
+import roslib
+import unittest
+import owl_msgs.msg
+import numpy as np
+import random
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
+from geometry_msgs.msg import Pose, Quaternion
+from action_testing import *
+from fastdtw import fastdtw
+from scipy.spatial.distance import euclidean
+
+PKG = 'ow_sim_tests'
+TEST_NAME = 'arm_consistency'
+roslib.load_manifest(PKG)
+
+def _dtw_helper(trajectories, runs):
+  baseline_index = 0
+
+  threshold = 10
+
+  while not rospy.is_shutdown():
+    baseline_trajectory = trajectories[baseline_index]
+    outlier_indices = []
+    for i, traj in enumerate(trajectories[1:]):
+      distance, _ = fastdtw(baseline_trajectory, traj, dist = euclidean)
+      if distance > threshold:
+        outlier_indices.append(i+1)
+    if len(outlier_indices) >= (runs / 2):
+      baseline_index += 1
+    else:
+      break
+      
+  return outlier_indices, threshold
+
+def _plot_helper(trajectories):
+  fig = plt.figure()
+  ax = fig.add_subplot(111, projection='3d')
+  
+  for i, traj in enumerate(trajectories):
+    traj = np.array(traj)
+    xs, ys, zs = traj[:, 0], traj[:, 1], traj[:, 2]
+    ax.plot(xs, ys, zs)
+
+  ax.set_xlabel('X')
+  ax.set_ylabel('Y')
+  ax.set_zlabel('Z')
+  plt.title('3D Trajectories')
+  plt.legend()
+  fig.savefig('/home/honghao/Documents/3D_trajectories_RRTConnect_testing.png')
+  
+class TestArmConsistency(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    rospy.init_node("arm_unstow_test")
+
+    set_ignore_action_checks(True)
+    # proceed with test only when ros clock has been initialized
+    
+    random.seed(42)
+    cls.tfBuffer = tf2_ros.Buffer()
+    cls.listener = tf2_ros.TransformListener(cls.tfBuffer)
+    cls.client_unstow = actionlib.SimpleActionClient('ArmUnstow', owl_msgs.msg.ArmUnstowAction)
+    cls.client_stow = actionlib.SimpleActionClient('ArmStow', owl_msgs.msg.ArmStowAction)
+    cls.client_arm_move_cartesian = actionlib.SimpleActionClient('ArmMoveCartesian', 
+                                                                 owl_msgs.msg.ArmMoveCartesianAction)
+    cls.client_unstow.wait_for_server(timeout = rospy.Duration(50))
+    cls.client_stow.wait_for_server(timeout = rospy.Duration(50))
+    cls.client_arm_move_cartesian.wait_for_server(timeout=rospy.Duration(50))
+
+    while rospy.get_time() == 0:
+      rospy.sleep(0.1)
+
+  def test_01_multiple_runs(self):
+    num_runs = 10
+    trajectories = []
+    goal_unstow = owl_msgs.msg.ArmUnstowGoal()
+    goal_arm_move = owl_msgs.msg.ArmMoveCartesianGoal(
+        frame = 0,
+        relative = False,
+        pose= Pose(
+          position = Point(1.166, 0.356, 0.588),
+          orientation = Quaternion(-0.254, 0.727, -0.456, 0.446)
+        )
+    )
+    self.client_unstow.send_goal(goal_unstow)
+    self.client_unstow.wait_for_result()
+    for i in range(num_runs):
+      rospy.sleep(0.1)
+
+      self.client_arm_move_cartesian.send_goal(goal_arm_move)
+
+      trajectory = []
+      rate = rospy.Rate(10.0)
+      start_time = rospy.Time.now()
+
+      while not self.client_arm_move_cartesian.wait_for_result(rospy.Duration(0.1)):
+        try:
+          trans = self.tfBuffer.lookup_transform('base_link', 'l_scoop_tip',rospy.Time(0))
+          print('x location', trans.transform.translation.x)
+          trajectory.append([ trans.transform.translation.x, 
+                              trans.transform.translation.y, 
+                              trans.transform.translation.z])
+        except (tf2_ros.LookupException, 
+                tf2_ros.ConnectivityException, 
+                tf2_ros.ExtrapolationException):
+              print('Could not get transform')
+              continue
+        rate.sleep()
+
+      rospy.sleep(0.1)
+      self.client_unstow.send_goal(goal_unstow)
+      self.client_unstow.wait_for_result()
+  
+      trajectories.append(trajectory)
+
+    # Using Dynamic Time Warping (DTW) to find the outlier trajectories
+    outlier_indices, threshold = _dtw_helper(trajectories, num_runs)
+    total_outliers = len(outlier_indices)
+    try:
+      with open('/home/honghao/Documents/test_results_RRTConnect_testing.txt', 'w') as f:
+        f.write("Total number of runs: {}\n".format(num_runs))
+        f.write("Outliers found at runs: {}\n".format(outlier_indices))
+        f.write("Total number of outliers: {}\n".format(total_outliers))
+        f.write("Threshold: {}\n".format(threshold))
+    except Exception as e:
+      rospy.logerr("Failed to save test results: {}".format(e))
+    dfs = []
+    for i, traj in enumerate(trajectories):
+      df = pd.DataFrame(traj, columns=[f'x_run{i}', f'y_run{i}', f'z_run{i}'])
+      dfs.append(df)
+    
+    result = pd.concat(dfs, axis = 1)
+
+    try:
+      result.to_csv('/home/honghao/Documents/all_trajectories_RRTConnect_testing.csv')
+      print("File saved successfully")
+    except Exception as e:
+      print("Failed to save file", e)
+
+    _plot_helper(trajectories)
+
+    self.assertTrue(len(trajectories) == num_runs)
+if __name__ == '__main__':
+  import rostest
+  rostest.rosrun(PKG, TEST_NAME, TestArmConsistency)

--- a/ow_sim_tests/scripts/test_arm_consistency.py
+++ b/ow_sim_tests/scripts/test_arm_consistency.py
@@ -5,6 +5,7 @@
 # this repository.
 
 import rospy
+import os
 import actionlib
 import pandas as pd
 import tf2_ros
@@ -22,6 +23,10 @@ from scipy.spatial.distance import euclidean
 
 PKG = 'ow_sim_tests'
 TEST_NAME = 'arm_consistency'
+common_dir = os.path.expanduser('~/Documents')
+fig_3d_path = os.path.join(common_dir, '3D_trajectories_RRTConnect_testing.png')
+result_path = os.path.join(common_dir, 'test_results_RRTConnect_testing.txt')
+data_path = os.path.join(common_dir, 'all_trajectories_RRTConnect_testing.csv.txt')
 roslib.load_manifest(PKG)
 
 def _dtw_helper(trajectories, runs):
@@ -58,7 +63,7 @@ def _plot_helper(trajectories):
   plt.title('3D Trajectories')
   plt.legend()
   # TODO change the saving location in your local directory
-  fig.savefig('/home/honghao/Documents/3D_trajectories_RRTConnect_testing.png')
+  fig.savefig(fig_3d_path)
   
 class TestArmConsistency(unittest.TestCase):
 
@@ -131,7 +136,7 @@ class TestArmConsistency(unittest.TestCase):
     total_outliers = len(outlier_indices)
     try:
       # TODO change the saving location in your local directory
-      with open('/home/honghao/Documents/test_results_RRTConnect_testing.txt', 'w') as f:
+      with open(result_path, 'w') as f:
         f.write("Total number of runs: {}\n".format(num_runs))
         f.write("Outliers found at runs: {}\n".format(outlier_indices))
         f.write("Total number of outliers: {}\n".format(total_outliers))
@@ -147,7 +152,7 @@ class TestArmConsistency(unittest.TestCase):
 
     try:
       # TODO change the saving location in your local directory
-      result.to_csv('/home/honghao/Documents/all_trajectories_RRTConnect_testing.csv')
+      result.to_csv(data_path)
       print("File saved successfully")
     except Exception as e:
       print("Failed to save file", e)

--- a/ow_sim_tests/test/test_arm_consistency.test
+++ b/ow_sim_tests/test/test_arm_consistency.test
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<launch>
+
+    <arg name="gzclient" default="true" />
+
+    <include file="$(find ow)/launch/europa_terminator_workspace.launch">
+        <arg name="rqt_gui" value="false" />
+        <arg name="use_rviz" value="false"/>
+        <arg name="gzclient" value="$(arg gzclient)"/>
+    </include>
+
+    <test test-name="test_arm_consistency" pkg="ow_sim_tests"
+        type="test_arm_consistency.py" time-limit="7000.0"/>
+    
+</launch>


### PR DESCRIPTION
## Linked Issues:
| Jira Ticket 🎟️ | [OCEANWATER-1099](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1099) |


## Summary of Changes
* This Pull Request introduces a novel optimization algorithm for arm trajectory planning. Previously, the MoveIt! framework generates a single trajectory for arm or antenna movement based on the provided parameters. However, this trajectory may not always be optimal and therefore might result in inconsistent paths. The new method addresses this limitation by generating multiple trajectories, specifically, five different plans. These plans are then compared, and the trajectory with the minimum Euclidean distance is selected for implementation. This ensures a more optimal, efficient, and consistent arm movement in the applications.

## ROS Test
* Before doing the automatic ROS test, you might need to install the following Python package: `Numpy` `pandas` `fastdtw`. This can be done in the ubuntu terminal `pip install numpy`, `pip install pandas`, and `pip installs fastdtw`. Information about fastdtw can be found here: https://github.com/slaypni/fastdtw. The algorithm is used to compare the similarity of the trajectories.
* The ros test will generate 3 statistical documents, under dir `/home/username/Documents`, if need you can change the dir or file name :
   * `test_results_RRTConnect_testing.txt` contains information about the final result of the test, including the number of outlier trajectories. 
   * `all_trajectories_RRTConnect_testing.csv` the detail positions for all testing trajectories 
   * `3D_trajectories_RRTConnect_testing.png` 3D plot for all trajectories, if we only see one trajectory, that means all of them overlap together.
* On Ubuntu terminal, input `rostest ow_sim_tests test_arm_consistency.test`
   * I set the number of trials as 10, if you want to make the statistical data more reliable, you can manually change this number by adjusting the `test_arm_consistency.py` line 87, changing the value of `num_runs` to 100.


- You should expect to see the arm end in this pose, as the result of the most optimal path: ![Screenshot from 2023-08-31 09-28-09](https://github.com/nasa/ow_simulator/assets/124640235/860942b2-2675-49a6-9620-6427de59cc68)
- The suboptimal pose look like this: 
![Screenshot from 2023-08-31 09-30-33](https://github.com/nasa/ow_simulator/assets/124640235/8f2b44c6-e7e3-44c8-9513-96561691f17a)

## Manual Test

- You can ignore the ros test to do the manual test, however, the information will be limited in the animation of the gazebo.
   -  We need two terminal, The first one run the simulator: `roslaunch ow europa_terminator_workspace.launch`
   -  `rosrun ow_lander arm_unstow.py`
   -  After we see the arm_unstow action done, run `rosrun ow_lander arm_move_cartesian.py -x 1.166 -y 0.356 -z 0.588 -q -0.254 0.727 -0.456 0.446` the same parameter was used for ros test, the reason using this sets of parameters, it has a high chance to result in an inconsistent path, so can consider as "worst case".
   - Repeat the unstow and arm_move_cartesian again.


## Note and further testing

- For my testing experience, even though we generated 5 plans using RRTConnect, it is still significantly faster compared to RRTStar. So I suggest for all the action if previously switched to RRTStar for constant behavior (| Jira Ticket 🎟️ | [OCEANWATER-932](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-932) |, it might be more computation efficient switch to RRTConnect now and using the optimization method. 
- I only try one location, if you have experienced non-consistent path generation before, let me know the action and parameter you use. I will do further study on.