### PR TITLE
OW-1209: Artifical Power Faults

### DIFF
--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -261,7 +261,7 @@ void FaultDetector::cameraRawCb(const sensor_msgs::Image& msg)
 void FaultDetector::powerTemperatureListener(const BatteryTemperature& msg)
 {
   // check for excessive battery temperature
-  if (msg.value > POWER_THERMAL_MAX) {
+  if (msg.value >= POWER_THERMAL_MAX) {
     m_power_faults_flags |= PowerFaultsStatus::THERMAL_FAULT;
   } else {
     m_power_faults_flags &= ~PowerFaultsStatus::THERMAL_FAULT;

--- a/ow_faults_injection/cfg/Faults.cfg
+++ b/ow_faults_injection/cfg/Faults.cfg
@@ -114,4 +114,11 @@ power_faults.add("battery_nodes_to_disconnect",   int_t, 0,
 power_faults.add("disconnect_battery_nodes",    bool_t, 0,
     "Disconnect the selected number of battery nodes. Cannot be reversed without restarting the simulation", False)
 
+power_faults.add("low_state_of_charge", bool_t, 0,
+    "Artificially force the battery to the low state of charge threshold", False)
+power_faults.add("instantaneous_capacity_loss", bool_t, 0,
+    "Artificially force the battery to lose enough of its current charge every cycle to trigger an ICL fault", False)
+power_faults.add("thermal_failure", bool_t, 0,
+    "Artificially force the battery's temperature reading to the thermal failure threshold", False)
+
 exit(gen.generate(PACKAGE, "faults", "Faults"))

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -39,6 +39,12 @@ using PrognoserVector = std::vector<PrognoserMap>;
 // simulates 6 cells at once, so only 4 models are needed.
 constexpr int NUM_MODELS = 4;
 
+// Power fault thresholds, for their related faults.
+// They are slightly beyond the actual thresholds to prevent rounding errors.
+static constexpr float POWER_THERMAL_MAX = 70.0;
+static constexpr float POWER_SOC_MIN = 0.095;
+static constexpr float POWER_SOC_MAX_DIFF = 0.052;
+
 // Struct that groups the variables/classes used to handle PrognoserInputHandlers.
 struct PowerModel {
   std::string name;
@@ -162,11 +168,19 @@ private:
   // The matrix used to store EoD events.
   EoDValues m_EoD_events[NUM_MODELS];
 
+  // The most recent published SoC, for use in ICL fault injection.
+  double m_prev_soc;
+
+  // Fault flags.
   bool m_high_power_draw_activated = false;
   bool m_custom_power_fault_activated = false;
   bool m_disconnect_battery_nodes_fault_activated = false;
   PrognoserVector m_custom_power_fault_sequence;
   size_t m_custom_power_fault_sequence_index = 0;
+
+  bool m_low_soc_activated = false;
+  bool m_icl_activated = false;
+  bool m_thermal_failure_activated = false;
 
   // Used for mechanical power debug printouts.
   double m_power_watts;

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -47,6 +47,7 @@ static void printPrognoserOutputs(double rul,
 static void printMechanicalPower(double raw, double mean, int window);
 static void printTopics(double rul, double soc, double tmp);
 static void printFaultDisabledWarning();
+static void printPowerFaultWarning();
 
 /*
  * The primary function with the loop that controls each cycle.
@@ -774,11 +775,7 @@ void PowerSystemNode::injectFault(const std::string& fault_name)
       ROS_INFO_STREAM(fault_name << " activated!");
       m_low_soc_activated = true;
       // Warn the user about the invalid behavior associated with power faults.
-      ROS_WARN_STREAM("Note that artificial power fault injection simply "
-                   << "temporarily overrides GSAP's predictions. RUL will "
-                   << "not react to the fault and the system "
-                   << "will continue without any loss of battery health after "
-                   << "the fault is removed, which is not realistic.");
+      printPowerFaultWarning();
 
       // Extra logic if the ICL fault was already activated, to immediately
       // bring SoC down to the threshold.
@@ -814,11 +811,7 @@ void PowerSystemNode::injectFault(const std::string& fault_name)
       ROS_INFO_STREAM(fault_name << " activated!");
       m_icl_activated = true;
       // Warn the user about the invalid behavior associated with power faults.
-      ROS_WARN_STREAM("Note that artificial power fault injection simply "
-                   << "temporarily overrides GSAP's predictions. RUL will "
-                   << "not react to the fault and the system "
-                   << "will continue without any loss of battery health after "
-                   << "the fault is removed, which is not realistic.");
+      printPowerFaultWarning();
     }
     else if (m_icl_activated && !fault_enabled)
     {
@@ -847,11 +840,7 @@ void PowerSystemNode::injectFault(const std::string& fault_name)
       ROS_INFO_STREAM(fault_name << " activated!");
       m_thermal_failure_activated = true;
       // Warn the user about the invalid behavior associated with power faults.
-      ROS_WARN_STREAM("Note that artificial power fault injection simply "
-                   << "temporarily overrides GSAP's predictions. RUL will "
-                   << "not react to the fault and the system "
-                   << "will continue without any loss of battery health after "
-                   << "the fault is removed, which is not realistic.");
+      printPowerFaultWarning();
     }
     else if (m_thermal_failure_activated && !fault_enabled)
     {
@@ -1195,4 +1184,16 @@ static void printFaultDisabledWarning()
   ROS_WARN_STREAM_THROTTLE(60, "Faults cannot be injected while the power system "
                     << "is disabled. Modify ow_power_system/config/system.cfg "
                     << "and restart the simulator to re-enable.");
+}
+
+/*
+ * Prints a warning to the user when they inject one of the artificial power
+ * faults.
+ */
+static void printPowerFaultWarning()
+{
+  ROS_WARN_STREAM("Note that artificial power fault injection simply overrides "
+                  "GSAP's predictions. Remaining useful life will not be "
+                  "affected and the system will continue without any loss of "
+                  "battery health after the fault is cleared.");
 }

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -779,6 +779,13 @@ void PowerSystemNode::injectFault(const std::string& fault_name)
                    << "not react to the fault and the system "
                    << "will continue without any loss of battery health after "
                    << "the fault is removed, which is not realistic.");
+
+      // Extra logic if the ICL fault was already activated, to immediately
+      // bring SoC down to the threshold.
+      if (m_icl_activated && m_prev_soc > POWER_SOC_MIN)
+      {
+        m_prev_soc = POWER_SOC_MIN;
+      }
     }
     else if (m_low_soc_activated && !fault_enabled)
     {


### PR DESCRIPTION
This PR is critical for Release 12 testing of Fault Detection & Injection, as it allows the user to easily (though artificially) trigger conditions where power faults should occur.

## Linked Issues:
| EPIC ⚡ | N/A |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1209](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1209) |
| Github :octocat:  | # |


## Summary of Changes
* The user can now inject low state-of-charge, instantaneous capacity loss, and thermal failure. These faults each modify the outputs of GSAP post-prediction, and thus do not interact with GSAP at all. 
  * This means their behavior is unrealistic, particularly in regards to RUL (which is not affected at all) and when removing the fault (the predictions immediately return to pre-fault values as if nothing had occurred). Still, it allows users to test for power fault behavior, which is important for Release 12 as the new power system can no longer feasibly reach a state where a power fault would naturally be triggered otherwise. The dramatically increased battery life means dramatically increased time before power starts to run low.

## Test
* Open up four terminals:
  * The first terminal will run the simulation. Build & run the simulator in the OceanWATERS directory. The world shouldn't matter, though I used the ``atacama`` world (``roslaunch ow atacama_y1a.launch``).
  * Run the following command in the second terminal to monitor published state of charge:
    * ``rostopic echo /battery_state_of_charge/value``
  * Run the following command in the third terminal to monitor published battery temperature:
    * ``rostopic echo /battery_temperature/value``
  * Run the following command in the fourth terminal to monitor power fault flags:
    * ``rostopic echo /power_faults_status/value``
* Once the simulation has started, navigate to the ``Dynamic Reconfigure`` tab on the bottom of the RQT window, and from there, to the ``faults`` section. Scroll down until you see the ``power_faults`` subsection that contains three additional faults: ``low_state_of_charge``, ``instantaneous_capacity_loss``, & ``thermal_failure``.
* Individually inject each fault and ensure its behavior lines up as expected:
  * ``low_state_of_charge`` should reduce the published values on the ``/battery_state_of_charge`` topic to under 10%. Additionally, ``/power_faults_status/value`` should increase by 1 while the fault is active.
    * Note that for one or two publications upon activation, ``/power_faults_status/value`` may increase by an additional 2 due to the likely sudden jump in state of charge triggering the threshold for an instantaneous capacity loss fault. It should stabilize to 1 quickly.
  * ``instantaneous_capacity_loss`` should reduce the current charge published by ``/battery_state_of_charge`` by at least 5% of its current state of charge, every cycle. Additionally, ``/power_faults_status/value`` should increase by 2 while the fault is active.
  * ``thermal_failure`` should set set the published value of the ``/battery_temperature`` topic to at least 70. Additionally, ``/power_faults_status/value`` should increase by 4 while the fault is active.
* Once the behavior of all 3 new faults has been individually verified, experiment with activating multiple artificial power faults at once. These 3 faults should all work at the same time if desired, though keep in mind that while they are overriding the outputs from GSAP, other power faults that modify inputs to GSAP (for example, ``high_power_draw`` and ``disconnect_battery_nodes``) will not have an effect on the state of charge & temperature topics. These other faults will still affect GSAP and its predictions as expected, even while these artificial faults are in use. Their effects will just not be published until the artificial faults are removed.