### PR TITLE
Partial fix for scoop stalling

### DIFF
--- a/ow/launch/common.launch
+++ b/ow/launch/common.launch
@@ -92,7 +92,7 @@
     <!-- cubed meters that must be removed from terrain before a regolith particle is spawned -->
     <param name="spawn_volume_threshold" type="double" value="2e-4"/>
     <!-- horizontal spacing between each consecutive regolith spawned -->
-    <param name="spawn_spacing" type="double" value="0.02"/>
+    <param name="spawn_spacing" type="double" value="0.021"/>
   </node>
 
   <!-- == Start rqt with a short delay so most topics will be visible and we won't need to refresh widgets ====== -->

--- a/ow_dynamic_terrain/scripts/modify_terrain_grinder_pub.py
+++ b/ow_dynamic_terrain/scripts/modify_terrain_grinder_pub.py
@@ -53,8 +53,12 @@ class ModifyTerrainGrinder:
     if not all(np.isclose(current_orientation, effective_orientation, atol=10)):
       return # grinder not aligned for digging, abort
 
+    # the distance the scoop must travel before a modification message is sent
+    MODIFICATION_DISTANCE = 5.e-3  # meters
+
     current_translation = np.array([new_position.x, new_position.y, new_position.z])
-    if all(np.isclose(current_translation, self.last_translation, atol=1.e-4)):
+    if all(np.isclose(current_translation, self.last_translation,
+                      atol=MODIFICATION_DISTANCE)):
       return  # no significant change, abort
 
     self.last_translation = current_translation

--- a/ow_dynamic_terrain/scripts/modify_terrain_scoop_pub.py
+++ b/ow_dynamic_terrain/scripts/modify_terrain_scoop_pub.py
@@ -46,8 +46,12 @@ class ModifyTerrainScoop:
   def check_and_submit(self, new_position, new_rotation):
     """ Checks if position has changed significantly before submmitting a message """
 
+    # the distance the scoop must travel before a modification message is sent
+    MODIFICATION_DISTANCE = 5.e-3  # meters
+
     current_translation = np.array([new_position.x, new_position.y, new_position.z])
-    if all(np.isclose(current_translation, self.last_translation, atol=1.e-4)):
+    if all(np.isclose(current_translation, self.last_translation,
+                      atol=MODIFICATION_DISTANCE)):
       return  # no significant change, abort
 
     self.last_translation = current_translation

--- a/ow_gazebo_plugins/src/BalovnevModelPlugin/BalovnevModelPlugin.h
+++ b/ow_gazebo_plugins/src/BalovnevModelPlugin/BalovnevModelPlugin.h
@@ -40,6 +40,8 @@ private:
 
   void publishForces();
 
+  void resetVerticalForces();
+  void resetHorizontalForces();
   void resetForces();
 
   void resetDepth();
@@ -57,8 +59,6 @@ private:
 
   ros::Publisher m_pub_horizontal_force;
   ros::Publisher m_pub_vertical_force;
-  // DEBUG CODE
-  ros::Publisher m_pub_depth;
   
   ros::Timer m_dig_timeout;
 

--- a/ow_regolith/models/sphere_2cm/model.sdf
+++ b/ow_regolith/models/sphere_2cm/model.sdf
@@ -8,6 +8,8 @@
 
       <pose>0 0 0.01 0 0 0</pose>
       <inertial>
+        <!-- Acquired by taking the density of ice ~0.9168 g/cm^3 and
+             multiplying by the volume of a 2cm sphere. Converted to kg. -->
         <mass>0.031</mass>
         <!-- Set high moments to "disable" rotation -->
         <inertia>

--- a/ow_regolith/models/sphere_2cm/model.sdf
+++ b/ow_regolith/models/sphere_2cm/model.sdf
@@ -8,7 +8,7 @@
 
       <pose>0 0 0.01 0 0 0</pose>
       <inertial>
-        <mass>0.3769911184307752</mass>
+        <mass>0.031</mass>
         <!-- Set high moments to "disable" rotation -->
         <inertia>
           <ixx>1.5e-02</ixx>


### PR DESCRIPTION
## Summary of Changes
* Reduced the rate of deformation messages by a factor of 15. These changes were carried over from a not-ready-for-primetime epic branch. Terry you'll recognize them. 
* Changed blunt edge angle in BalovnevModelPlugin
* Simplified how pushback and pushdown behavior is handled. Now the forces applied by BalovnevModelPugin will max out at some hardcoded value. This is a temporary fix. 
* Fixed the mass of regolith, which was an order of magnitude more massive than it needed to be. 

## Test
Run through [Release 12 - Test 7 - Sample Collection](https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/OW-TEST-012-7+Sample+Collection). This can serve as both the PR test and the Release 12 test.
