### PR TITLE
Oceanwater 1218 improve lighting realism

### DIFF
--- a/ow_ephemeris/README.md
+++ b/ow_ephemeris/README.md
@@ -14,5 +14,5 @@ OceanWATERS:
  - A config file for `irg_planetary_ephemeris` that sets up a mission site on
    Europa.
  - A script that converts sunlight distance from `irg_planetary_ephemeris` into 
-   lux values for our shaders.
+   irradiance values for our shaders.
 

--- a/ow_ephemeris/scripts/sunlight_values_for_shaders.py
+++ b/ow_ephemeris/scripts/sunlight_values_for_shaders.py
@@ -25,7 +25,7 @@ class SunValues:
     self.listener = tf.TransformListener()
 
     # Must use separate messages or they sometimes interfere with one another
-    self.lux_msg = ShaderParamUpdate()
+    self.flux_msg = ShaderParamUpdate()
     self.visibility_msg = ShaderParamUpdate()
     self.shader_param_pub = rospy.Publisher("/gazebo/global_shader_param", ShaderParamUpdate, queue_size=1)
 
@@ -46,17 +46,17 @@ class SunValues:
     dist = math.sqrt(trans[0] * trans[0] + trans[1] * trans[1] + trans[2] * trans[2])
     # Ratio of 1 AU over distance
     dist_ratio = 149597870700.0 / dist
-    # Use the solar illuminance constant to compute lux at this distance from sun
-    lux = 133000.0 * dist_ratio * dist_ratio
+    # Use the solar constant (in W / m^2) to compute flux at this distance from sun
+    flux = 1361.5 * dist_ratio * dist_ratio
 
-    self.lux_msg.shaderType = ShaderParamUpdate.SHADER_TYPE_FRAGMENT
-    self.lux_msg.paramName = "sunIntensity"
-    self.lux_msg.paramValue = str(lux) + ' ' + str(lux) + ' ' + str(lux)
-    self.shader_param_pub.publish(self.lux_msg)
+    self.flux_msg.shaderType = ShaderParamUpdate.SHADER_TYPE_FRAGMENT
+    self.flux_msg.paramName = "sunIntensity"
+    self.flux_msg.paramValue = str(flux) + ' ' + str(flux) + ' ' + str(flux)
+    self.shader_param_pub.publish(self.flux_msg)
 
-    self.lens_flare_color_msg.x = lux
-    self.lens_flare_color_msg.y = lux
-    self.lens_flare_color_msg.z = lux
+    self.lens_flare_color_msg.x = flux
+    self.lens_flare_color_msg.y = flux
+    self.lens_flare_color_msg.z = flux
     self.lens_flare_color_pub.publish(self.lens_flare_color_msg)
 
   # Pass sun visibility value from irg_planetary_ephemeris to shaders in our

--- a/ow_lander/materials/scripts/ow_lander.frag
+++ b/ow_lander/materials/scripts/ow_lander.frag
@@ -13,9 +13,7 @@ in vec3 wsNormal;
 in vec3 wsVecToEye;
 in vec2 wsHeightmapUV;
 in vec3 vsPos;
-//in vec3 vsNormal;
 in mat3 normalMatrix;
-//in vec3 vsVecToSun;
 
 uniform vec4 materialDiffuse;
 uniform vec4 materialSpecular;
@@ -37,8 +35,8 @@ uniform sampler2DShadow shadowMap2;
 float inverseShadowMapSize = 1.0 / float(textureSize(shadowMap0, 0).x);
 in vec4 lsPos[3];
 
-uniform vec4 vsLightPos[3];
-uniform vec4 vsLightDir[3];
+uniform vec4 wsLightPos[3];
+uniform vec4 wsLightDir[3];
 uniform vec4 lightDiffuseColor[3];
 uniform vec4 lightAtten[3];
 uniform vec4 spotlightParams[3];
@@ -49,6 +47,8 @@ uniform sampler2D spotlightMap;
 
 // output
 out vec4 outputCol;
+
+const float PI = 3.14159265358979;
 
 // Blend normals using Reoriented Normal Mapping.
 // Using RNM method from http://blog.selfshadow.com/publications/blending-in-detail
