### PR TITLE
Oceanwater 1164 means to reposition lander

### DIFF
--- a/ow/launch/atacama_y1a.launch
+++ b/ow/launch/atacama_y1a.launch
@@ -9,16 +9,22 @@
   <arg name="rqt_gui" default="true"/>
   <arg name="use_rviz" default="true"/>
   <arg name="sim_regolith" default="true" />
+  <arg name="init_x" default="-1"/>
+  <arg name="init_y" default="0"/>
+  <arg name="init_z" default="0.37"/>
+  <arg name="init_R" default="0"/>
+  <arg name="init_P" default="0"/>
+  <arg name="init_Y" default="0"/>
 
   <include file="$(find ow)/launch/common.launch">
     <arg name="gazebo_launch_file" default="$(arg gazebo_launch_file)" />
     <arg name="world_name" value="$(find ow_europa)/worlds/atacama_y1a.world"/>
-    <arg name="init_x" value="-1"/>
-    <arg name="init_y" value="0"/>
-    <arg name="init_z" value="0.37"/>
-    <arg name="init_R" value="0"/>
-    <arg name="init_P" value="0"/>
-    <arg name="init_Y" value="0"/>
+    <arg name="init_x" value="$(arg init_x)"/>
+    <arg name="init_y" value="$(arg init_y)"/>
+    <arg name="init_z" value="$(arg init_z)"/>
+    <arg name="init_R" value="$(arg init_R)"/>
+    <arg name="init_P" value="$(arg init_P)"/>
+    <arg name="init_Y" value="$(arg init_Y)"/>
     <arg name="freeze_base_link" value="true"/>
     <arg name="arm_sim_enable" value="$(arg arm_sim_enable)"/>
     <arg name="gazebo" value="$(arg gazebo)"/>

--- a/ow/launch/europa_terminator.launch
+++ b/ow/launch/europa_terminator.launch
@@ -9,16 +9,22 @@
   <arg name="rqt_gui" default="true"/>
   <arg name="use_rviz" default="true"/>
   <arg name="sim_regolith" default="true" />
+  <arg name="init_x" default="0"/>
+  <arg name="init_y" default="0"/>
+  <arg name="init_z" default="-7.291"/>
+  <arg name="init_R" default="-0.105"/>
+  <arg name="init_P" default="0.008"/>
+  <arg name="init_Y" default="0"/>
 
   <include file="$(find ow)/launch/common.launch" >
     <arg name="gazebo_launch_file" default="$(arg gazebo_launch_file)" />
     <arg name="world_name" value="$(find ow_europa)/worlds/terminator.world"/>
-    <arg name="init_x" value="0"/>
-    <arg name="init_y" value="0"/>
-    <arg name="init_z" value="-7.291"/>
-    <arg name="init_R" value="-0.105"/>
-    <arg name="init_P" value="0.008"/>
-    <arg name="init_Y" value="0"/>
+    <arg name="init_x" value="$(arg init_x)"/>
+    <arg name="init_y" value="$(arg init_y)"/>
+    <arg name="init_z" value="$(arg init_z)"/>
+    <arg name="init_R" value="$(arg init_R)"/>
+    <arg name="init_P" value="$(arg init_P)"/>
+    <arg name="init_Y" value="$(arg init_Y)"/>
     <arg name="freeze_base_link" value="true"/>
     <arg name="arm_sim_enable" value="$(arg arm_sim_enable)"/>
     <arg name="gazebo" value="$(arg gazebo)"/>

--- a/ow/launch/europa_terminator_workspace.launch
+++ b/ow/launch/europa_terminator_workspace.launch
@@ -9,16 +9,22 @@
   <arg name="rqt_gui" default="true"/>
   <arg name="use_rviz" default="true"/>
   <arg name="sim_regolith" default="true" />
