### PR TITLE
Replaced baseline power draw for lights with computed value

### DIFF
--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -1,8 +1,10 @@
-# IMPORTANT: If disabled, the power system will not run predictions
-# 	     or use GSAP. All power publications will remain static.
-#	     This maximizes performance for those not looking for
-#	     power predictions, but the power system will not react
-#	     to anything as a result.
+# Power system related configurations
+
+# IMPORTANT: If disabled, the power system will not run predictions or
+# use GSAP. All power publications will remain static.  This maximizes
+# performance for those not looking for power predictions, but the
+# power system will not react to anything as a result.
+#
 enable_power_system: true
 
 # configuration
@@ -21,17 +23,21 @@ initial_soc: 0.95           		# % (used for first placeholder publication)
 base_voltage: 16.8			        # volts
 voltage_range: 0.1			        # volts
 
-# power (watts)
-# These estimated values are per cell and are based on the Europa
-# Lander Study as well as sample values from other planetary rovers.
+# Power values (wattage). These estimated values are per cell. Some
+# are based on a Europa Lander draft specification, others on sample
+# values from other planetary rovers, and some are just guesses.
+
+# Baseline values (watts) for constant power draws.
 baseline_power_camera: 0.1
-baseline_power_lights: 0.6
 baseline_power_communications: 0.6
 baseline_power_computing: 0.1
 baseline_power_heating: 1.2
 baseline_power_science_instr: 0.6
 baseline_power_sample_handling: 0.6
 baseline_power_other: 2.2
+
+# Power coefficients for dynamically computed power draw.
+wattage_coefficient_lights: 0.3
 
 # temperature
 min_temperature: 17.5			      # deg. C
@@ -40,8 +46,6 @@ max_temperature: 21.5			      # deg. C
 # Estimate of battery lifetime
 battery_lifetime: 27380.0		    # s
 
-
-# Power system related configurations
 
 # IMPORTANT: This value governs the number of GSAP prognosers
 # initialized by the power system to get predictions. 4

--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -37,7 +37,7 @@ baseline_power_sample_handling: 0.6
 baseline_power_other: 2.2
 
 # Power coefficients for dynamically computed power draw.
-wattage_coefficient_lights: 0.3
+wattage_coefficient_lights: 0.3    # power draw (W) per light at max intensity
 
 # temperature
 min_temperature: 17.5			      # deg. C

--- a/ow_power_system/include/PrognoserInputHandler.h
+++ b/ow_power_system/include/PrognoserInputHandler.h
@@ -5,7 +5,7 @@
 // This is the header file for the PrognoserInputHandler class, which controls
 // the inputs to a single prognoser within a PowerSystemNode. It stores the
 // data used as inputs to a GSAP asynchronous prognoser and generates the next
-// input set (including any value modifications from faults or other functions) 
+// input set (including any value modifications from faults or other functions)
 // to be sent to GSAP.
 
 #ifndef __PROGNOSER_INPUT_HANDLER_H__
@@ -48,6 +48,8 @@ private:
   double generateTemperatureEstimate();
   double generateVoltageEstimate();
   void applyValueMods(double& power, double& voltage, double& temperature);
+  double electricalPower() const;
+  double electricalPowerLights() const;
 
   double m_init_time = 0;
 
@@ -61,7 +63,7 @@ private:
   double m_voltage_range;       // [V]
   double m_efficiency;          // default 90% efficiency
   double m_baseline_wattage;    // Base power drawn by continuously-running systems.
-
+  double m_wattage_coefficient_lights;
   double m_current_timestamp = 0.0;
 
   // HACK ALERT.  The prognoser produced erratic/erroneous output when

