### PR TITLE
More regolith for shallow digs

### DIFF
--- a/ow/launch/common.launch
+++ b/ow/launch/common.launch
@@ -90,7 +90,7 @@
     <!-- model that gets spawned into scoop -->
     <param name="regolith_model_uri" type="string" value="model://sphere_2cm"/>
     <!-- cubed meters that must be removed from terrain before a regolith particle is spawned -->
-    <param name="spawn_volume_threshold" type="double" value="1e-3"/>
+    <param name="spawn_volume_threshold" type="double" value="2e-4"/>
     <!-- horizontal spacing between each consecutive regolith spawned -->
     <param name="spawn_spacing" type="double" value="0.02"/>
   </node>

--- a/ow_sim_tests/scripts/sample_collection.py
+++ b/ow_sim_tests/scripts/sample_collection.py
@@ -27,7 +27,7 @@ TEST_NAME = 'sample_collection'
 roslib.load_manifest(PKG)
 
 DISCARD_POSITION = Point(1.5, 0.8, constants.DEFAULT_GROUND_HEIGHT) # default for discard action
-REGOLITH_CLEANUP_DELAY = 5.0 # seconds
+REGOLITH_CLEANUP_DELAY = 10.0 # seconds
 
 SCOOP_LINK_NAME = 'lander::l_scoop'
 SAMPLE_DOCK_LINK_NAME = 'lander::lander_sample_dock_link'
@@ -246,10 +246,10 @@ class SampleCollection(unittest.TestCase):
     grind_result = test_arm_action(self,
       'TaskGrind', owl_msgs.msg.TaskGrindAction,
       owl_msgs.msg.TaskGrindGoal(
-        x_start         = 1.65,
+        x_start         = 1.7,
         y_start         = 0.0,
-        depth           = 0.15, # grind deep so terrain is modified
-        length          = 0.7,
+        depth           = 0.13, # grind deep so terrain is modified
+        length          = 0.4,
         parallel        = True,
         ground_position = constants.DEFAULT_GROUND_HEIGHT
       ),
@@ -267,8 +267,9 @@ class SampleCollection(unittest.TestCase):
       owl_msgs.msg.TaskScoopLinearGoal(
         frame     = 0,
         relative  = False,
-        point     = Point(1.46, 0, constants.DEFAULT_GROUND_HEIGHT),
-        depth     = 0.01,
+        point     = Point(1.7, 0, constants.DEFAULT_GROUND_HEIGHT),
+        depth     = 0.05,  # scoop extra deep because the previous deep grind
+                           # left a dip
         length    = 0.1
       ),
       TEST_NAME, "test_03_task_scoop_linear",
@@ -299,8 +300,12 @@ class SampleCollection(unittest.TestCase):
     self._assert_scoop_regolith_containment(False)
 
     # assert regolith was cleaned up after contacting with the terrain
+    # NOTE: Can be dependent on how much regolith spawns per unit volume.
+    #       More regolith seems to take longer to remove.
     rospy.sleep(REGOLITH_CLEANUP_DELAY)
-    self._assert_regolith_not_present()
+    self._assert_regolith_not_present(
+      "Some regolith remains in world after discard!"
+    )
 
   """
   Grind a new trench in a different location on the terrain.
@@ -309,10 +314,10 @@ class SampleCollection(unittest.TestCase):
     task_grind_result = test_arm_action(self,
       'TaskGrind', owl_msgs.msg.TaskGrindAction,
       owl_msgs.msg.TaskGrindGoal(
-        x_start         = 1.65,
+        x_start         = 1.7,
         y_start         = 0.5,
         depth           = 0.05,
-        length          = 0.6,
+        length          = 0.4,
         parallel        = True,
         ground_position = constants.DEFAULT_GROUND_HEIGHT
       ),
@@ -330,7 +335,7 @@ class SampleCollection(unittest.TestCase):
       owl_msgs.msg.TaskScoopCircularGoal(
         frame    = 0,
         relative = False,
-        point    = Point(1.65, 0.5, constants.DEFAULT_GROUND_HEIGHT),
+        point    = Point(1.7, 0.5, constants.DEFAULT_GROUND_HEIGHT),
         depth    = 0.01,
         parallel = True
       ),


### PR DESCRIPTION
The new dig model means we dig more shallow trenches at a time. This change ensures we still see a some regolith spawn out of those more shallow digs

## Summary of Changes
* 5x as many regolith particles will spawn for the same amount of dug volume.
* Updates to sample_collection.py, so it works well with the new dig model. 

## Test
Run `rostest ow_sim_tests sample_collection.test ignore_action_checks:=True` and ensure it passes. 
