### PR TITLE
goal errors are cleared at the beginning of the next command

### DIFF
--- a/ow_lander/src/ow_lander/server.py
+++ b/ow_lander/src/ow_lander/server.py
@@ -138,7 +138,7 @@ class ActionServerBase(ABC):
                    "This should never happen!")
       return
     rospy.loginfo(f"{self.name} action started")
-    # reset execution fault flag by sending a PENDING state
+    # reset execution fault flag by sending a SUCCEEDED state
     # HACK: The SUCCEEDED state does not reflect the current state of the action
     #   that has been called. It cannot have succeeded yet because it has yet to
     #   be attempted here. This is a hack. ActionGoalStatus.msg is effectively

--- a/ow_lander/src/ow_lander/server.py
+++ b/ow_lander/src/ow_lander/server.py
@@ -138,6 +138,14 @@ class ActionServerBase(ABC):
                    "This should never happen!")
       return
     rospy.loginfo(f"{self.name} action started")
+    # reset execution fault flag by sending a PENDING state
+    # HACK: The SUCCEEDED state does not reflect the current state of the action
+    #   that has been called. It cannot have succeeded yet because it has yet to
+    #   be attempted here. This is a hack. ActionGoalStatus.msg is effectively
+    #   interpreted by ow_fault_detector as a boolean array because an element
+    #   can either be SUCCEEDED or ABORTED. To reset system_faults_status goal
+    #   error flags to 0 at the beginning of an action, we broadcast SUCCEEDED.
+    self.__publish_state(actionlib_msgs.msg.GoalStatus.SUCCEEDED)
     self.execute_action(goal)
     rospy.loginfo(f"{self.name} action complete")
 


### PR DESCRIPTION
This PR spawned from discussion in #361

## Summary of Changes
* Reset the relevant action group GOAL_ERROR flag at the beginning of an action. 

## Test
Launch any simulator world
1. Monitor the system faults topic `rostopic echo /system_faults_status` and the arm faults topic `rostopic echo /arm_faults_status` in two separate terminals. 
2. Call an invalid ArmMoveCartesian `rosrun ow_lander arm_move_cartesian.py`
3. The command will fail. Both topics should show a value of 2. 
4. Call a valid TaskGrind `rosurn ow_lander task_grind.py`
5. The system fault will remain 2, because we are calling an action in a different group (TASK), but arm faults will be reset to 0 at the beginning of the TaskGrind because it uses the arm. Let the TaskGrind complete.
6. Call a valid ArmMoveCertaisn `rosrun ow_lander arm_move_cartesian.py -x 1.8 -z 0.5`
7. System faults will become 0 immediately. The action will complete and both topics should both now be 0. 