@@ -133,56 +133,85 @@ float calcPSSMDepthShadowDebug(
   return shadow;
 }
 
-// vsVecToLight must not be normalized.
-// vsNegLightDir and vsDirToEye must be normalized.
-void spotlight(in vec3 vsVecToLight,
-               in vec3 vsNegLightDir,  // Light is pointed in this direction
+// wsVecToLight must not be normalized.
+// wsLightDir must be normalized.
+vec3 spotlight(in vec3 wsVecToLight,
+               in vec3 wsLightDir,
                in vec4 attenParams,
                in vec4 spotParams,
                in vec3 color,
                in vec4 texCoord,
-               in vec3 vsDirToEye,
-               in vec3 vsNormal,
-               in float specularPower,
-               inout vec3 diffuse,
-               inout vec3 specular)
+               in int index)
 {
   // If this is not a spotlight or a spotlight isn't applied to this object
   // because it is too far away, spotParams will be set to 1,0,0,1
   if (spotParams == vec4(1, 0, 0, 1))
   {
-    return;
+    return vec3(0, 0, 0);
   }
+  else
+  {
+    float lightD = length(wsVecToLight);
+    vec3 wsDirToLight = wsVecToLight / lightD;
 
-  float lightD = length(vsVecToLight);
-  vec3 vsDirToLight = vsVecToLight / lightD;
-  vec3 vsNegLightDirNorm = normalize(vsNegLightDir);
+    // For realism, we are only using squared component in attenuation. A spotlight
+    // is really an area light, but it behaves almost exactly like a point light
+    // at about 3*diameter away from the light.
+    float atten = 1.0 / (/*attenParams.y + attenParams.z * lightD +*/ attenParams.w * lightD * lightD);
 
-  // For realism, we are only using squared component in attenuation. A spotlight
-  // is really an area light, but it behaves almost exactly like a point light
-  // at about 3*diameter away from the light.
-  float atten = 1.0 / (/*attenParams.y + attenParams.z * lightD +*/ attenParams.w * lightD * lightD);
+    // In a typical spotlight implementation, spotT would ordinarily zero-out
+    // all light outside a circle based on the spotlight cone angles:
+    // float rho = dot(-wsLightDir, wsDirToLight);
+    // float spotT = clamp((rho - spotParams.y) / (spotParams.x - spotParams.y), 0.0, 1.0);
+    // spotT = pow(spotT, spotParams.z);
+    // But we are projecting a square texture and instead cut off light outside
+    // valid texcoords {0.0, 1.0}. This avoids cutting off the texture corners.
+    // The math is a bit complicated, but it results in a spotT value of 1.0
+    // where the texture is projected and 0.0 outside the texture. A simpler
+    // implementation would use conditionals but it would likely be slower.
+    vec2 normalizedTexCoord = texCoord.xy / texCoord.w;
+    // Arbitrarily large multiplier for saturating values at 0 or 1
+    const float saturator = 1000000.0;
+    // 0 where texcoord < 0 and 1 where texcoord > 0
+    vec2 spotT0 = clamp(normalizedTexCoord * saturator, 0.0, 1.0);
+    // 0 where texcoord > 1 and 1 where texcoord < 1
+    vec2 spotT1 = clamp((vec2(1.0) - normalizedTexCoord) * saturator, 0.0, 1.0);
+    // 0 behind light and 1 in front of light
+    float spotTZ = clamp(dot(-wsLightDir, wsDirToLight) * saturator, 0.0, 1.0);
+    float spotT = spotT0.x * spotT0.y * spotT1.x * spotT1.y * spotTZ;
 
-  // Even though we are projecting textures, we use this spot cone calculation
-  // to avoid artifacts to the side of the light
-  float rho = dot(vsNegLightDirNorm, vsDirToLight);
-  float spotT = clamp((rho - spotParams.y) / (spotParams.x - spotParams.y), 0.0, 1.0);
-  // We don't need a falloff exponent to soften the spot edge because we are projecting a texture
-  //spotT = pow(spotT, spotParams.z);
+    vec3 texColor = textureProj(spotlightMap, texCoord).rgb;
 
-  vec3 texColor = textureProj(spotlightMap, texCoord).rgb;
+    // Attenuation and spot cone get baked into final light color. This is how
+    // spotlights get generalized so they can be stored in lights array.
+    return max(texColor * color * (atten * spotT), vec3(0.0));
+  }
+}
 
