### PR TITLE
hotfix/oceanwater 1159 fix for DockIngestSample

### DIFF
--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -1128,19 +1128,16 @@ class DockIngestSampleServer(ActionServerBase):
     return transformed
 
   def _is_position_in_sample_dock(self, position):
-    # relative_to_dock = FrameTransformer().transform_geometry(
-    #   position, "lander_sample_dock_link", "world")
     relative_to_dock = self._transform_relative_to_dock(position)
     if relative_to_dock is None:
       raise ActionError("Transform of regolith position failed")
-    # perform a simple axis-aligned bounding box check, since in the sample
-    # dock's frame it is a an axis_aligned box centered
+    # perform an axis-aligned box containment check since, in the sample dock's
+    # frame, it happens to be an axis-aligned box
     X_DIM = 0.3 # meters
     Y_DIM = 0.05
     Z_DIM = 0.095
     # NOTE: This value can be found by adding the y-value on line 25 of
     #   lander_sample_dock.xacro to the point assigned to the origin on line 34
-    #   and multiplying the result by negative one
     OFFSET_RELATIVE_TO_FRAME = Point(0.0, -0.33, 0.025)
     p = math3d.subtract(relative_to_dock, OFFSET_RELATIVE_TO_FRAME)
     if (    -X_DIM/2 < p.x < X_DIM/2

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -1163,7 +1163,6 @@ class DockIngestSampleServer(ActionServerBase):
     regolith_to_remove = self._identify_active_regolith_in_sample_dock()
     if not regolith_to_remove:
       return False
-    rospy.loginfo(f"regolith_to_remove = {regolith_to_remove}")
     REMOVE_REGOLITH_SERVICE = '/ow_regolith/remove_regolith'
     rospy.wait_for_service(REMOVE_REGOLITH_SERVICE, timeout=10)
     service = rospy.ServiceProxy(REMOVE_REGOLITH_SERVICE, RemoveRegolith)

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -13,7 +13,6 @@ import rospy
 import moveit_commander
 from abc import ABC, abstractmethod
 from std_msgs.msg import Float64
-from sensor_msgs.msg import JointState
 from geometry_msgs.msg import Pose, PoseStamped, PointStamped
 from tf2_geometry_msgs import do_transform_pose
 from owl_msgs.msg import ArmFaultsStatus

--- a/ow_lander/urdf/lander_sample_dock.xacro
+++ b/ow_lander/urdf/lander_sample_dock.xacro
@@ -73,19 +73,6 @@
           <visibility_bitmask>${vis_mask}</visibility_bitmask>
         </plugin>
       </visual>
-      <sensor name="contact_sensor_sample_dock" type="contact">
-        <parent link="lander_sample_dock${suffix}"/>
-        <contact>
-          <collision>
-            lander_sample_dock_link_fixed_joint_lump__lander_sample_dock${suffix}_collision
-          </collision>
-        </contact>
-        <plugin name="contact_sensor_sample_dock_plugin"
-                filename="libContactSensorPlugin.so">
-          <topic>/ow_regolith/contacts/sample_dock</topic>
-          <report_only>regolith_\d*.*</report_only>
-        </plugin>
-      </sensor>
     </gazebo>
 
   </xacro:macro>

--- a/ow_regolith/src/ContactSensorPlugin.cpp
+++ b/ow_regolith/src/ContactSensorPlugin.cpp
@@ -18,12 +18,14 @@ using std::string, std::set, std::vector, std::bind, std::dynamic_pointer_cast,
       std::endl, std::regex_match, std::begin, std::end, std::regex,
       std::make_unique;
 
-const static string NODE_PREFIX = "contact_sensor_";
+const string NODE_PREFIX = "contact_sensor_";
 
-const static string PLUGIN_NAME = "ContactSensorPlugin";
+const string PLUGIN_NAME = "ContactSensorPlugin";
 
-const static string PARAMETER_TOPIC = "topic";
-const static string PARAMETER_REPORT_ONLY = "report_only";
+const string PARAMETER_TOPIC = "topic";
+const string PARAMETER_REPORT_ONLY = "report_only";
+
+const double SENSOR_UPDATE_RATE = 10; // hertz
 
 GZ_REGISTER_SENSOR_PLUGIN(ContactSensorPlugin)
 
@@ -38,6 +40,7 @@ void ContactSensorPlugin::Load(sensors::SensorPtr sensor, sdf::ElementPtr sdf)
     bind(&ContactSensorPlugin::onUpdate, this)
   );
   m_parent_sensor->SetActive(true);
+  m_parent_sensor->SetUpdateRate(SENSOR_UPDATE_RATE);
 
   // get plugin parameters
   if (!sdf->HasElement(PARAMETER_TOPIC)) // required


### PR DESCRIPTION
Jira Ticket 🎟️ | [OCEANWATER-1159](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1159)

## Reviewers
@mikedalal Feel free to defer the full review to Terry, seeing as I'm getting this in late before your vacation.
@mogumbo Please test and provide a technical review. 

## Summary of Changes
* DockIngestSample rebuilt to not rely on ContactSensorPlugin
  * _Note_ ContactSensorPlugin is still in use for removing regolith that collides with the terrain, and so will not yet be removed at this time.

This rebuild was necessary. The previous approach to DockIngestSample was over complicated and reliant on ContactSensorPlugin, which appears to be bugged. I dug deep into the Gazebo API, but the contact sensor API will randomly fall into a state where there are clearly contacts present on the collision body, but it reports zero contacts. Unable to see a work around to this bug, and finding the original DockIngestSample code difficult to debug (even as the person who wrote it), I decided to rewrite it from scratch using a different method. 

The new method is to just treat the sample dock as the axis-aligned bounding box that it is and do a containment check with each regolith present in the world. It would have been simpler if I could use tf to transform a regolith's position from the world frame to the sample dock's frame, but [OW-1194](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1194) made that impossible without hard-coding offsets for each and every world into the action. The transformation is done manually using only data from Gazebo (which does not suffer from OW-1194), and I have confirmed it works in different worlds. 

## Test
1. Launch any world in which you can dig.
2. In another terminal `roslaunch ow_plexil ow_exec.launch plan:=TestActions.plx`

Each time DockIngestSample sample is called in the above procedures, sample should be removed from the sample dock, even if it had to cascade into it following after other removed sample, and when all the sample is removed the action will end 3 seconds later. Sample still may remain if it did not roll into the sample dock. 

