### PR TITLE
Updated baseline power categories and values

### DIFF
--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -22,10 +22,16 @@ base_voltage: 16.8			        # volts
 voltage_range: 0.1			        # volts
 
 # power (watts)
-baseline_power_comms: 2.0
-baseline_power_compute: 2.0
-baseline_power_heating: 2.0
-baseline_power_other: 0.0
+# These estimated values are per cell and are based on the Europa
+# Lander Study as well as sample values from other planetary rovers.
+baseline_power_camera: 0.1
+baseline_power_lights: 0.6
+baseline_power_communications: 0.6
+baseline_power_computing: 0.1
+baseline_power_heating: 1.2
+baseline_power_science_instr: 0.6
+baseline_power_sample_handling: 0.6
+baseline_power_other: 2.2
 
 # temperature
 min_temperature: 17.5			      # deg. C

--- a/ow_power_system/src/PrognoserInputHandler.cpp
+++ b/ow_power_system/src/PrognoserInputHandler.cpp
@@ -50,9 +50,13 @@ bool PrognoserInputHandler::loadSystemConfig()
     m_efficiency = system_config.getDouble("efficiency");
     m_temperature_dist = uniform_real_distribution<double>(m_min_temperature,
                                                           m_max_temperature);
-    m_baseline_wattage = (system_config.getDouble("baseline_power_comms") +
-			  system_config.getDouble("baseline_power_compute") +
+    m_baseline_wattage = (system_config.getDouble("baseline_power_camera") +
+			  system_config.getDouble("baseline_power_lights") +
+			  system_config.getDouble("baseline_power_communications") +
+			  system_config.getDouble("baseline_power_computing") +
 			  system_config.getDouble("baseline_power_heating") +
+			  system_config.getDouble("baseline_power_science_instr") +
+			  system_config.getDouble("baseline_power_sample_handling") +
 			  system_config.getDouble("baseline_power_other"));
     m_max_gsap_input_watts = system_config.getDouble("max_gsap_power_input");
     m_time_interval = 1 / (system_config.getDouble("loop_rate"));


### PR DESCRIPTION
## Linked Issues: 
None

## Summary of Changes

* Updated baseline power parameters and values based on the Power Consumption wiki as of 1/25/24.

## Test

* Edit `ow_simulator/ow_power_system/config/system.cfg` and set the following debug flags to true: `print_debug`, `inputs_print_debug`.
* Start any simulator world.
* Verify that a message similar to the following repeats in the ensuing shell output: 
```
[ INFO]: M00 INPUT power: 6.000000.  volts: 17.603089.  tmp: 17.704866
```
The input power should always be 6.0.