### PR TITLE
Antenna exceptions  are now correctly handled by pan/tilt actions

### DIFF
--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -1227,7 +1227,7 @@ class PanTiltMoveJointsServer(mixins.PanTiltMoveMixin, ActionServerBase):
   def execute_action(self, goal):
     try:
       not_preempted = self.move_pan_and_tilt(goal.pan, goal.tilt)
-    except ArmExecutionError as err:
+    except (AntennaPlanningError, AntennaExecutionError) as err:
       pan, tilt = self._ant_joints_monitor.get_joint_positions()
       self._set_aborted(str(err), pan_position=pan, tilt_position=tilt)
     else:
@@ -1257,7 +1257,7 @@ class PanServer(mixins.PanTiltMoveMixin, ActionServerBase):
   def execute_action(self, goal):
     try:
       not_preempted = self.move_pan(goal.pan)
-    except ArmExecutionError as err:
+    except (AntennaPlanningError, AntennaExecutionError) as err:
       pan, _ = self._ant_joints_monitor.get_joint_positions()
       self._set_aborted(str(err), pan_position=pan)
     else:
@@ -1284,7 +1284,7 @@ class TiltServer(mixins.PanTiltMoveMixin, ActionServerBase):
   def execute_action(self, goal):
     try:
       not_preempted = self.move_tilt(goal.tilt)
-    except ArmExecutionError as err:
+    except (AntennaPlanningError, AntennaExecutionError) as err:
       _, tilt = self._ant_joints_monitor.get_joint_positions()
       self._set_aborted(str(err), tilt_position=tilt)
     else:

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -1226,7 +1226,7 @@ class PanTiltMoveJointsServer(mixins.PanTiltMoveMixin, ActionServerBase):
 
   def execute_action(self, goal):
     try:
-      not_preempted = self.move_pan_and_tilt(goal.pan, goal.tilt)
+      not_preempted = self.move(pan = goal.pan, tilt = goal.tilt)
     except (AntennaPlanningError, AntennaExecutionError) as err:
       pan, tilt = self._ant_joints_monitor.get_joint_positions()
       self._set_aborted(str(err), pan_position=pan, tilt_position=tilt)
@@ -1256,7 +1256,7 @@ class PanServer(mixins.PanTiltMoveMixin, ActionServerBase):
 
   def execute_action(self, goal):
     try:
-      not_preempted = self.move_pan(goal.pan)
+      not_preempted = self.move(pan = goal.pan)
     except (AntennaPlanningError, AntennaExecutionError) as err:
       pan, _ = self._ant_joints_monitor.get_joint_positions()
       self._set_aborted(str(err), pan_position=pan)
@@ -1283,7 +1283,7 @@ class TiltServer(mixins.PanTiltMoveMixin, ActionServerBase):
 
   def execute_action(self, goal):
     try:
-      not_preempted = self.move_tilt(goal.tilt)
+      not_preempted = self.move(tilt = goal.tilt)
     except (AntennaPlanningError, AntennaExecutionError) as err:
       _, tilt = self._ant_joints_monitor.get_joint_positions()
       self._set_aborted(str(err), tilt_position=tilt)
@@ -1316,7 +1316,7 @@ class PanTiltMoveCartesianServer(mixins.PanTiltMoveMixin, ActionServerBase):
                                                      'l_ant_panel')
     try:
       frame_id = mixins.FrameMixin.get_frame_id_from_index(goal.frame)
-    except ArmExecutionError as err:
+    except ActionError as err:
       self._set_aborted(str(err))
       return
     lookat = goal.point
@@ -1359,7 +1359,7 @@ class PanTiltMoveCartesianServer(mixins.PanTiltMoveMixin, ActionServerBase):
     tilt_raw = -(a + b - (math.pi / 2))
     tilt = normalize_radians(tilt_raw)
     try:
-      not_preempted = self.move_pan_and_tilt(pan, tilt)
+      not_preempted = self.move(pan = pan, tilt = tilt)
     except (AntennaPlanningError, AntennaExecutionError) as err:
       self._set_aborted(str(err))
     else:

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -383,7 +383,7 @@ class PanTiltMoveMixin:
     rate = rospy.Rate(FREQUENCY)
     # sleep first to give the joint a chance to start moving
     rate.sleep()
-    for i in range(0, int(TIMEOUT * FREQUENCY)):
+    for _i in range(0, int(TIMEOUT * FREQUENCY)):
       if self._is_preempt_requested():
         return False
       # publish feedback message

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -349,6 +349,12 @@ class PanTiltMoveMixin:
     self._start_server()
 
   def move(self, pan=None, tilt=None):
