### PR TITLE
Regolith can now be simulated without a material distribution

### DIFF
--- a/ow/launch/atacama_y1a.launch
+++ b/ow/launch/atacama_y1a.launch
@@ -9,9 +9,10 @@
   <arg name="rqt_gui" default="true"/>
   <arg name="use_rviz" default="true"/>
   <arg name="sim_regolith" default="true" />
+  <arg name="sim_material_distribution" default="true" />
 
   <include file="$(find ow)/launch/common.launch">
-    <arg name="gazebo_launch_file" default="$(arg gazebo_launch_file)" />
+    <arg name="gazebo_launch_file" value="$(arg gazebo_launch_file)" />
     <arg name="world_name" value="$(find ow_europa)/worlds/atacama_y1a.world"/>
     <arg name="init_x" value="-1"/>
     <arg name="init_y" value="0"/>
@@ -25,8 +26,9 @@
     <arg name="gzclient" value="$(arg gzclient)"/>
     <arg name="record_bag" value="$(arg record_bag)"/>
     <arg name="rqt_gui" value="$(arg rqt_gui)"/>
-    <arg name="use_rviz" default="$(arg use_rviz)"/>
-    <arg name="sim_regolith" default="$(arg sim_regolith)"/>
+    <arg name="use_rviz" value="$(arg use_rviz)"/>
+    <arg name="sim_regolith" value="$(arg sim_regolith)"/>
+    <arg name="sim_material_distribution" value="$(arg sim_material_distribution)" />
   </include>
 
 </launch>

--- a/ow/launch/atacama_y1a.launch
+++ b/ow/launch/atacama_y1a.launch
@@ -9,7 +9,7 @@
   <arg name="rqt_gui" default="true"/>
   <arg name="use_rviz" default="true"/>
   <arg name="sim_regolith" default="true" />
-  <arg name="sim_material_distribution" default="true" />
+  <arg name="sim_multimaterial" default="true" />
 
   <include file="$(find ow)/launch/common.launch">
     <arg name="gazebo_launch_file" value="$(arg gazebo_launch_file)" />
@@ -28,7 +28,7 @@
     <arg name="rqt_gui" value="$(arg rqt_gui)"/>
     <arg name="use_rviz" value="$(arg use_rviz)"/>
     <arg name="sim_regolith" value="$(arg sim_regolith)"/>
-    <arg name="sim_material_distribution" value="$(arg sim_material_distribution)" />
+    <arg name="sim_multimaterial" value="$(arg sim_multimaterial)" />
   </include>
 
 </launch>

--- a/ow/launch/common.launch
+++ b/ow/launch/common.launch
@@ -11,6 +11,7 @@
   <arg name="rqt_gui" default="true" />
   <arg name="use_rviz" default="true" />
   <arg name="sim_regolith" default="true" />
+  <arg name="sim_material_distribution" default="true" />
 
   <!-- Initial pose arguments -->
   <arg name="init_x" default="0" />
@@ -90,8 +91,10 @@
   <node name="modify_terrain_grinder" pkg="ow_dynamic_terrain" type="modify_terrain_grinder_pub.py" output="screen"/>
 
   <!-- load materials file into ROS parameters -->
-  <rosparam command="load" ns="ow_materials"
-    file="$(find ow_materials)/config/materials.yaml"/>
+  <rosparam command="load" ns="ow_materials/materials"
+            file="$(find ow_materials)/config/materials.yaml" />
+  <param name="ow_materials/sim_material_distribution" type="bool"
+         value="$(arg sim_material_distribution)" />
 
   <!-- == Start rqt with a short delay so most topics will be visible and we won't need to refresh widgets ====== -->
   <!-- Starting without a .perspective file will reload the last used configuration. -->

--- a/ow/launch/common.launch
+++ b/ow/launch/common.launch
@@ -11,7 +11,7 @@
   <arg name="rqt_gui" default="true" />
   <arg name="use_rviz" default="true" />
   <arg name="sim_regolith" default="true" />
-  <arg name="sim_material_distribution" default="true" />
+  <arg name="sim_multimaterial" default="true" />
 
   <!-- Initial pose arguments -->
   <arg name="init_x" default="0" />
@@ -93,8 +93,8 @@
   <!-- load materials file into ROS parameters -->
   <rosparam command="load" ns="ow_materials/materials"
             file="$(find ow_materials)/config/materials.yaml" />
