### PR TITLE
Baseline power draw for multiple subsystems

### DIFF
--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -24,8 +24,8 @@ voltage_range: 0.1			        # volts
 # power (watts)
 baseline_power_comms: 2.0
 baseline_power_compute: 2.0
-baseline_power_heating: 1.5
-baseline_power_science: 0.5
+baseline_power_heating: 2.0
+baseline_power_other: 0.0
 
 # temperature
 min_temperature: 17.5			      # deg. C

--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -6,20 +6,20 @@
 enable_power_system: true
 
 # configuration
-efficiency: 0.9  # a value 0 - 1
+efficiency: 0.9			            # a value 0 - 1
 
 
 # Initial battery configuration
 
-initial_power: 0.0        # watts
-initial_voltage: 25.2
-initial_temperature: 20.0 # degrees C
+initial_power: 0.0			        # watts
+initial_voltage: 25.2			      # volts
+initial_temperature: 20.0   		# deg. C
 
-initial_soc: 0.95         # % (used for first placeholder publication)
+initial_soc: 0.95           		# % (used for first placeholder publication)
 
 # voltage
-base_voltage: 16.8
-voltage_range: 0.1
+base_voltage: 16.8			        # volts
+voltage_range: 0.1			        # volts
 
 # power (watts)
 baseline_power_comms: 2.0
@@ -27,13 +27,12 @@ baseline_power_compute: 2.0
 baseline_power_heating: 1.5
 baseline_power_science: 0.5
 
-
-# temperature (C)
-min_temperature: 17.5
-max_temperature: 21.5
+# temperature
+min_temperature: 17.5			      # deg. C
+max_temperature: 21.5			      # deg. C
 
 # Estimate of battery lifetime
-battery_lifetime: 27380.0   # seconds
+battery_lifetime: 27380.0		    # s
 
 
 # Power system related configurations
@@ -55,7 +54,7 @@ active_models: 1
 # The frequency of the main loop in the power system.
 # Dictates the time interval between publications
 # & the size of the mechanical power moving average window.
-loop_rate: 1  # hz
+loop_rate: 1				            # hz
 
 # Number of threads to use for the asynchronous ROS spinning in the main
 # power system loop (to allow the joint states callback function to run
@@ -71,7 +70,7 @@ spinner_threads: 4
 # Lower values mean faster prediction returns in the event GSAP is predicting
 # beyond this value, but it also means the prognoser can't return RUL
 # values higher than this.
-max_horizon: 100000  # seconds
+max_horizon: 100000			        # s
 
 # Number of samples created by each node during prognoser predictions
 # for accuracy. Lowering this value increases the rate of prediction returns
@@ -83,14 +82,14 @@ num_samples: 100
 # is currently unknown, but the previous single-cell model
 # could not handle much more than 15W per cell. As such,
 # we multiply this by 6 to get the artificial starting cap.
-max_gsap_power_input: 90    # watts
+max_gsap_power_input: 90		    # watts
 
 
 # DEBUG CUSTOMIZATION
 
 # This flag disables all power-related debug output from printing if false.
 # The other flags allow filtering of specific messages.
-print_debug: true
+print_debug: false
 
 # Prints the timestamp of each cycle to the terminal.
 # Output: 1 line per cycle.
@@ -98,7 +97,7 @@ timestamp_print_debug: false
 
 # Prints the input data sent to GSAP's asynchronous prognosers each cycle.
 # Output: NUM_NODES lines per cycle.
-inputs_print_debug: true
+inputs_print_debug: false
 
 # Prints the information currently stored in all nodes each cycle.
 # Output: NUM_NODES lines per cycle.

--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -6,30 +6,34 @@
 enable_power_system: true
 
 # configuration
-efficiency: 0.9			            # a value 0 - 1
+efficiency: 0.9  # a value 0 - 1
 
 
 # Initial battery configuration
 
-initial_power: 0.0			        # watts
-initial_voltage: 25.2			      # volts
-initial_temperature: 20.0   		# deg. C
+initial_power: 0.0        # watts
+initial_voltage: 25.2
+initial_temperature: 20.0 # degrees C
 
-initial_soc: 0.95           		# % (used for first placeholder publication)
+initial_soc: 0.95         # % (used for first placeholder publication)
 
 # voltage
-base_voltage: 16.8			        # volts
-voltage_range: 0.1			        # volts
+base_voltage: 16.8
+voltage_range: 0.1
 
-# power
-baseline_power: 6.0			        # watts
+# power (watts)
+baseline_power_comms: 2.0
+baseline_power_compute: 2.0
+baseline_power_heating: 1.5
+baseline_power_science: 0.5
 