--- a/ow_power_system/src/PrognoserInputHandler.cpp
+++ b/ow_power_system/src/PrognoserInputHandler.cpp
@@ -136,11 +136,12 @@ void PrognoserInputHandler::applyValueMods(double& power,
 
 double PrognoserInputHandler::electricalPower () const
 {
-  return
-    // Power consumption of joints (arm, antenna)
-    m_mechanical_power_to_be_processed / m_efficiency +
-    // Power consumption of other systems (more to be added)
-    electricalPowerLights();
+ return (
+   // Power consumption of joints (arm, antenna)
+   m_mechanical_power_to_be_processed / m_efficiency +
+   // Power consumption of other systems (more to be added)
+   electricalPowerLights()
+ );
 }
 
 double PrognoserInputHandler::electricalPowerLights () const

--- a/ow_power_system/src/PrognoserInputHandler.cpp
+++ b/ow_power_system/src/PrognoserInputHandler.cpp
@@ -51,13 +51,14 @@ bool PrognoserInputHandler::loadSystemConfig()
     m_temperature_dist = uniform_real_distribution<double>(m_min_temperature,
                                                           m_max_temperature);
     m_baseline_wattage = (system_config.getDouble("baseline_power_camera") +
-			  system_config.getDouble("baseline_power_lights") +
 			  system_config.getDouble("baseline_power_communications") +
 			  system_config.getDouble("baseline_power_computing") +
 			  system_config.getDouble("baseline_power_heating") +
 			  system_config.getDouble("baseline_power_science_instr") +
 			  system_config.getDouble("baseline_power_sample_handling") +
 			  system_config.getDouble("baseline_power_other"));
+    m_wattage_coefficient_lights =
+      system_config.getDouble("wattage_coefficient_lights");
     m_max_gsap_input_watts = system_config.getDouble("max_gsap_power_input");
     m_time_interval = 1 / (system_config.getDouble("loop_rate"));
   }
@@ -132,6 +133,24 @@ void PrognoserInputHandler::applyValueMods(double& power,
   m_temperature_modifier = 0.0;
 }
 
+
+double PrognoserInputHandler::electricalPower () const
+{
+  return
+    // Power consumption of joints (arm, antenna)
+    m_mechanical_power_to_be_processed / m_efficiency +
+    // Power consumption of other systems (more to be added)
+    electricalPowerLights();
+}
+
+double PrognoserInputHandler::electricalPowerLights () const
+{
+  double left_intensity, right_intensity;
+  ros::param::getCached("/OWLightControlPlugin/left_light", left_intensity);
+  ros::param::getCached("/OWLightControlPlugin/right_light", right_intensity);
+  return m_wattage_coefficient_lights * (left_intensity + right_intensity);
+}
+
 /*
  * Compiles the input values of power/voltage/temperature to be sent into GSAP
  * by the PowerSystemNode each cycle.
@@ -145,14 +164,12 @@ bool PrognoserInputHandler::cyclePrognoserInputs()
   {
     m_init_time = ros::Time::now().toSec();
   }
-  // Calculate actual power applied to the system.
-  double electrical_power = m_mechanical_power_to_be_processed / m_efficiency;
 
   // Temperature estimate based on pseudorandom noise and fixed range
   m_current_timestamp += m_time_interval;
   m_temperature_estimate = generateTemperatureEstimate();
   m_voltage_estimate = generateVoltageEstimate();
-  m_wattage_estimate = electrical_power + m_baseline_wattage;
+  m_wattage_estimate = electricalPower() + m_baseline_wattage;
   applyValueMods(m_wattage_estimate, m_voltage_estimate, m_temperature_estimate);
 
   if (m_wattage_estimate > m_max_gsap_input_watts) {


### PR DESCRIPTION
## Linked Issues:
| EPIC ⚡ | [OCEANWATER-697](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-697) |
| :----------- | :----------- |
| Jira Ticket 🎟️ | [OCEANWATER-702](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-702) |
| Github :octocat:  | # |


## Summary of Changes
* Replaced baseline power draw for lights with computed value

## Test
* Edit `ow_simulator/ow_power_system/config/system.cfg`
   * set `print_debug` and `inputs_print_debug` to true
* Start any simulator world
* Note the input power of 6.0 (watts) printing in the shell.
* Tilt the antenna so that you can see the lander lights shine on the rover: `rosrun ow_lander tilt.py 1.2`
   * Note the input power increase above 6.0 while the antenna is moving - this a regression test.
* Noting the lights are initially at full intensity, experiment with different intensities using values [0..1) for N:
   * `rosrun ow_lander light_set_intensity.py left N`
   * `rosrun ow_lander light_set_intensity.py right N`
* Note a 0.3 watt drop in input power for each fully turned off light.  (E.g. both lights off will lower input wattage to 5.4, both at half intensity will lower it to 5.7).
 