-  <param name="ow_materials/sim_material_distribution" type="bool"
-         value="$(arg sim_material_distribution)" />
+  <param name="ow_materials/sim_multimaterial" type="bool"
+         value="$(arg sim_multimaterial)" />
 
   <!-- == Start rqt with a short delay so most topics will be visible and we won't need to refresh widgets ====== -->
   <!-- Starting without a .perspective file will reload the last used configuration. -->

--- a/ow/launch/europa_terminator.launch
+++ b/ow/launch/europa_terminator.launch
@@ -27,7 +27,7 @@
     <arg name="use_rviz" value="$(arg use_rviz)"/>
     <!-- regolith and material distribution not supported on this world -->
     <arg name="sim_regolith" value="false"/>
-    <arg name="sim_material_distribution" value="false" />
+    <arg name="sim_multimaterial" value="false" />
   </include>
 
 </launch>

--- a/ow/launch/europa_terminator.launch
+++ b/ow/launch/europa_terminator.launch
@@ -8,10 +8,9 @@
   <arg name="record_bag" default="false"/>
   <arg name="rqt_gui" default="true"/>
   <arg name="use_rviz" default="true"/>
-  <arg name="sim_regolith" default="true" />
 
   <include file="$(find ow)/launch/common.launch" >
-    <arg name="gazebo_launch_file" default="$(arg gazebo_launch_file)" />
+    <arg name="gazebo_launch_file" value="$(arg gazebo_launch_file)" />
     <arg name="world_name" value="$(find ow_europa)/worlds/terminator.world"/>
     <arg name="init_x" value="0"/>
     <arg name="init_y" value="0"/>
@@ -25,8 +24,10 @@
     <arg name="gzclient" value="$(arg gzclient)"/>
     <arg name="record_bag" value="$(arg record_bag)"/>
     <arg name="rqt_gui" value="$(arg rqt_gui)"/>
-    <arg name="use_rviz" default="$(arg use_rviz)"/>
-    <arg name="sim_regolith" default="$(arg sim_regolith)"/>
+    <arg name="use_rviz" value="$(arg use_rviz)"/>
+    <!-- regolith and material distribution not supported on this world -->
+    <arg name="sim_regolith" value="false"/>
+    <arg name="sim_material_distribution" value="false" />
   </include>
 
 </launch>

--- a/ow/launch/europa_terminator_workspace.launch
+++ b/ow/launch/europa_terminator_workspace.launch
@@ -11,7 +11,7 @@
   <arg name="sim_regolith" default="true" />
 
   <include file="$(find ow)/launch/common.launch">
-    <arg name="gazebo_launch_file" default="$(arg gazebo_launch_file)" />
+    <arg name="gazebo_launch_file" value="$(arg gazebo_launch_file)" />
     <arg name="world_name" value="$(find ow_europa)/worlds/terminator_workspace.world"/>
     <arg name="init_x" value="0"/>
     <arg name="init_y" value="0"/>
@@ -25,8 +25,10 @@
     <arg name="gzclient" value="$(arg gzclient)"/>
     <arg name="record_bag" value="$(arg record_bag)"/>
     <arg name="rqt_gui" value="$(arg rqt_gui)"/>
-    <arg name="use_rviz" default="$(arg use_rviz)"/>
-    <arg name="sim_regolith" default="$(arg sim_regolith)"/>
+    <arg name="use_rviz" value="$(arg use_rviz)"/>
+    <arg name="sim_regolith" value="$(arg sim_regolith)"/>
+    <!-- material distribution not supported on this world -->
+    <arg name="sim_material_distribution" value="false" />
   </include>
 
 </launch>

--- a/ow/launch/europa_terminator_workspace.launch
+++ b/ow/launch/europa_terminator_workspace.launch
@@ -28,7 +28,7 @@
     <arg name="use_rviz" value="$(arg use_rviz)"/>
     <arg name="sim_regolith" value="$(arg sim_regolith)"/>
     <!-- material distribution not supported on this world -->
-    <arg name="sim_material_distribution" value="false" />
+    <arg name="sim_multimaterial" value="false" />
   </include>
 
 </launch>

--- a/ow/launch/europa_test_dem.launch
+++ b/ow/launch/europa_test_dem.launch
@@ -27,7 +27,7 @@
     <arg name="use_rviz" value="$(arg use_rviz)"/>
     <!-- regolith and material distribution not supported on this world -->
     <arg name="sim_regolith" value="false"/>