+  <arg name="init_x" default="0"/>
+  <arg name="init_y" default="0"/>
+  <arg name="init_z" default="-7.19"/>
+  <arg name="init_R" default="-0.105"/>
+  <arg name="init_P" default="0.008"/>
+  <arg name="init_Y" default="0"/>
 
   <include file="$(find ow)/launch/common.launch">
     <arg name="gazebo_launch_file" default="$(arg gazebo_launch_file)" />
     <arg name="world_name" value="$(find ow_europa)/worlds/terminator_workspace.world"/>
-    <arg name="init_x" value="0"/>
-    <arg name="init_y" value="0"/>
-    <arg name="init_z" value="-7.19"/>
-    <arg name="init_R" value="-0.105"/>
-    <arg name="init_P" value="0.008"/>
-    <arg name="init_Y" value="0"/>
+    <arg name="init_x" value="$(arg init_x)"/>
+    <arg name="init_y" value="$(arg init_y)"/>
+    <arg name="init_z" value="$(arg init_z)"/>
+    <arg name="init_R" value="$(arg init_R)"/>
+    <arg name="init_P" value="$(arg init_P)"/>
+    <arg name="init_Y" value="$(arg init_Y)"/>
     <arg name="freeze_base_link" value="true"/>
     <arg name="arm_sim_enable" value="$(arg arm_sim_enable)"/>
     <arg name="gazebo" value="$(arg gazebo)"/>

--- a/ow/launch/europa_test_dem.launch
+++ b/ow/launch/europa_test_dem.launch
@@ -9,16 +9,22 @@
   <arg name="rqt_gui" default="true"/>
   <arg name="use_rviz" default="true"/>
   <arg name="sim_regolith" default="true" />
+  <arg name="init_x" default="20"/>
+  <arg name="init_y" default="-15"/>
+  <arg name="init_z" default="2.25"/>
+  <arg name="init_R" default="0.191"/>
+  <arg name="init_P" default="0.097"/>
+  <arg name="init_Y" default="0.035"/>
   
   <include file="$(find ow)/launch/common.launch" >
     <arg name="gazebo_launch_file" default="$(arg gazebo_launch_file)" />
     <arg name="world_name" value="$(find ow_europa)/worlds/test_dem.world"/>
-    <arg name="init_x" value="20"/>
-    <arg name="init_y" value="-15"/>
-    <arg name="init_z" value="2.25"/>
-    <arg name="init_R" value="0.191"/>
-    <arg name="init_P" value="0.097"/>
-    <arg name="init_Y" value="0.035"/>
+    <arg name="init_x" value="$(arg init_x)"/>
+    <arg name="init_y" value="$(arg init_y)"/>
+    <arg name="init_z" value="$(arg init_z)"/>
+    <arg name="init_R" value="$(arg init_R)"/>
+    <arg name="init_P" value="$(arg init_P)"/>
+    <arg name="init_Y" value="$(arg init_Y)"/>
     <arg name="freeze_base_link" value="true"/>
     <arg name="arm_sim_enable" value="$(arg arm_sim_enable)"/>
     <arg name="gazebo" value="$(arg gazebo)"/>

