### PR TITLE
HOTFIX All baseline power distributed across all 4 power cells

### DIFF
--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -27,15 +27,13 @@ voltage_range: 0.1
 # are based on a Europa Lander draft specification, others on sample
 # values from other planetary rovers, and some are just guesses.
 
-# Per-cell baseline power draws (watts)
-baseline_power_computing: 0.1
-baseline_power_heating: 1.2
-baseline_power_science_instr: 0.6
-baseline_power_sample_handling: 0.6
-baseline_power_other: 2.2
-
 # Baseline power draws (watts)
 power_baseline_camera_controller: 1.6
+power_baseline_computing: 0.1
+power_baseline_heating: 1.2
+power_baseline_science_instr: 0.6
+power_baseline_sample_handling: 0.6
+power_baseline_other: 2.2
 
 # Power draws (watts) while components are active
 power_active_lights: 4.8        # power draw (W) per light at max intensity

--- a/ow_power_system/config/system.cfg
+++ b/ow_power_system/config/system.cfg
@@ -27,7 +27,7 @@ voltage_range: 0.1
 # are based on a Europa Lander draft specification, others on sample
 # values from other planetary rovers, and some are just guesses.
 
-# Baseline power draws (watts)
+# Baseline power draws in Watts. These cannot be turned off during simulation.
 power_baseline_camera_controller: 1.6
 power_baseline_computing: 0.1
 power_baseline_heating: 1.2
@@ -35,10 +35,10 @@ power_baseline_science_instr: 0.6
 power_baseline_sample_handling: 0.6
 power_baseline_other: 2.2
 
-# Power draws (watts) while components are active
+# Power draws in Watts for certain components while they are active.
 power_active_lights: 4.8        # power draw (W) per light at max intensity
-power_active_camera: 0.1        # power draw while stereo camera exposes
-power_active_comms: 9.6         # power draw when comms is activated
+power_active_camera: 0.1        # power draw (W) while stereo camera exposes
+power_active_comms: 9.6         # power draw (W) when comms is activated
 
 # Temperature
 min_temperature: 17.5      # deg. C

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -144,7 +144,7 @@ private:
   
   double m_mechanical_efficiency;
 
-  // Watts drawn by the system in idle. These cannot be turned off and are a
+  // Watts drawn by the system in idle. These cannot be turned off and is a
   // sum of several values in the system.cfg prefixed with power_baseline_
   double m_power_baseline;
 

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -144,12 +144,12 @@ private:
   
   double m_mechanical_efficiency;
 
-  // Watts drawn by a single light at maximum intensity
-  double m_power_active_lights;
-
   // Watts drawn by the system in idle. These cannot be turned off and are a
   // sum of several values in the system.cfg prefixed with power_baseline_
   double m_power_baseline;
+
+  // Watts drawn by a single light at maximum intensity.
+  double m_power_active_lights;
 
   // End system.cfg variables.
 

--- a/ow_power_system/include/PowerSystemNode.h
+++ b/ow_power_system/include/PowerSystemNode.h
@@ -144,8 +144,12 @@ private:
   
   double m_mechanical_efficiency;
 
+  // Watts drawn by a single light at maximum intensity
   double m_power_active_lights;
-  double m_power_baseline_camera_controller;
+
+  // Watts drawn by the system in idle. These cannot be turned off and are a
+  // sum of several values in the system.cfg prefixed with power_baseline_
+  double m_power_baseline;
 
   // End system.cfg variables.
 

--- a/ow_power_system/include/PrognoserInputHandler.h
+++ b/ow_power_system/include/PrognoserInputHandler.h
@@ -59,7 +59,6 @@ private:
   double m_battery_lifetime;    // Estimate of battery lifetime (seconds)
   double m_base_voltage;        // [V] estimate
   double m_voltage_range;       // [V]
-  double m_baseline_wattage;    // Base power drawn by continuously-running systems.
   double m_current_timestamp = 0.0;
 
   // HACK ALERT.  The prognoser produced erratic/erroneous output when

--- a/ow_power_system/src/PowerSystemNode.cpp
+++ b/ow_power_system/src/PowerSystemNode.cpp
@@ -93,8 +93,14 @@ void PowerSystemNode::initAndRun()
     m_spinner_threads = system_config.getInt32("spinner_threads");
     m_mechanical_efficiency = system_config.getDouble("motor_efficiency");
     m_power_active_lights = system_config.getDouble("power_active_lights");