-  vec3 finalColor = max(texColor * color * (atten * spotT), vec3(0.0));
-  diffuse += max(dot(vsDirToLight, vsNormal), 0.0) * finalColor;
-  vec3 reflectvec = reflect(-vsDirToEye, vsNormal);
-  float spotspec = pow(max(dot(vsDirToLight, reflectvec), 0.0), specularPower);
-  specular += finalColor * spotspec;
+// Incoming vectors L, V, and N, must be normalized
+vec3 brdf_oren_nayar(vec3 L, vec3 V, vec3 N, float roughness, vec3 albedo) {
+  // Adapted from https://mimosa-pudica.net/improved-oren-nayar.html
+  float r2 = roughness * roughness;
+  float LdotV = dot(L, V);
+  float NdotL = dot(N, L);
+  float NdotV = dot(N, V);
+  float s = LdotV - NdotL * NdotV;
+  float t = mix(1.0, max(NdotL, NdotV), step(0.0, s));
+  vec3  A = vec3(1.0) - vec3(0.5 * r2 / (r2 + 0.33)) + albedo * vec3(0.17 * r2 / (r2 + 0.13));
+  float B = (0.45 * r2 / (r2 + 0.09));
+  return albedo * max(0.0, NdotL) * (A + vec3(B * s / t)) / PI;
 }
 
 // wsDirToSun, wsDirToEye, wsNormal, and wsDetailNormalHeight.xyz must be normalized