-    <arg name="sim_material_distribution" value="false" />
+    <arg name="sim_multimaterial" value="false" />
   </include>
 
 </launch>

--- a/ow/launch/europa_test_dem.launch
+++ b/ow/launch/europa_test_dem.launch
@@ -8,10 +8,9 @@
   <arg name="record_bag" default="false"/>
   <arg name="rqt_gui" default="true"/>
   <arg name="use_rviz" default="true"/>
-  <arg name="sim_regolith" default="true" />
   
   <include file="$(find ow)/launch/common.launch" >
-    <arg name="gazebo_launch_file" default="$(arg gazebo_launch_file)" />
+    <arg name="gazebo_launch_file" value="$(arg gazebo_launch_file)" />
     <arg name="world_name" value="$(find ow_europa)/worlds/test_dem.world"/>
     <arg name="init_x" value="20"/>
     <arg name="init_y" value="-15"/>
@@ -25,8 +24,10 @@
     <arg name="gzclient" value="$(arg gzclient)"/>
     <arg name="record_bag" value="$(arg record_bag)"/>
     <arg name="rqt_gui" value="$(arg rqt_gui)"/>
-    <arg name="use_rviz" default="$(arg use_rviz)"/>
-    <arg name="sim_regolith" default="$(arg sim_regolith)"/>
+    <arg name="use_rviz" value="$(arg use_rviz)"/>
+    <!-- regolith and material distribution not supported on this world -->
+    <arg name="sim_regolith" value="false"/>
+    <arg name="sim_material_distribution" value="false" />
   </include>
 
 </launch>

--- a/ow_materials/include/ow_materials/material_mixing.h
+++ b/ow_materials/include/ow_materials/material_mixing.h
@@ -31,6 +31,7 @@ public:
   ~Blend()                       = default;
 
   Blend(std::vector<MaterialConcentration> const &composition);
+  Blend(CompositionType const &composition);
 
   inline CompositionType const &getComposition() const {
     return m_composition;

--- a/ow_materials/src/MaterialDatabase.cpp
+++ b/ow_materials/src/MaterialDatabase.cpp
@@ -106,7 +106,7 @@ void MaterialDatabase::populate_from_rosparams(const string &ns)
   }
   if (mat_names.size() == 0) {
     throw MaterialConfigError("A minimum of 1 material is required even if "
-                              "the sim_material_distribution flag is false.");
+                              "the sim_multimaterial flag is false.");
   }
   // build and add all materials to database
   for (const auto &mat : mat_names) {

--- a/ow_materials/src/MaterialDatabase.cpp
+++ b/ow_materials/src/MaterialDatabase.cpp
@@ -104,6 +104,10 @@ void MaterialDatabase::populate_from_rosparams(const string &ns)
       mat_names.insert(mat_name);
     }
   }