-# temperature
-min_temperature: 17.5			      # deg. C
-max_temperature: 21.5			      # deg. C
+
+# temperature (C)
+min_temperature: 17.5
+max_temperature: 21.5
 
 # Estimate of battery lifetime
-battery_lifetime: 27380.0		    # s
+battery_lifetime: 27380.0   # seconds
 
 
 # Power system related configurations
@@ -51,7 +55,7 @@ active_models: 1
 # The frequency of the main loop in the power system.
 # Dictates the time interval between publications
 # & the size of the mechanical power moving average window.
-loop_rate: 1				            # hz
+loop_rate: 1  # hz
 
 # Number of threads to use for the asynchronous ROS spinning in the main
 # power system loop (to allow the joint states callback function to run
@@ -67,7 +71,7 @@ spinner_threads: 4
 # Lower values mean faster prediction returns in the event GSAP is predicting
 # beyond this value, but it also means the prognoser can't return RUL
 # values higher than this.
-max_horizon: 100000			        # s
+max_horizon: 100000  # seconds
 
 # Number of samples created by each node during prognoser predictions
 # for accuracy. Lowering this value increases the rate of prediction returns
@@ -79,14 +83,14 @@ num_samples: 100
 # is currently unknown, but the previous single-cell model
 # could not handle much more than 15W per cell. As such,
 # we multiply this by 6 to get the artificial starting cap.
-max_gsap_power_input: 90		    # watts
+max_gsap_power_input: 90    # watts
 
 
 # DEBUG CUSTOMIZATION
 
 # This flag disables all power-related debug output from printing if false.
 # The other flags allow filtering of specific messages.
-print_debug: false
+print_debug: true
 
 # Prints the timestamp of each cycle to the terminal.
 # Output: 1 line per cycle.
@@ -94,7 +98,7 @@ timestamp_print_debug: false
 
 # Prints the input data sent to GSAP's asynchronous prognosers each cycle.
 # Output: NUM_NODES lines per cycle.
-inputs_print_debug: false
+inputs_print_debug: true
 
 # Prints the information currently stored in all nodes each cycle.
 # Output: NUM_NODES lines per cycle.

--- a/ow_power_system/src/PrognoserInputHandler.cpp
+++ b/ow_power_system/src/PrognoserInputHandler.cpp
@@ -53,7 +53,7 @@ bool PrognoserInputHandler::loadSystemConfig()
     m_baseline_wattage = (system_config.getDouble("baseline_power_comms") +
 			  system_config.getDouble("baseline_power_compute") +
 			  system_config.getDouble("baseline_power_heating") +
-			  system_config.getDouble("baseline_power_science"));
+			  system_config.getDouble("baseline_power_other"));
     m_max_gsap_input_watts = system_config.getDouble("max_gsap_power_input");
     m_time_interval = 1 / (system_config.getDouble("loop_rate"));
   }

--- a/ow_power_system/src/PrognoserInputHandler.cpp
+++ b/ow_power_system/src/PrognoserInputHandler.cpp
@@ -50,13 +50,16 @@ bool PrognoserInputHandler::loadSystemConfig()
     m_efficiency = system_config.getDouble("efficiency");
     m_temperature_dist = uniform_real_distribution<double>(m_min_temperature,
                                                           m_max_temperature);
-    m_baseline_wattage = system_config.getDouble("baseline_power");
+    m_baseline_wattage = (system_config.getDouble("baseline_power_comms") +
+			  system_config.getDouble("baseline_power_compute") +
+			  system_config.getDouble("baseline_power_heating") +
+			  system_config.getDouble("baseline_power_science"));
     m_max_gsap_input_watts = system_config.getDouble("max_gsap_power_input");
     m_time_interval = 1 / (system_config.getDouble("loop_rate"));
   }
   catch(const std::exception& err)
   {
-    ROS_ERROR_STREAM("OW_POWER_SYSTEM ERROR: " << err.what() 
+    ROS_ERROR_STREAM("OW_POWER_SYSTEM ERROR: " << err.what()
                      << " while attempting to read system.cfg"
                      << " in an input handler!\n"
                      << "Ensure system.cfg is formatted properly before "


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-697](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-697) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-1232](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1232) |
| Github :octocat:  | # |


## Summary of Changes
* Replaces the `baseline_power` configuration parameter with a set of new ones for specific subsystems.

## Test
* Edit `ow_simulator/ow_power_system/config/system.cfg` and set the following debug flags to true: `print_debug`, `inputs_print_debug`.
* Start any simulator world.
* Verify that a message similar to the following repeats in the ensuing shell output: 
```
[ INFO]: M00 INPUT power: 6.000000.  volts: 17.603089.  tmp: 17.704866
```
The input power should always be 6.0.