-    m_power_baseline_camera_controller
-      = system_config.getDouble("power_baseline_camera_controller");
+    m_power_baseline = (
+        system_config.getDouble("power_baseline_camera_controller")
+      + system_config.getDouble("power_baseline_computing")
+      + system_config.getDouble("power_baseline_heating")
+      + system_config.getDouble("power_baseline_science_instr")
+      + system_config.getDouble("power_baseline_sample_handling")
+      + system_config.getDouble("power_baseline_other")
+    );
     // use ROS Param to make other nodes, such as the lander action servers,
     // aware of power parameters
     m_nh.setParam(
@@ -284,7 +290,7 @@ void PowerSystemNode::initAndRun()
       = (
           actual_mech_power
           + m_electrical_power
-          + m_power_baseline_camera_controller
+          + m_power_baseline
           + electricalPowerLights()
         ) / (NUM_MODELS - m_deactivated_models);
     for (int i = 0; i < m_active_models; i++)

--- a/ow_power_system/src/PrognoserInputHandler.cpp
+++ b/ow_power_system/src/PrognoserInputHandler.cpp
@@ -49,13 +49,6 @@ bool PrognoserInputHandler::loadSystemConfig()
     m_battery_lifetime = system_config.getDouble("battery_lifetime");
     m_temperature_dist = uniform_real_distribution<double>(m_min_temperature,
                                                           m_max_temperature);
-    m_baseline_wattage = (
-		  system_config.getDouble("baseline_power_computing") +
-		  system_config.getDouble("baseline_power_heating") +
-		  system_config.getDouble("baseline_power_science_instr") +
-		  system_config.getDouble("baseline_power_sample_handling") +
-		  system_config.getDouble("baseline_power_other")
-    );
     m_max_gsap_input_watts = system_config.getDouble("max_gsap_power_input");
     m_time_interval = 1 / (system_config.getDouble("loop_rate"));
   }
@@ -149,7 +142,7 @@ bool PrognoserInputHandler::cyclePrognoserInputs()
   m_current_timestamp += m_time_interval;
   m_temperature_estimate = generateTemperatureEstimate();
   m_voltage_estimate = generateVoltageEstimate();
-  m_wattage_estimate = m_power_load + m_baseline_wattage;
+  m_wattage_estimate = m_power_load;
   applyValueMods(m_wattage_estimate, m_voltage_estimate, m_temperature_estimate);
 
   if (m_wattage_estimate > m_max_gsap_input_watts) {


### PR DESCRIPTION
## Linked Issues:
 Jira Ticket 🎟️ | [OCEANWATER-1245](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1245)

## Summary of Changes
* All baseline power is now distributed evenly across as power nodes connected in parallel. 

## Test
1. Go into `ow_power_system/config/system.cfg` and change `print_debug` to **true** and `inputs_print_debug` to **true**.
2. Start the simulation in any world. You will see the following line continually print. 
```
[ INFO:/power_system_node] M00 INPUT power: 3.975000.  volts: 17.611784.  tmp: 18.298205
```
3. In RQT increase `battery_nodes_to_disconnect` to 1 and tick `disconnect_battery_nodes`. The message should now equal the same power, but distributed across only 3 nodes instead of 4. We can compute what this value should be with 3.975 * 4 / 3 = 5.3
```
[ INFO:/power_system_node] disconnect_battery_nodes activated!
[ INFO:/power_system_node] disconnect_battery_nodes updated! 1 out of 4 models are now disconnected.
[ INFO:/power_system_node] M00 INPUT power: 5.300000.  volts: 17.656972.  tmp: 19.390101
```
4. Increase `battery_nodes_to_disconnect` to 2 for a new value of 3.975 * 4 / 2 = 7.95
```
[ INFO:/power_system_node] disconnect_battery_nodes updated! 2 out of 4 models are now disconnected.
[ INFO:/power_system_node] M00 INPUT power: 7.950000.  volts: 17.692063.  tmp: 18.740624
```
5. Increase `battery_nodes_to_disconnect` to 3 for a new value of 3.975 * 4 / 1 = 15.9
```
[ INFO:/power_system_node] disconnect_battery_nodes updated! 3 out of 4 models are now disconnected.
[ INFO:/power_system_node] M00 INPUT power: 15.900000.  volts: 17.624586.  tmp: 20.168456
```
