### PR TITLE
Hotfix for camera goal error

### DIFF
--- a/ow_faults_detection/src/FaultDetector.cpp
+++ b/ow_faults_detection/src/FaultDetector.cpp
@@ -237,7 +237,6 @@ void FaultDetector::cameraTriggerCb(const std_msgs::Empty& msg)
   if (m_camera_data_pending) {
     m_camera_faults_flags |= CameraFaultsStatus::NO_IMAGE;
     m_system_faults_flags |= SystemFaultsStatus::CAMERA_EXECUTION_ERROR;
-    m_system_faults_flags |= SystemFaultsStatus::CAMERA_GOAL_ERROR;
 
     // publish updated faults messages (exonerated faults published in cameraRawCb)
     publishFaultsMessage(m_camera_faults_msg_pub, CameraFaultsStatus(), m_camera_faults_flags);
@@ -251,7 +250,6 @@ void FaultDetector::cameraRawCb(const sensor_msgs::Image& msg)
   // exonerate fault when camera_raw data is received
   m_camera_faults_flags &= ~CameraFaultsStatus::NO_IMAGE;
   m_system_faults_flags &= ~SystemFaultsStatus::CAMERA_EXECUTION_ERROR;
-  m_system_faults_flags &= ~SystemFaultsStatus::CAMERA_GOAL_ERROR;
   m_camera_data_pending = false;
 
   // publish updated faults messages


### PR DESCRIPTION
### Summary

Recently, fault detection was modified to flag a goal error if there is no point cloud received after the camera is triggered.  The problem here is that the check was done *just* after the trigger.  Some point clouds may need more time to arrive.

This "fix" also allowed goal errors to get flagged when the camera was triggered without the `CameraCapture` action, i.e. via a message.  However this is invalid, because goal errors should only be associated with actions.  I.e. actions have goals, pure messages do not.

This hotfix is simply to remove this invalid "fix".

## Test
* Try ReferenceMission1 without this hotfix and see most or every CameraCapture fail due to spurious goal errors.
* Apply the hotfix, and ReferenceMission1 should be free of the above problem.
* Inject the camera fault and run `camera_capture.py`.  You should experience a goal error.