--- a/ow_materials/src/MaterialDistributionPlugin.cpp
+++ b/ow_materials/src/MaterialDistributionPlugin.cpp
@@ -279,7 +279,8 @@ void MaterialDistributionPlugin::attemptToAcquireWorldData() {
 
   try {
     m_grid = make_unique<VoxelGrid<Blend>>(
-      m_corner_a, m_corner_b, m_cell_side_length, grid_transform
+      m_corner_a, m_corner_b, m_cell_side_length,
+      grid_transform.Pos(), grid_transform.Rot().Euler().Z()
     );
   } catch (const GridConfigError &e) {
     GZERR(e.what() << endl);

--- a/ow_materials/src/MaterialDistributionPlugin.cpp
+++ b/ow_materials/src/MaterialDistributionPlugin.cpp
@@ -66,6 +66,8 @@ void MaterialDistributionPlugin::Load(physics::ModelPtr model,
   const auto corner_b = sdf->Get<GridPositionType>(PARAMETER_CORNER_B);
   const auto cell_side_length = sdf->Get<double>(PARAMETER_CELL_SIDE_LENGTH);
 
+
+
   try {
     m_grid = make_unique<AxisAlignedGrid<Blend>>(corner_a, corner_b,
                                                  cell_side_length);
@@ -330,7 +332,7 @@ void MaterialDistributionPlugin::populateGrid(Ogre::Image albedo,
 
   // publish and latch grid data as a point cloud for visualization
   // only need to do this once because the grid is never modified
-  publishPointCloud(&m_pub_grid, grid_points);
+  publishPointCloud(&m_pub_grid, grid_points, "world");
 
   gzlog << PLUGIN_NAME << ": Grid visualization now ready for viewing in Rviz."
         << endl;

--- a/ow_materials/src/MaterialDistributionPlugin.h
+++ b/ow_materials/src/MaterialDistributionPlugin.h
@@ -78,8 +78,8 @@ private:
 
   gazebo::physics::ModelPtr m_heightmap_model;
 
-  ignition::math::Vector3d m_corner_a;
-  ignition::math::Vector3d m_corner_b;
+  GridPositionType m_corner_a;
+  GridPositionType m_corner_b;
   double m_cell_side_length;
   // Either world or the name of a static model the grid will be relative to.
   std::string m_relative_to;

--- a/ow_materials/src/MaterialDistributionPlugin.h
+++ b/ow_materials/src/MaterialDistributionPlugin.h
@@ -16,7 +16,7 @@
 #include "gazebo/common/Event.hh"
 #include "gazebo/physics/Model.hh"
 
-#include "AxisAlignedGrid.h"
+#include "VoxelGrid.h"
 #include "MaterialDatabase.h"
 #include "MaterialIntegrator.h"
 #include "material_mixing.h"
@@ -42,8 +42,6 @@ public:
 
   void Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf);
 
-  void getHeightmapAlbedo();
-
   // NOTE: Only used if m_grid_in_use is false
   // Alternative message diff callback for computing dug volume.
   void computeDiffVolume(
@@ -54,15 +52,16 @@ public:
   //// STUBBED FEATURE: reactivate for grinder terramechanics (OW-998)
   // void handleCollisionBulk(Blend const &blend, double volume) const;
 
+  // A delayed initialization function that waits for certain Gazebo resources
+  // to have been loaded and become accessible.
+  void attemptToAcquireWorldData();
+
   Color interpolateColor(Blend const &blend) const;
 
 private:
   void populateGrid(Ogre::Image albedo, Ogre::Terrain *terrain);
 
   std::unique_ptr<ros::NodeHandle> m_node_handle;
-
-  // when false a grid is not generated and only dug volume is computed
-  bool m_grid_in_use;
 
   std::unique_ptr<gazebo::event::ConnectionPtr> m_temp_render_connection;
 
@@ -75,18 +74,18 @@ private:
 
   MaterialDatabase m_material_db;
 
-  std::unique_ptr<AxisAlignedGrid<Blend>> m_grid;
+  std::unique_ptr<VoxelGrid<Blend>> m_grid;
 
-  gazebo::physics::ModelPtr m_heightmap;
+  gazebo::physics::ModelPtr m_heightmap_model;
 
   ignition::math::Vector3d m_corner_a;
   ignition::math::Vector3d m_corner_b;
   double m_cell_side_length;
-  std::string m_grid_frame;
+  // Either world or the name of a static model the grid will be relative to.
+  std::string m_relative_to;
 
   std::unique_ptr<MaterialIntegrator> m_visual_integrator;
-
-  //// STUBBED FEATURE: reactivate for grinder terramechanics (OW-998)
+  //// STUBBED FEATURE: reactivate to implement grinder terramechanics (OW-998)
   // std::unique_ptr<MaterialIntegrator> m_collision_integrator;
 
   std::vector<std::pair<MaterialID, Color>> m_reference_colors;

--- a/ow_materials/src/MaterialDistributionPlugin.h
+++ b/ow_materials/src/MaterialDistributionPlugin.h
@@ -14,6 +14,7 @@
 #include "gazebo/gazebo.hh"
 #include "gazebo/common/common.hh"
 #include "gazebo/common/Event.hh"
+#include "gazebo/physics/Model.hh"
 
 #include "AxisAlignedGrid.h"
 #include "MaterialDatabase.h"
@@ -64,6 +65,13 @@ private:
   MaterialDatabase m_material_db;
 
   std::unique_ptr<AxisAlignedGrid<Blend>> m_grid;
+
+  gazebo::physics::ModelPtr m_heightmap;
+
+  ignition::math::Vector3d m_corner_a;
+  ignition::math::Vector3d m_corner_b;
+  double m_cell_side_length;
+  std::string m_grid_frame;
 
   std::unique_ptr<MaterialIntegrator> m_visual_integrator;
 

--- a/ow_materials/src/MaterialIntegrator.cpp
+++ b/ow_materials/src/MaterialIntegrator.cpp
@@ -147,19 +147,18 @@ void MaterialIntegrator::integrate(
       }
       // dz is always negative here, so subtract to get a positive volume
       volume_displaced -= dz * pixel_area;
+      // determine world-space z values at the bottom of the z-column
+      const auto z_bottom = result_handle->image.at<float>(i, j);
       // compute world-space coordinates of this pixel's center
       const float x = (msg->position.x - msg->width / 2)
                         + static_cast<float>(j) / rows * msg->width;
       // +i and +y are in opposite directions, so flip the signs
       const float y = (msg->position.y + msg->height / 2)
                         - static_cast<float>(i) / cols * msg->height;
-      const auto pixel_center = GridPositionType2D{x + pixel_width / 2,
-                                                   y + pixel_height / 2};
-      // determine world-space z values at the top and bottom of the z-column
-      const auto z_bottom = result_handle->image.at<float>(i, j);
-      const auto z_top = z_bottom - dz; // dz is negative
-      m_grid->runForEachInColumn(
-        pixel_center, z_bottom, z_top,
+      const auto column_bottom = GridPositionType{x + pixel_width / 2,
+                                                  y + pixel_height / 2,
+                                                  z_bottom};
+      m_grid->runForEachInColumn(column_bottom, dz,
         [&bulk_blend, &points]
         (Blend const &b, GridPositionType center) {
           if (b.isEmpty()) return;
@@ -193,7 +192,7 @@ void MaterialIntegrator::integrate(
     += (ros::WallTime::now() - start_time).toNSec();
   m_batch_accumulated_merges += points.size();
 
-  publishPointCloud(&m_dug_points_pub, points, "world");
+  publishPointCloud(&m_dug_points_pub, points, "base_link");
 
   m_handle_bulk_cb(bulk_blend, static_cast<double>(volume_displaced));
 }

--- a/ow_materials/src/MaterialIntegrator.cpp
+++ b/ow_materials/src/MaterialIntegrator.cpp
@@ -24,7 +24,7 @@ const auto STAT_LOG_TIMEOUT = ros::Duration(1.0); // second
 const uint MINIMUM_INTEGRATE_THREADS = 4u;
 
 MaterialIntegrator::MaterialIntegrator(
-  ros::NodeHandle *node_handle, AxisAlignedGrid<Blend> const *grid,
+  ros::NodeHandle *node_handle, VoxelGrid<Blend> const *grid,
   const std::string &modification_topic, const std::string &dug_points_topic,
   HandleBulkCallback handle_bulk_cb, ColorizerCallback colorizer_cb)
   : m_node_handle(node_handle), m_grid(grid),

--- a/ow_materials/src/MaterialIntegrator.cpp
+++ b/ow_materials/src/MaterialIntegrator.cpp
@@ -193,7 +193,7 @@ void MaterialIntegrator::integrate(
     += (ros::WallTime::now() - start_time).toNSec();
   m_batch_accumulated_merges += points.size();
 
-  publishPointCloud(&m_dug_points_pub, points);
+  publishPointCloud(&m_dug_points_pub, points, "world");
 
   m_handle_bulk_cb(bulk_blend, static_cast<double>(volume_displaced));
 }

--- a/ow_materials/src/MaterialIntegrator.h
+++ b/ow_materials/src/MaterialIntegrator.h
@@ -15,7 +15,7 @@
 
 #include "ow_dynamic_terrain/modified_terrain_diff.h"
 
-#include "AxisAlignedGrid.h"
+#include "VoxelGrid.h"
 #include "Material.h"
 #include "material_mixing.h"
 
@@ -35,7 +35,7 @@ class MaterialIntegrator
 
 public:
   MaterialIntegrator(ros::NodeHandle *node_handle,
-                     AxisAlignedGrid<Blend> const *grid,
+                     VoxelGrid<Blend> const *grid,
                      const std::string &modification_topic,
                      const std::string &dug_points_topic,
                      HandleBulkCallback handle_bulk_cb,
@@ -61,7 +61,7 @@ private:
 
   ColorizerCallback m_colorizer_cb;
 
-  AxisAlignedGrid<Blend> const *m_grid;
+  VoxelGrid<Blend> const *m_grid;
 
   std::uint32_t m_next_expected_seq = 0u;
 

--- a/ow_materials/src/VoxelGrid.h
+++ b/ow_materials/src/VoxelGrid.h
@@ -37,7 +37,8 @@ class VoxelGrid {
 
 public:
   VoxelGrid(GridPositionType corner_1, GridPositionType corner_2,
-                  double cell_side_length, GridTransformType frame_transform);
+                  double cell_side_length,
+                  GridPositionType position_offset, double yaw);
   ~VoxelGrid() = default;
 
   VoxelGrid() = delete;

--- a/ow_materials/src/VoxelGrid.h
+++ b/ow_materials/src/VoxelGrid.h
@@ -50,8 +50,7 @@ public:
   const double &getCellVolume() const;
   inline double getCellLength() const { return m_cell_length; }
 
-  // WARNING: execution will may take a long time depending on grid resolution
-  // void runForEach(std::function<void(const T&, GridPositionType)> f) const;
+  // WARNING: Execution will may take a long time depending on grid resolution.
   void runForEach(
     std::function<void(T&, GridPositionType, GridPositionType)> f);
   

--- a/ow_materials/src/VoxelGrid.h
+++ b/ow_materials/src/VoxelGrid.h
@@ -2,8 +2,8 @@
 // Research and Simulation can be found in README.md in the root directory of
 // this repository.
 
-#ifndef AXIS_ALIGNED_GRID_H
-#define AXIS_ALIGNED_GRID_H
+#ifndef VOXEL_GRID_H
+#define VOXEL_GRID_H
 
 #include <vector>
 #include <memory>
@@ -27,28 +27,25 @@ using GridTransformType = ignition::math::Pose3d;
 using GridPositionType = ignition::math::Vector3d;
 using GridPositionType2D = ignition::math::Vector2d;
 
-// TODO: rename class to something not axis aligned specific
 template <typename T>
-class AxisAlignedGrid {
+class VoxelGrid {
 
-  // An axis-aligned box which is partitioned into cubes of a given side length.
-  // Each cube, or cell, or voxel, is linked to a value of type T.
+  // A box which is partitioned into cubes of a constant side length.
+  // Each cube/cell/voxel is given a value of type T.
 
   using GridIndexType = ignition::math::Vector3<std::size_t>;
 
 public:
-  AxisAlignedGrid(GridPositionType corner_1, GridPositionType corner_2,
+  VoxelGrid(GridPositionType corner_1, GridPositionType corner_2,
                   double cell_side_length, GridTransformType frame_transform);
-  ~AxisAlignedGrid() = default;
+  ~VoxelGrid() = default;
 
-  AxisAlignedGrid() = delete;
-  AxisAlignedGrid(const AxisAlignedGrid&) = delete;
-  AxisAlignedGrid& operator=(const AxisAlignedGrid&) = delete;
+  VoxelGrid() = delete;
+  VoxelGrid(const VoxelGrid&) = delete;
+  VoxelGrid& operator=(const VoxelGrid&) = delete;
 
-  const GridPositionType &getDiagonal() const;
-  const GridPositionType &getMaxCorner() const;
-  const GridPositionType &getMinCorner() const;
-  const GridPositionType &getCenter() const;
+  const GridPositionType &getDimensions() const;
+  const GridPositionType &getWorldCenter() const;
 
   const double &getCellVolume() const;
   inline double getCellLength() const { return m_cell_length; }
@@ -63,6 +60,13 @@ public:
 
 private:
 
+  inline const GridPositionType &getMaxCorner() const {
+    return m_domain->Max();
+  };
+  inline const GridPositionType &getMinCorner() const {
+    return m_domain->Min();
+  };
+
   GridPositionType getCellCenter(GridIndexType i) const;
 
   inline const T &getCellValue(GridIndexType i) const {
@@ -73,23 +77,8 @@ private:
     return m_cells[index(i)];
   };
 
-  GridPositionType transformIntoFrame(const GridPositionType &p) const {
-    auto m = p - m_frame_offset;
-    return GridPositionType{
-       m.X() * std::cos(m_frame_yaw) + m.Y() * std::sin(m_frame_yaw),
-      -m.X() * std::sin(m_frame_yaw) + m.Y() * std::cos(m_frame_yaw),
-       m.Z()
-    };
-  };
-
-  GridPositionType transformIntoWorld(const GridPositionType &p) const{
-    auto m = GridPositionType{
-      p.X() * std::cos(m_frame_yaw) - p.Y() * std::sin(m_frame_yaw),
-      p.X() * std::sin(m_frame_yaw) + p.Y() * std::cos(m_frame_yaw),
-      p.Z()
-    };
-    return m + m_frame_offset;
-  };
+  GridPositionType transformIntoFrame(const GridPositionType &p) const;
+  GridPositionType transformIntoWorld(const GridPositionType &p) const;
 
   std::size_t index(GridIndexType i) const;
 
@@ -107,6 +96,6 @@ private:
 
 }
 
-#include <AxisAlignedGrid.tpp>
+#include <VoxelGrid.tpp>
 
-#endif // AXIS_ALIGNED_GRID_H
+#endif // VOXEL_GRID_H

--- a/ow_materials/src/VoxelGrid.tpp
+++ b/ow_materials/src/VoxelGrid.tpp
@@ -36,10 +36,10 @@ static GridPositionType maxPosition(GridPositionType const &a,
 
 template <typename T>
 VoxelGrid<T>::VoxelGrid(GridPositionType corner_1, GridPositionType corner_2,
-                        double const cell_side_length,
-                        GridTransformType const frame_transform)
-  : m_cell_length(cell_side_length), m_frame_offset(frame_transform.Pos()),
-    m_frame_yaw(frame_transform.Rot().Euler().Z())
+                        double cell_side_length,
+                        GridPositionType position_offset, double yaw)
+  : m_cell_length(cell_side_length), m_frame_offset(position_offset),
+    m_frame_yaw(yaw)
 {
 
   // cannot have a negative/zero length

--- a/ow_materials/src/point_cloud_util.cpp
+++ b/ow_materials/src/point_cloud_util.cpp
@@ -7,9 +7,10 @@
 #include "ros/ros.h"
 
 void publishPointCloud(ros::Publisher *pub,
-                       pcl::PointCloud<pcl::PointXYZRGB> &cloud)
+                       pcl::PointCloud<pcl::PointXYZRGB> &cloud,
+                       const std::string frame_id)
 {
-  cloud.header.frame_id = "world";
+  cloud.header.frame_id = frame_id;
   pcl_conversions::toPCL(ros::Time::now(), cloud.header.stamp);
   sensor_msgs::PointCloud2 msg;
   pcl::toROSMsg(cloud, msg);

--- a/ow_materials/src/point_cloud_util.cpp
+++ b/ow_materials/src/point_cloud_util.cpp
@@ -8,7 +8,7 @@
 
 void publishPointCloud(ros::Publisher *pub,
                        pcl::PointCloud<pcl::PointXYZRGB> &cloud,
-                       const std::string frame_id)
+                       const std::string &frame_id)
 {
   cloud.header.frame_id = frame_id;
   pcl_conversions::toPCL(ros::Time::now(), cloud.header.stamp);

--- a/ow_materials/src/point_cloud_util.h
+++ b/ow_materials/src/point_cloud_util.h
@@ -5,10 +5,13 @@
 #ifndef POINT_CLOUD_UTIL_H
 #define POINT_CLOUD_UTIL_H
 
+#include <string>
+
 #include "pcl_ros/point_cloud.h"
 #include "pcl/point_types.h"
 
 void publishPointCloud(ros::Publisher *pub,
-                       pcl::PointCloud<pcl::PointXYZRGB> &cloud);
+                       pcl::PointCloud<pcl::PointXYZRGB> &cloud,
+                       const std::string &frame_id);
 
 #endif // POINT_CLOUD_UTIL_H


### PR DESCRIPTION
## Linked Issues:
Jira Ticket 🎟️ | [OCEANWATER-1164](https://babelfish.arc.nasa.gov/jira/browse/OCEANWATER-1164)

## Sibling PR
https://github.com/nasa/ow_europa/pull/38

## Summary of Changes
* Arguments can now be provided to all world launch files to specify lander initial pose in 3D position and Euler angles.   
* The voxel grid created by MaterialDistributionPlugin can now be positioned relative to a model in the world. 
  * The model should be relatively level with the world frame. Only yaw (z-rotation) will be applied to the grid. 
  * This allows the voxel grid, and therefore the workspace in which a material distribution will be simulated, to follow the lander to wherever it's moved to. 

## Test
For this test we will run ReferenceMission1 in two different locations of atacama_y1a
### In the default position (regression)
1. Launch atacama_y1a with the lander in the default position `roslaunch ow atacama_y1a.launch`
2. Run ReferenceMission1 in another terminal `roslaunch ow_plexil ow_exec.launch plan:=ReferenceMission1.plx`

The test should work the same as it does in noetic-devel. 

### In a new lander position
1. Launch atacama_y1a with the lander in a new position. `roslaunch ow atacama_y1a.launch init_x:=-2.0 init_y:=-2.0 init_Y:=0.707`. The lander will wind up positioned as in the image.
![default_gzclient_camera(1)-2024-05-31T16_26_09 791872](https://github.com/nasa/ow_simulator/assets/17039973/f0d1eb83-9fbb-49db-bf1a-30cf1ed2f4e1)
Feel free to use a position of your own choice, the mission plan should work so long as there is terrain in front of the lander for it to dig through. 
2. Going into Rviz and ticking material_grid will reveal that the generated material grid looks entirely different form the one that's generated in the default lander position. This is the because the grid domain now follows the lander wherever it is moved. If you used the same lander pose as I used, it will look like the following image. 
![Screenshot_20240531_160527](https://github.com/nasa/ow_simulator/assets/17039973/c4c77f7a-b009-46f0-b569-b4b65bffc077)
3. Run ReferenceMission1 in another terminal `roslaunch ow_plexil ow_exec.launch plan:=ReferenceMission1.plx`

#### Test Caveats
Test should work, but it may have to use the fallback position, and the scoop will likely dig excessively deep. Because the scoop digs excessively deep, the following warnings are likely to be spammed. 
```
[Wrn] [RegolithPlugin.cpp:273] RegolithPlugin: Regolith particle spawn skipped to avoid particle overlap.
[Wrn] [RegolithPlugin.cpp:308] RegolithPlugin: More volume is being displaced per frame than can be spawned as regolith. Consider increasing the value of spawn_volume_threshold in common.launch to avoid this warning.
```  
The real issue here is that the reference mission plans need to be made more robust to new terrain positions. I would like to address this in a hotfix that ensures GuardedMove always happens so a proper terrain height is queried. 

## Caveats
In worlds where multimaterial is used, the "relative_to" parameter must be a model that is level to the XY plane. This is because the voxel grid must be level to align itself with the heightmap modifications.