+  if (mat_names.size() == 0) {
+    throw MaterialConfigError("A minimum of 1 material is required even if "
+                              "the sim_material_distribution flag is false.");
+  }
   // build and add all materials to database
   for (const auto &mat : mat_names) {
     const bool added = addMaterial(

--- a/ow_materials/src/MaterialDistributionPlugin.cpp
+++ b/ow_materials/src/MaterialDistributionPlugin.cpp
@@ -30,7 +30,7 @@ const string NAMESPACE_MATERIALS = "/ow_materials/materials";
 
 const string NODE_NAME = "/ow_materials/material_distribution_plugin";
 const string TOPIC_MOD_DIFF_VISUAL = "/ow_dynamic_terrain/modification_differential/visual";
-const string ROSPARAM_SIM_MAT_DIST = "/ow_materials/sim_material_distribution";
+const string ROSPARAM_SIM_MAT_DIST = "/ow_materials/sim_multimaterial";
 
 const string PARAMETER_CORNER_A         = "corner_a";
 const string PARAMETER_CORNER_B         = "corner_b";
@@ -107,7 +107,7 @@ void MaterialDistributionPlugin::Load(physics::ModelPtr model,
   ros::param::param(ROSPARAM_SIM_MAT_DIST, m_grid_in_use, true);
   if (!m_grid_in_use) {
     gzlog << PLUGIN_NAME << ": Material distribution will not be simulated. "
-          "To enable, launch a supported world with sim_material_distribution "
+          "To enable, launch a supported world with sim_multimaterial "
           "set to true." << endl;
     m_sub_modification_diff = m_node_handle->subscribe(TOPIC_MOD_DIFF_VISUAL,
       1, &MaterialDistributionPlugin::computeDiffVolume, this);

--- a/ow_materials/src/MaterialDistributionPlugin.cpp
+++ b/ow_materials/src/MaterialDistributionPlugin.cpp
@@ -48,7 +48,7 @@ static float colorSpaceDistance(const Color &c1, const Color &c2)
 }
 
 void MaterialDistributionPlugin::computeDiffVolume(
-  const ow_dynamic_terrain::modified_terrain_diff::ConstPtr &msg)
+  const ow_dynamic_terrain::modified_terrain_diff::ConstPtr &msg) const
 {
   auto diff_handle = cv_bridge::CvImageConstPtr();
   try {
@@ -387,7 +387,7 @@ void MaterialDistributionPlugin::populateGrid(Ogre::Image albedo,
 }
 
 void MaterialDistributionPlugin::handleVisualBulk(Blend const &blend,
-                                                  double volume)
+                                                  double volume) const
 {
   Bulk excavated_bulk(blend, volume);
   BulkExcavation msg;
@@ -403,7 +403,7 @@ void MaterialDistributionPlugin::handleVisualBulk(Blend const &blend,
 
 //// STUBBED FEATURE: reactivate for grinder terramechanics (OW-998)
 // void MaterialDistributionPlugin::handleCollisionBulk(Blend const &blend,
-//                                                      double volume)
+//                                                      double volume) const
 // {
 
 // }

--- a/ow_materials/src/MaterialDistributionPlugin.h
+++ b/ow_materials/src/MaterialDistributionPlugin.h
@@ -43,6 +43,11 @@ public:
 
   void getHeightmapAlbedo();
 
+  // NOTE: Only used if m_grid_in_use is false
+  // Alternative message diff callback for computing dug volume.
+  void computeDiffVolume(
+    const ow_dynamic_terrain::modified_terrain_diff::ConstPtr &msg);
+
   void handleVisualBulk(Blend const &blend, double volume);
 
   //// STUBBED FEATURE: reactivate for grinder terramechanics (OW-998)
@@ -55,11 +60,17 @@ private:
 
   std::unique_ptr<ros::NodeHandle> m_node_handle;
 
+  // when false a grid is not generated and only dug volume is computed
+  bool m_grid_in_use;
+
   std::unique_ptr<gazebo::event::ConnectionPtr> m_temp_render_connection;
 
   ros::Publisher m_pub_grid;
   ros::Publisher m_pub_bulk_excavation_visual;
   ros::Publisher m_pub_bulk_excavation_collision;
+
+  // NOTE: Only used if m_grid_in_use is false
+  ros::Subscriber m_sub_modification_diff;
 
   MaterialDatabase m_material_db;
 

--- a/ow_materials/src/MaterialDistributionPlugin.h
+++ b/ow_materials/src/MaterialDistributionPlugin.h
@@ -46,12 +46,12 @@ public:
   // NOTE: Only used if m_grid_in_use is false
   // Alternative message diff callback for computing dug volume.
   void computeDiffVolume(
-    const ow_dynamic_terrain::modified_terrain_diff::ConstPtr &msg);
+    const ow_dynamic_terrain::modified_terrain_diff::ConstPtr &msg) const;
 
-  void handleVisualBulk(Blend const &blend, double volume);
+  void handleVisualBulk(Blend const &blend, double volume) const;
 
   //// STUBBED FEATURE: reactivate for grinder terramechanics (OW-998)
-  // void handleCollisionBulk(Blend const &blend, double volume);
+  // void handleCollisionBulk(Blend const &blend, double volume) const;
 
   Color interpolateColor(Blend const &blend) const;
 

--- a/ow_materials/src/MaterialIntegrator.cpp
+++ b/ow_materials/src/MaterialIntegrator.cpp
@@ -91,7 +91,6 @@ void MaterialIntegrator::onModificationMsg(
     boost::bind(&MaterialIntegrator::integrate, this, msg));
 }
 
-
 void MaterialIntegrator::integrate(
   const ow_dynamic_terrain::modified_terrain_diff::ConstPtr &msg)
 {
@@ -114,8 +113,8 @@ void MaterialIntegrator::integrate(
   const auto rows = diff_handle->image.rows;
   const auto cols = diff_handle->image.cols;
 
-  const auto pixel_height = msg->height / rows;
-  const auto pixel_width = msg->width / cols;
+  auto pixel_height = msg->height / rows;
+  auto pixel_width = msg->width / cols;
   const float pixel_area = static_cast<float>(pixel_height * pixel_width);
 
   Blend bulk_blend;

--- a/ow_materials/src/material_mixing.cpp
+++ b/ow_materials/src/material_mixing.cpp
@@ -20,6 +20,11 @@ Blend::Blend(vector<MaterialConcentration> const &composition)
   }
 }
 
+Blend::Blend(CompositionType const &composition)
+{
+  m_composition = composition;
+}
+
 bool Blend::isNormalized() const
 {
   return std::fabs(1.0 - sumConcentrations())

--- a/ow_regolith/src/RegolithPlugin.cpp
+++ b/ow_regolith/src/RegolithPlugin.cpp
@@ -35,6 +35,8 @@ const string TOPIC_BULK_EXCAVATION   = "/ow_materials/bulk_excavation/visual";
 const string TOPIC_DIG_PHASE         = "/ow_dynamic_terrain/scoop_dig_phase";
 const string TOPIC_MATERIAL_INGESTED = "/ground_truth/material_ingested";
 
+const string NAMESPACE_MATERIALS = "/ow_materials/materials";
+
 // constants specific to the scoop end-effector
 const Vector3d SCOOP_SPAWN_OFFSET(0.0, 0.0, -0.05);
 
@@ -125,7 +127,7 @@ void RegolithPlugin::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
 
   // populate materials database
   try {
-    m_material_db.populate_from_rosparams("/ow_materials");
+    m_material_db.populate_from_rosparams(NAMESPACE_MATERIALS);
   } catch (const ow_materials::MaterialConfigError &e) {
     GZERR("Failed initialize material database: " << e.what() << endl);
     return;


### PR DESCRIPTION
## Linked Issues:
Jira Ticket 🎟️ | [OCEANWATER-1250](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1250)
Jira Ticket 🎟️ | [OCEANWATER-1235](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1235)

## Sibling PR
https://github.com/nasa/ow_europa/pull/37

## Summary of Changes
* A roslaunch flag has been added to atacama_y1a.launch (the only world that supports multi-material terrain).
* Any launch files for worlds that do not support either regolith or multi-material terrain have lost flag argument for each respectively and turning those facilities off is now hard-coded in the launch file.  
* The MaterialDistributionPlugin can now be run in a mode that does not material distribution computations, and only computes displaced volume so that RegolithPlugin can still use that data to spawn regolith. 
* Some clean up of roslaunch files. 

## Test atacama_y1a with material distribution turned on (the default)
1. Launch atacama_y1a `roslaunch ow atacama_y1a.launch`
2. In Rviz under Displays tick `material_grid`. The generated material_grid should display.
3. Untick material_grid, and tick dug_points. Nothing will show yet.
4. Call a grind then a scoop linear.
```
rosrun ow_lander task_grind.py
rosrun ow_lander task_scoop_linear.py
```
5. As the scoop moves through terrain you should see the dug_points topic display the voxels the scoop has passed through. 
6. Shut down the sim.

## Test atacama_y1a with material distribution turned off
1. Launch atacama_y1a `roslaunch ow atacama_y1a.launch sim_material_distribution:=false`
2. In Rviz under Displays tick `material_grid`. Nothing will show. Both `material_grid` and `dug_points` will display nothing in this mode. 
4. Call a grind then a scoop linear.
```
rosrun ow_lander task_grind.py
rosrun ow_lander task_scoop_linear.py
```
5. No visualization will show in Rviz, but despite the distribution not being simulated, regolith will still fill the scoop as it moves through terrain. 
6. Shutdown the simulation. 

## Test europa_terminator_workspace
In Release 13 this world lost regolith simulation due to how multi-material terrain was integrate. It still cannot support a material distribution, but it can again simulate regolith thanks to this update. 
1. Launch europa_terminator_workspace `roslaunch ow europa_terminator_workspace.launch`. Note that the argument does not exist for this world because the flag is already set to false internally. 
2. In Rviz under Displays tick `material_grid`. Nothing will show. Both `material_grid` and `dug_points` will display nothing in this world. 
3. Repeate steps 4-6 from the previous section. It should have the same result. Regolith will fill the scoop.
 