+    if pan is None and tilt is None:
+      raise AntennaPlanningError(
+        "PanTiltMoveMixin.move must always be called with either both or one "
+        "the pan or tilt keyword arguments."
+      )
+
     if pan is not None and \
        not in_closed_range(pan, constants.PAN_MIN, constants.PAN_MAX):
       raise AntennaPlanningError(

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -370,19 +370,6 @@ class PanTiltMoveMixin:
     if tilt is not None:
       self._tilt_pub.publish(tilt)
 
-    # FIXME: The outcome of ReferenceMission1 happens to be closely tied to
-    #        the value of FREQUENCY. When a fast frequency was selected (10 Hz),
-    #        the image used to identify a sample location would be slightly to
-    #        the right than the image would have been if the frequency is set to
-    #        1 Hz, which would result in a sample location being selected that
-    #        is about half a meter closer to the lander than otherwise.
-    #        Such a dependency on FREQUENCY should not occur and implies that
-    #        the loop terminates before the antenna mast has completed its
-    #        movement. This breaks the synchronicity of actions, and therefore
-    #        of PLEXIL commands.
-    #        The loop break should instead trigger when both antenna joint
-    #        velocities are near enough to zero.
-    #         This issue is captured by OW-1105
     # loop until pan/tilt reach their goal values
     FREQUENCY = 5 # Hz
     TIMEOUT = 30 # seconds


### PR DESCRIPTION
I noticed while testing https://github.com/nasa/ow_autonomy/pull/133 that pan/tilt actions would not handle their timeout exception resulting in a long error print-out and the action not being set to aborted. 

In master the output is
```
[ERROR:/lander_action_servers] Exception in your execute callback: Timed out waiting for pan value to reach goal.
Traceback (most recent call last):                                                                                                             
  File "/opt/ros/noetic/lib/python3/dist-packages/actionlib/simple_action_server.py", line 289, in executeLoop                                 
    self.execute_callback(goal)                                                                                                                
  File "/usr/local/home/tstucky/ow/alpha_ws/src/ow_simulator/ow_lander/src/ow_lander/server.py", line 149, in __on_action_called               
    self.execute_action(goal)                                                                                                                  
  File "/usr/local/home/tstucky/ow/alpha_ws/src/ow_simulator/ow_lander/src/ow_lander/actions.py", line 1259, in execute_action                 
    not_preempted = self.move_pan(goal.pan)                                                                                                    
  File "/usr/local/home/tstucky/ow/alpha_ws/src/ow_simulator/ow_lander/src/ow_lander/mixins.py", line 420, in move_pan                         
    raise AntennaExecutionError(                                                                                                               
ow_lander.exception.AntennaExecutionError: Timed out waiting for pan value to reach goal.   
```

In this branch the output is shorter and does not crash a callback function.

## Summary of Changes
* Antenna exception objects are now handled for pan/tilt actions
* **EDIT** Antenna pan/tilt control loop now breaks when both joint velocities are near enough to zero. This fixes [OW-1105](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1105)

## Test
1. Run the simulation in any world with rqt open so you can set faults. 
2. Call any of the following pan/tilt actions
    * Pan
    * Tilt
    * PanTiltMoveJoints
3. While the antenna is still moving to its destination, trigger a fault for pan/tilt depending which action you have called. 
4. The antenna will stop and you will immediately see one of the following messages.
```
[ERROR:/lander_action_servers] PanTiltMoveJoints: Aborted - Both pan and tilt joints failed to reach their goal position.
```
```
[ERROR:/lander_action_servers] PanTiltMoveCartesian: Aborted - Pan joint failed to reach its goal position.
```
```
[ERROR:/lander_action_servers] PanTiltMoveJoints: Aborted - Tilt joint failed to reach its goal position.
```

_NOTE_ If you are calling a PanTiltMoveJoints action, and only lock one of the joints, then the unlocked joint will continue moving. When the unlocked joint arrives at its goal position, or when it too is locked, only then will the above error message display. 
5. **EDIT** Now unlock the joint. It may jerk very slightly, but otherwise will not continue moving towards its original goal from before the fault injection. 

## Regression Test
@kmdalal In addition to the above test, please run ReferenceMission1.plx on atacama_y1a and make sure there are no issues. I'm asking for this test now because this PR now addresses [OW-1105](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1105), which affected ReferenceMission1 outcome.
