### PR TITLE
Fixed tf broadcasting the wrong transform for world -> base_link

### DIFF
--- a/ow_lander/config/moveit.rviz
+++ b/ow_lander/config/moveit.rviz
@@ -436,7 +436,7 @@ Visualization Manager:
   Global Options:
     Background Color: 48; 48; 48
     Default Light: true
-    Fixed Frame: world
+    Fixed Frame: base_link
     Frame Rate: 30
   Name: root
   Tools:
@@ -484,5 +484,5 @@ Window Geometry:
   Views:
     collapsed: false
   Width: 1211
-  X: 1334
-  Y: 0
+  X: 0
+  Y: 56

--- a/ow_lander/launch/spawn.launch
+++ b/ow_lander/launch/spawn.launch
@@ -35,7 +35,9 @@
   <!-- Load lander urdf -->
   <param name="robot_description"
     command="$(find xacro)/xacro '$(find ow_lander)/urdf/lander.xacro'
-    freeze_base_link:=$(arg freeze_base_link)"/>
+    freeze_base_link:=$(arg freeze_base_link)
+    x:=$(arg init_x) y:=$(arg init_y) z:=$(arg init_z)
+    R:=$(arg init_R) P:=$(arg init_P) Y:=$(arg init_Y)"/>
 
   <!-- Spawn lander in gazebo with the arm in a stowed pose -->
   <!-- -J (initial joint position) must affect joints *and* controllers. Due to
@@ -45,8 +47,6 @@
        https://answers.ros.org/question/216420/initial-joint-angles -->
   <node name="lander_model" pkg="gazebo_ros" type="spawn_model" output="screen"
     args="-urdf -param robot_description -model lander
-    -x $(arg init_x) -y $(arg init_y) -z $(arg init_z)
-    -R $(arg init_R) -P $(arg init_P) -Y $(arg init_Y)
     -J j_shou_yaw $(arg stowed_shou_yaw)
     -J j_shou_pitch $(arg stowed_shou_pitch)
     -J j_prox_pitch $(arg stowed_prox_pitch)