-void lighting(vec3 wsDirToSun, vec3 wsDirToEye, vec3 wsNormal, vec4 wsDetailNormalHeight, out vec3 diffuse, out vec3 specular)
+void lighting(vec3 wsDirToSun, vec3 wsDirToEye, vec3 wsNormal, vec4 wsDetailNormalHeight,
+              vec3 albedo, out vec3 diffuse, out vec3 specular)
 {
-  const float specular_power = 100.0;
+  const int NUM_LIGHTS = 3;
+  struct LightData {
+    vec3 wsVecToLight;
+    vec3 color;
+  };
+  LightData lights[NUM_LIGHTS];
 
   // shadows
   // Compute shadow lookup bias using formula from
@@ -202,16 +231,35 @@ void lighting(vec3 wsDirToSun, vec3 wsDirToEye, vec3 wsNormal, vec4 wsDetailNorm
   float surfaceDot = dot(wsNormal, wsDirToSun);
   float heightMultiplier = clamp((wsDetailNormalHeight.w * 5.0 + 5.0) - (10.0 - surfaceDot * 50.0), 0.0, 1.0);
 
-  float visibility = sunVisibility * heightMultiplier * shadow;
+  // sunlight
+  lights[0].wsVecToLight = wsDirToSun;
+  lights[0].color = sunIntensity * (sunVisibility * heightMultiplier * shadow);
 
-  // directional light diffuse
-  float sundiffuse = max(dot(wsDetailNormalHeight.xyz, wsDirToSun), 0.0);
-  diffuse += sunIntensity * (sundiffuse * visibility);
+  // lander lights
+  for (int i=0; i<2; i++) {
+    vec3 wsVecToLight = wsLightPos[i+1].xyz - wsPos;
+    lights[i+1].wsVecToLight = wsVecToLight;
+    lights[i+1].color = spotlight(wsVecToLight, wsLightDir[i+1].xyz, lightAtten[i+1],
+                                  spotlightParams[1+1], lightDiffuseColor[i+1].rgb,
+                                  spotlightTexCoord[i], i+1);
+  }
 
-  // directional light specular
-  vec3 reflectvec = reflect(-wsDirToEye, wsDetailNormalHeight.xyz);
-  float sunspec = pow(max(dot(wsDirToSun, reflectvec), 0.0), specular_power);
-  specular += sunIntensity * (sunspec * visibility);
+  const float roughness = 0.3;
+  const float specPower = 60.0;
+  for (int i = 0; i < NUM_LIGHTS; i++)
+  {
+    vec3 wsDirToLight = normalize(lights[i].wsVecToLight);
+    float nDotL = dot(wsNormal, wsDirToLight);
+    if (nDotL > 0.0)
+    {
+      diffuse += lights[i].color * brdf_oren_nayar(wsDirToLight, normalize(wsDirToEye),
+                                                   wsDetailNormalHeight.xyz, roughness, albedo);
+
+      vec3 reflectVec = reflect(-wsDirToLight, wsDetailNormalHeight.xyz);
+      float specShape = pow( max(dot(reflectVec, normalize(wsDirToEye)), 0.0), specPower);
+      specular += lights[i].color * clamp(specShape, 0.0, 1.0);
+    }
+  }
 
   // irradiance diffuse (area light source simulation)
   // Gazebo is z-up but Ogre is y-up. Must rotate before cube texture lookup.
@@ -225,21 +273,6 @@ void lighting(vec3 wsDirToSun, vec3 wsDirToEye, vec3 wsNormal, vec4 wsDetailNorm
   //vec3 reflectvec_gazebo2ogre_and_mirrored = vec3(reflectvec.x, reflectvec.z, reflectvec.y);
   // TODO: Use a specular map and use textureLod() to correlate roughness with a specific mipmap level
   //specular += texture(irradianceMap, reflectvec_gazebo2ogre_and_mirrored).rgb;
-
-  // lander lights
-  // These lander lights are computed in view space due to legacy code while
-  // sunlight is computed in world space. This is awkward and a bit confusing,
-  // but it seems premature to make this consistent before implementing multiple
-  // materials and lighting that is more advanced than the Lambertian diffuse +
-  // Phong specular model we are currently using.
-  vec3 vsDirToEye = normalize(normalMatrix * wsDirToEye);
-  vec3 vsDetailNormal = normalize(normalMatrix * wsDetailNormalHeight.xyz);
-  for (int i=0; i<2; i++) {
-    spotlight(vsLightPos[i+1].xyz - vsPos, -vsLightDir[i+1].xyz, lightAtten[i+1],
-              spotlightParams[i+1], lightDiffuseColor[i+1].rgb,
-              spotlightTexCoord[i], vsDirToEye, vsDetailNormal, specular_power,
-              diffuse, specular);
-  }
 }
 
 void main()
@@ -247,10 +280,7 @@ void main()
   vec3 wsNormalNormalized = normalize(wsNormal);
   vec3 diffuse = vec3(0);
   vec3 specular = vec3(0);
-  lighting(normalize(wsSunPosition.xyz), normalize(wsVecToEye), wsNormalNormalized, vec4(wsNormalNormalized, 1.0), diffuse, specular);
-
-  // material color
-  diffuse *= materialDiffuse.rgb;
+  lighting(normalize(wsSunPosition.xyz), normalize(wsVecToEye), wsNormalNormalized, vec4(wsNormalNormalized, 1.0), materialDiffuse.rgb, diffuse, specular);
   specular *= materialSpecular.rgb;
 
   outputCol = vec4(diffuse + specular, 1.0);

--- a/ow_lander/materials/scripts/ow_lander.material
+++ b/ow_lander/materials/scripts/ow_lander.material
@@ -32,7 +32,7 @@ fragment_program ow_lander_frag glsl
   default_params
   {
     param_named_auto wsSunPosition             light_position 0
-    // Sun lux at Jupiter
+    // Sun irradiance at Jupiter
     param_named sunIntensity                   float3 4438.0 4438.0 4438.0
     param_named sunVisibility                  float 1.0
 
@@ -48,8 +48,8 @@ fragment_program ow_lander_frag glsl
 
     // lander lights
     // Control status of lander lights (spotlights)
-    param_named_auto vsLightPos                light_position_view_space_array 3
-    param_named_auto vsLightDir                light_direction_view_space_array 3
+    param_named_auto wsLightPos                light_position_array 3
+    param_named_auto wsLightDir                light_direction_array 3
     // Color is misused to turn lights on and off
     param_named_auto lightDiffuseColor         light_diffuse_colour_array 3
     // Light intensity is baked into attenuation

--- a/ow_lander/materials/scripts/ow_lander.vert
+++ b/ow_lander/materials/scripts/ow_lander.vert
@@ -38,9 +38,7 @@ out vec3 wsNormal;
 out vec3 wsVecToEye;
 out vec2 wsHeightmapUV;
 out vec3 vsPos;
-//out vec3 vsNormal;
 out mat3 normalMatrix;
-//out vec3 vsVecToSun;
 
 // halfFOVy must be in radians. near and far must be positive.
 mat4 perspectiveProjection(float halfFOVy, float near, float far)
@@ -85,9 +83,6 @@ void main()
   wsHeightmapUV = uv0;
 
   normalMatrix = mat3(inverseTransposeWorldViewMatrix);
-
-  //vsNormal = normalMatrix * normal;
-  //vsVecToSun = normalMatrix * normalize(wsSunPosition.xyz);
 
   // PSSM shadows
   vec4 worldPos = worldMatrix * position;

--- a/ow_lander/urdf/lander_lights.xacro
+++ b/ow_lander/urdf/lander_lights.xacro
@@ -77,8 +77,8 @@
         <attenuation>
           <range>100</range>
           <!-- Our shader uses a quadratic term for attenuation, but no constant or linear terms.
-            Attenuation = 1.0 / (q * d^2) So q = 0.001 gives us 1000 lux at 1 meter.-->
-          <quadratic>0.001</quadratic>
+            Attenuation = 1.0 / (q * d^2) So q = 0.04 gives us 25 W/m^2 at 1 meter.-->
+          <quadratic>0.04</quadratic>
         </attenuation>
         <direction>0 0 -1</direction>
         <spot>

--- a/ow_lander/urdf/stereo_camera_triggered.xacro
+++ b/ow_lander/urdf/stereo_camera_triggered.xacro
@@ -159,8 +159,8 @@
         <compositor>CameraLensFlare/PF_FLOAT32_R</compositor>
       </plugin>
       <plugin name="CameraSim" filename="libIRGCameraSimSensorPlugin.so" >
-        <exposure>0.05</exposure>
-        <energy_conversion>0.005</energy_conversion>
+        <exposure>0.001</exposure>
+        <energy_conversion>80.0</energy_conversion>
       </plugin>
     </sensor>
   </gazebo>  


### PR DESCRIPTION
| Jira Ticket 🎟️ | [OCEANWATER-1218](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1218) |

This also requires sibling PR: https://github.com/nasa/ow_europa/pull/30

## Summary of Changes
* Convert light units from lux to W/m^2. Lux is a measure of intensity as perceived by the human eye, which is not so appropriate while we're using simulated cameras for all our images. Lights are now about 3X brighter, which I believe to be a reasonable value based on work on other projects (there's a lot of wiggle-room here depending on specific mission design).
* Use Oren-Nayar reflectance instead of Lambertian. Surfaces now have stronger backscatter and their radiance is slightly view-dependent. All along we had neglected to divide diffuse reflectance by pi. That's fixed now and causes the specular reflection to be considerably brighter relative to diffuse reflection.
* Use more realistic energy_conversion and exposure values. Default exposure went from 0.05 to 0.001.

In lieu of testing, here are some before and after screenshots:
* 
![camera_before](https://github.com/nasa/ow_simulator/assets/30808090/7fb75933-3b65-4d53-862a-0f7d0d4caf98) 
![camera_after](https://github.com/nasa/ow_simulator/assets/30808090/0cfed6b0-e6a2-40e4-a0ef-f15cd5b4855e)
* 
![terrain_before](https://github.com/nasa/ow_simulator/assets/30808090/6571e24a-597c-4555-b9b6-2c69a2e23a63)
![terrain_after](https://github.com/nasa/ow_simulator/assets/30808090/eed2bfc2-ce3d-4894-9d2d-a9afef5f9570)




