### PR TITLE
Planning timeout increase for TaskDiscardSample

### DIFF
--- a/ow_lander/config/ompl_planning.yaml
+++ b/ow_lander/config/ompl_planning.yaml
@@ -33,7 +33,7 @@ planner_configs:
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   RRTstar:
     type: geometric::RRTstar
-    termination_condition: Iteration[1000]
+    termination_condition: Iteration[3000]
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
     goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
     optimization_objective: MechanicalWorkOptimizationObjective # Optimizer minimizes the mechanical effort

--- a/ow_lander/config/ompl_planning.yaml
+++ b/ow_lander/config/ompl_planning.yaml
@@ -33,10 +33,12 @@ planner_configs:
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   RRTstar:
     type: geometric::RRTstar
+    termination_condition: Iteration[1000]
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
     goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
     optimization_objective: MechanicalWorkOptimizationObjective # Optimizer minimizes the mechanical effort
     delay_collision_checking: 1  # Stop collision checking as soon as C-free parent found. default 1
+
   TRRT:
     type: geometric::TRRT
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()

--- a/ow_lander/launch/spawn.launch
+++ b/ow_lander/launch/spawn.launch
@@ -92,7 +92,7 @@
   <!-- == launch the action servers ============== -->
   <arg name="node_start_delay" default="10.0" />  
   <node pkg="ow_lander" name="lander_action_servers" type="lander_action_servers.py"
-    launch-prefix="bash -c 'sleep $(arg node_start_delay); $0 $@' " output="screen" respawn="true"/>
+    launch-prefix="bash -c 'sleep $(arg node_start_delay); $0 $@' " output="screen"/>
 
   <!-- == launch the state repackaging node ============== -->
   <node pkg="ow_lander" name="state_publisher" type="state_publisher.py" output="screen"/>

--- a/ow_lander/launch/spawn.launch
+++ b/ow_lander/launch/spawn.launch
@@ -92,7 +92,7 @@
   <!-- == launch the action servers ============== -->
   <arg name="node_start_delay" default="10.0" />  
   <node pkg="ow_lander" name="lander_action_servers" type="lander_action_servers.py"
-    launch-prefix="bash -c 'sleep $(arg node_start_delay); $0 $@' " output="screen"/>
+    launch-prefix="bash -c 'sleep $(arg node_start_delay); $0 $@' " output="screen" respawn="true"/>
 
   <!-- == launch the state repackaging node ============== -->
   <node pkg="ow_lander" name="state_publisher" type="state_publisher.py" output="screen"/>

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -542,6 +542,8 @@ class TaskDiscardSampleServer(mixins.FrameMixin, mixins.ArmTrajectoryMixin,
     discard_surface_pos = self.transform_to_planning_frame(
       self.get_intended_position(goal.frame, goal.relative, goal.point)).point
     self._arm.move_group_scoop.set_planner_id("RRTstar")
+    PLANNING_TIMEOUT = 0.1
+    self._arm.move_group_scoop.set_planning_time(PLANNING_TIMEOUT)
     try:
       sequence = TrajectorySequence(
         self._arm.robot, self._arm.move_group_scoop, 'l_scoop')

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -225,7 +225,7 @@ class GuardedMoveServer(mixins.ArmActionMixin, ActionServerBase):
         self._pub_result.publish(False, '', Point())
         self._set_succeeded("No ground detected", final=Point(), success=False)
     finally:
-      self._arm.move_group_scoop.set_planner_id('RRTstar')
+      self._arm.move_group_scoop.set_planner_id('RRTConnect')
 
 
 class ArmUnstowServer(mixins.ArmTrajectoryMixin, ActionServerBase):


### PR DESCRIPTION
## Sibling PR
https://github.com/nasa/ow_autonomy/pull/149

## Summary of Changes
* Added a planning time override for TaskDiscardSample only that restores the previous planning time values after completion of the action. 
* Added an `Iteration` termination condition for all RRTStar planned actions. This means the action will either reach the timeout or the iteration limit. 
* Fixed a bug where GuardedMove was not switching the planner back to RRTConnect after concluding. 

## Test
1. Have this ow_simulator on planning-timeout-test and ow_autonomy on remove-tailings-default-discard-arguments. Everything else on noetic-devel. 
2. Run ReferenceMission1.plx. several times. This passes so long as there is not a single plan trajectory failure. 