--- a/ow_lander/src/ow_lander/actions.py
+++ b/ow_lander/src/ow_lander/actions.py
@@ -758,7 +758,7 @@ class ArmFindSurfaceServer(mixins.FrameMixin, mixins.ArmActionMixin,
 
   def publish_feedback_cb(self, distance=0, force=0, torque=0):
     self._publish_feedback(
-      pose=self.get_end_effector_pose(constants.FRAME_ID_BASE).pose,
+      pose=self.get_end_effector_pose(constants.DEFAULT_PLANNING_FRAME).pose,
       distance=distance,
       force=force,
       torque=torque
@@ -818,8 +818,12 @@ class ArmFindSurfaceServer(mixins.FrameMixin, mixins.ArmActionMixin,
     except ArmError as err:
       self._arm.checkin_arm(self.name)
       self._set_aborted(str(err) + " - Setup trajectory failed",
-        final_pose=self.get_end_effector_pose(constants.FRAME_ID_BASE).pose,
-        final_distance=0, final_force=0, final_torque=0)
+        final_pose=self.get_end_effector_pose(
+          constants.DEFAULT_PLANNING_FRAME).pose,
+        final_distance=0,
+        final_force=0,
+        final_torque=0
+      )
       if isinstance(err, ArmPlanningError):
         self.fault_handler.set_arm_faults(ArmFaultsStatus.TRAJECTORY_GENERATION)
       return
@@ -828,12 +832,16 @@ class ArmFindSurfaceServer(mixins.FrameMixin, mixins.ArmActionMixin,
       if not self.verify_pose_reached(intended_start_pose_stamped,
                                       comparison_transform):
        self._set_aborted("Failed to reach setup pose.",
-          final_pose=self.get_end_effector_pose(constants.FRAME_ID_BASE).pose,
-          final_distance=0, final_force=0, final_torque=0)
+        final_pose=self.get_end_effector_pose(
+          constants.DEFAULT_PLANNING_FRAME).pose,
+        final_distance=0,
+        final_force=0,
+        final_torque=0
+      )
        return
     # local function to compute progress of the action during surface approach
     def compute_distance():
-      pose = self.get_end_effector_pose(constants.FRAME_ID_BASE).pose
+      pose = self.get_end_effector_pose(constants.DEFAULT_PLANNING_FRAME).pose
       d = math3d.subtract(pose.position, estimated_surface_stamped.point)
       return math3d.norm(d)
     # setup F/T monitor and its callback
@@ -856,7 +864,8 @@ class ArmFindSurfaceServer(mixins.FrameMixin, mixins.ArmActionMixin,
     except ArmError as err:
       self._arm.checkin_arm(self.name)
       self._set_aborted(str(err) + " - Surface approach trajectory failed",
-        final_pose=self.get_end_effector_pose(constants.FRAME_ID_BASE).pose,
+        final_pose=self.get_end_effector_pose(
+          constants.DEFAULT_PLANNING_FRAME).pose,
         final_distance=compute_distance(),
         final_force=monitor.get_force(),
         final_torque=monitor.get_torque()
@@ -866,7 +875,8 @@ class ArmFindSurfaceServer(mixins.FrameMixin, mixins.ArmActionMixin,
     else:
       self._arm.checkin_arm(self.name)
       results = {
-        'final_pose' : self.get_end_effector_pose(constants.FRAME_ID_BASE).pose,
+        'final_pose' : self.get_end_effector_pose(
+          constants.DEFAULT_PLANNING_FRAME).pose,
         'final_distance' : compute_distance(),
         'final_force'    : monitor.get_force(),
         'final_torque'   : monitor.get_torque(),
@@ -1356,7 +1366,7 @@ class PanTiltMoveCartesianServer(mixins.PanTiltMoveMixin, ActionServerBase):
   fault_handler = faults.PanTiltFaultHandler()
 
   def execute_action(self, goal):
-    LOOKAT_FRAME = constants.FRAME_ID_BASE
+    LOOKAT_FRAME = constants.DEFAULT_PLANNING_FRAME
     cam_center = FrameTransformer().lookup_transform(LOOKAT_FRAME,
                                                      'StereoCameraCenter_link')
     tilt_joint = FrameTransformer().lookup_transform(LOOKAT_FRAME,

--- a/ow_lander/src/ow_lander/arm_interface.py
+++ b/ow_lander/src/ow_lander/arm_interface.py
@@ -18,6 +18,7 @@ from actionlib_msgs.msg import GoalStatus
 from controller_manager_msgs.srv import SwitchController
 
 from ow_lander.common import Singleton
+from ow_lander.constants import DEFAULT_PLANNING_FRAME
 from ow_lander.exception import ArmExecutionError
 from ow_lander.frame_transformer import FrameTransformer
 
@@ -71,6 +72,8 @@ class OWArmInterface(metaclass = Singleton):
     self.robot = moveit_commander.RobotCommander()
     self.move_group_scoop = moveit_commander.MoveGroupCommander('arm')
     self.move_group_grinder = moveit_commander.MoveGroupCommander('grinder')
+    self.move_group_scoop.set_pose_reference_frame(DEFAULT_PLANNING_FRAME)
+    self.move_group_grinder.set_pose_reference_frame(DEFAULT_PLANNING_FRAME)
 
   def _stop_arm_if_fault(self, _feedback=None):
     """Ticks the stop flag when arm should stop due to a fault."""

--- a/ow_lander/src/ow_lander/constants.py
+++ b/ow_lander/src/ow_lander/constants.py
@@ -20,14 +20,11 @@ J_SCOOP_YAW = 5
 J_GRINDER = 5
 
 # these constants will eventually exist in a Frame message type in owl_msgs
-FRAME_BASE = 0
-FRAME_TOOL = 1
-FRAME_ID_BASE = 'base_link'
-FRAME_ID_TOOL = 'l_scoop_tip'
+DEFAULT_PLANNING_FRAME = 'base_link'
 # maps frame enumerate to the corresponding gazebo frame ID
 FRAME_ID_MAP = {
-  FRAME_BASE: FRAME_ID_BASE,
-  FRAME_TOOL: FRAME_ID_TOOL
+  0: DEFAULT_PLANNING_FRAME,
+  1: 'l_scoop_tip'
 }
 
 # allowed deviation from commanded joint values

--- a/ow_lander/src/ow_lander/mixins.py
+++ b/ow_lander/src/ow_lander/mixins.py
@@ -45,7 +45,6 @@ class ArmActionMixin:
     self._arm_tip_monitor = LinkStateSubscriber('lander::l_scoop_tip')
     self._start_server()
 
-
 class ArmTrajectoryMixin(ArmActionMixin, ABC):
 
   def __init__(self, *args, **kwargs):

--- a/ow_lander/urdf/lander.xacro
+++ b/ow_lander/urdf/lander.xacro
@@ -31,6 +31,9 @@
       "world" special behavior: http://sdformat.org/tutorials?tut=pose_frame_semantics&cat=specification&#specifying-parent-and-child-link-names-for-joints-in-sdf-1-4 -->
     <link name="world"/>
     <joint name="fixed" type="fixed">
+      <origin
+        xyz="$(arg x) $(arg y) $(arg z)"
+        rpy="$(arg R) $(arg P) $(arg Y)"/>
       <parent link="world"/>
       <child link="base_link"/>
     </joint>

--- a/ow_materials/src/MaterialDistributionPlugin.cpp
+++ b/ow_materials/src/MaterialDistributionPlugin.cpp
@@ -319,9 +319,6 @@ void MaterialDistributionPlugin::populateGrid(Ogre::Image albedo,
         static_cast<uint8_t>(last_insert->second.color.g),
         static_cast<uint8_t>(last_insert->second.color.b)
       );
-      // WORKAROUND for OW-1194, TF has an incorrect transform for
-      //            base_link (specific for atacama_y1a)
-      center -= GridPositionType(-1.0, 0.0, 0.37);
       grid_points.back().x = static_cast<float>(center.X());
       grid_points.back().y = static_cast<float>(center.Y());
       grid_points.back().z = static_cast<float>(center.Z());

--- a/ow_materials/src/MaterialIntegrator.cpp
+++ b/ow_materials/src/MaterialIntegrator.cpp
@@ -164,9 +164,7 @@ void MaterialIntegrator::integrate(
         (Blend const &b, GridPositionType center) {
           if (b.isEmpty()) return;
           bulk_blend.merge(b);
-          // WORKAROUND for OW-1194, TF has an incorrect transform for
-          //            base_link (specific for atacama_y1a)
-          center -= GridPositionType(-1.0, 0.0, 0.37);
+          // color must be set after the entire bulk blend is calculated
           points.emplace_back();
           points.back().x = static_cast<float>(center.X());
           points.back().y = static_cast<float>(center.Y());


### PR DESCRIPTION
Arm planning now takes place in the correct frame. Workarounds removed in ow_materials

## Linked Issues:
Jira Ticket 🎟️ | [OCEANWATER-1194](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1194)

## Summary of Changes
* Parameterized the lander's position inside of lander.xacro instead of setting lander position with the spawn_model node. This appears to have worked around OW-1194 where the world -> base_link transform is identity. 
* MoveIt plans based on TF transforms, so it's planning frame had to be changed from world -> base_link. This was always a bug, and we were always meant to be planning in the base_link frame, but these two different bugs canceled each other out. By correcting OW-1194 this bug now had to be addressed. 
*  Work arounds for OW-1194 removed in ow_materials code.

## Regression Tests
### Actions
No simulation behavior should have changed so these are all regression tests. 
Perform the following arm or frame relevant steps in [OW-TEST-013-4 ROS Actions](https://babelfish.arc.nasa.gov/confluence/display/OCEANWATERS/OW-TEST-013-4+ROS+Actions): **4.8, 4.11 - 4.27**

### Autonomy
Perform all mission plans in either atacama_y1a or europa_terminator_workspace: ReferenceMission1.plx, ReferenceMission2.plx, EuropaMission.plx